### PR TITLE
feat: add theme toggle to AI Coding pages

### DIFF
--- a/tools/ai-coding/index.html
+++ b/tools/ai-coding/index.html
@@ -32,6 +32,27 @@
       --radius-lg: 12px;
     }
 
+    [data-theme="light"] {
+      --bg-deep: #fafafa;
+      --bg-surface: #fff;
+      --bg-card: #fff;
+      --bg-card-hover: #f5f5f5;
+      --text-primary: #1a1a1a;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-subtle: #e5e5e5;
+      --border-strong: #d4d4d4;
+      --accent-cyan: #00d4b8;
+      --accent-magenta: #e63975;
+      --accent-yellow: #f5c518;
+      --accent-blue: #0ea5e9;
+      --accent-purple: #9333ea;
+      --accent-green: #059669;
+      --accent-orange: #ea580c;
+      --glow-cyan: rgb(0, 212, 184, 0.1);
+      --glow-magenta: rgb(230, 57, 117, 0.1);
+    }
+
     * {
       box-sizing: border-box;
       margin: 0;
@@ -106,6 +127,28 @@
     .back-link:hover {
       border-color: var(--accent-cyan);
       color: var(--accent-cyan);
+    }
+
+    .theme-toggle {
+      margin-left: auto;
+      width: 44px;
+      height: 44px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 1.2rem;
+      transition: all 0.3s ease;
+      color: var(--text-primary);
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px var(--glow-cyan);
+      transform: rotate(-5deg);
     }
 
     /* Hero Section */
@@ -562,6 +605,9 @@
   <div class="container">
     <div class="header">
       <a href="../../index.html" class="back-link">← 返回首页</a>
+      <button class="theme-toggle" id="theme-toggle" aria-label="切换主题">
+        <span class="theme-icon">🌙</span>
+      </button>
     </div>
 
     <!-- Hero Section -->
@@ -1001,8 +1047,33 @@
     const noResults = document.getElementById('no-results');
     const categoryBtns = document.querySelectorAll('.category-btn');
     const toolCards = document.querySelectorAll('.tool-card');
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
 
     let currentCategory = 'all';
+
+    // Theme management
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      htmlElement.setAttribute('data-theme', 'light');
+      themeIcon.textContent = '☀️';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = htmlElement.getAttribute('data-theme');
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+      if (newTheme === 'light') {
+        htmlElement.setAttribute('data-theme', 'light');
+        themeIcon.textContent = '☀️';
+      } else {
+        htmlElement.removeAttribute('data-theme');
+        themeIcon.textContent = '🌙';
+      }
+
+      localStorage.setItem('theme', newTheme);
+    });
 
     function filterTools() {
       const query = searchInput.value.toLowerCase().trim();

--- a/tools/ai-coding/wiki/claude-skills.html
+++ b/tools/ai-coding/wiki/claude-skills.html
@@ -30,6 +30,25 @@
       --radius-lg: 12px;
     }
 
+    [data-theme="light"] {
+      --bg-deep: #fafafa;
+      --bg-surface: #fff;
+      --bg-card: #fff;
+      --bg-code: #f5f5f5;
+      --text-primary: #1a1a1a;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-subtle: #e5e5e5;
+      --border-strong: #d4d4d4;
+      --accent-cyan: #00d4b8;
+      --accent-magenta: #e63975;
+      --accent-yellow: #f5c518;
+      --accent-blue: #0ea5e9;
+      --accent-purple: #9333ea;
+      --accent-green: #059669;
+      --glow-cyan: rgb(0, 212, 184, 0.1);
+    }
+
     * {
       box-sizing: border-box;
       margin: 0;
@@ -95,6 +114,28 @@
 
     .nav-separator {
       color: var(--text-muted);
+    }
+
+    .theme-toggle {
+      margin-left: auto;
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
+      color: var(--text-primary);
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px var(--glow-cyan);
+      transform: rotate(-5deg);
     }
 
     .nav-current {
@@ -498,6 +539,9 @@
       <a href="../index.html" class="nav-link">AI Coding</a>
       <span class="nav-separator">/</span>
       <span class="nav-current">Claude Skills</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="切换主题">
+        <span class="theme-icon">🌙</span>
+      </button>
     </nav>
 
     <!-- Article Header -->
@@ -816,6 +860,32 @@ description: 这是一个自定义技能的描述，说明什么时候应该使�
   </div>
 
   <script>
+    // Theme management
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
+
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      htmlElement.setAttribute('data-theme', 'light');
+      themeIcon.textContent = '☀️';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = htmlElement.getAttribute('data-theme');
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+      if (newTheme === 'light') {
+        htmlElement.setAttribute('data-theme', 'light');
+        themeIcon.textContent = '☀️';
+      } else {
+        htmlElement.removeAttribute('data-theme');
+        themeIcon.textContent = '🌙';
+      }
+
+      localStorage.setItem('theme', newTheme);
+    });
+
     function copyCode(btn) {
       const codeBlock = btn.closest('.code-block');
       const code = codeBlock.querySelector('pre').textContent;

--- a/tools/ai-coding/wiki/cursor-rules.html
+++ b/tools/ai-coding/wiki/cursor-rules.html
@@ -30,6 +30,25 @@
       --radius-lg: 12px;
     }
 
+    [data-theme="light"] {
+      --bg-deep: #fafafa;
+      --bg-surface: #fff;
+      --bg-card: #fff;
+      --bg-code: #f5f5f5;
+      --text-primary: #1a1a1a;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-subtle: #e5e5e5;
+      --border-strong: #d4d4d4;
+      --accent-cyan: #00d4b8;
+      --accent-magenta: #e63975;
+      --accent-yellow: #f5c518;
+      --accent-blue: #0ea5e9;
+      --accent-purple: #9333ea;
+      --accent-green: #059669;
+      --glow-cyan: rgb(0, 212, 184, 0.1);
+    }
+
     * {
       box-sizing: border-box;
       margin: 0;
@@ -101,6 +120,28 @@
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.85rem;
       color: var(--accent-cyan);
+    }
+
+    .theme-toggle {
+      margin-left: auto;
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
+      color: var(--text-primary);
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px var(--glow-cyan);
+      transform: rotate(-5deg);
     }
 
     /* Article Header */
@@ -456,6 +497,9 @@
       <a href="../index.html" class="nav-link">AI Coding</a>
       <span class="nav-separator">/</span>
       <span class="nav-current">Cursor Rules</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="切换主题">
+        <span class="theme-icon">🌙</span>
+      </button>
     </nav>
 
     <!-- Article Header -->
@@ -791,6 +835,32 @@ alwaysApply: true
   </div>
 
   <script>
+    // Theme management
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
+
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      htmlElement.setAttribute('data-theme', 'light');
+      themeIcon.textContent = '☀️';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = htmlElement.getAttribute('data-theme');
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+      if (newTheme === 'light') {
+        htmlElement.setAttribute('data-theme', 'light');
+        themeIcon.textContent = '☀️';
+      } else {
+        htmlElement.removeAttribute('data-theme');
+        themeIcon.textContent = '🌙';
+      }
+
+      localStorage.setItem('theme', newTheme);
+    });
+
     function copyCode(btn) {
       const codeBlock = btn.closest('.code-block');
       const code = codeBlock.querySelector('pre').textContent;

--- a/tools/ai-coding/wiki/mcp-servers.html
+++ b/tools/ai-coding/wiki/mcp-servers.html
@@ -31,6 +31,26 @@
       --radius-lg: 12px;
     }
 
+    [data-theme="light"] {
+      --bg-deep: #fafafa;
+      --bg-surface: #fff;
+      --bg-card: #fff;
+      --bg-code: #f5f5f5;
+      --text-primary: #1a1a1a;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-subtle: #e5e5e5;
+      --border-strong: #d4d4d4;
+      --accent-cyan: #00d4b8;
+      --accent-magenta: #e63975;
+      --accent-yellow: #f5c518;
+      --accent-blue: #0ea5e9;
+      --accent-purple: #9333ea;
+      --accent-green: #059669;
+      --accent-orange: #ea580c;
+      --glow-cyan: rgb(0, 212, 184, 0.1);
+    }
+
     * {
       box-sizing: border-box;
       margin: 0;
@@ -102,6 +122,28 @@
       font-family: 'JetBrains Mono', monospace;
       font-size: 0.85rem;
       color: var(--accent-cyan);
+    }
+
+    .theme-toggle {
+      margin-left: auto;
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
+      color: var(--text-primary);
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px var(--glow-cyan);
+      transform: rotate(-5deg);
     }
 
     /* Article Header */
@@ -509,6 +551,9 @@
       <a href="../index.html" class="nav-link">AI Coding</a>
       <span class="nav-separator">/</span>
       <span class="nav-current">MCP Servers</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="切换主题">
+        <span class="theme-icon">🌙</span>
+      </button>
     </nav>
 
     <!-- Article Header -->
@@ -869,6 +914,32 @@
   </div>
 
   <script>
+    // Theme management
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
+
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      htmlElement.setAttribute('data-theme', 'light');
+      themeIcon.textContent = '☀️';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = htmlElement.getAttribute('data-theme');
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+      if (newTheme === 'light') {
+        htmlElement.setAttribute('data-theme', 'light');
+        themeIcon.textContent = '☀️';
+      } else {
+        htmlElement.removeAttribute('data-theme');
+        themeIcon.textContent = '🌙';
+      }
+
+      localStorage.setItem('theme', newTheme);
+    });
+
     function copyCode(btn) {
       const codeBlock = btn.closest('.code-block');
       const code = codeBlock.querySelector('pre').textContent;


### PR DESCRIPTION
Add dark/light theme toggle support to all AI Coding pages:

- Resource navigation page
- Claude Skills wiki
- Cursor Rules wiki  
- MCP Servers wiki

Theme preference synced via localStorage with main site.