### PR TITLE
feat: add AI IDE wiki and simplify resource navigation

### DIFF
--- a/tools/ai-coding/index.html
+++ b/tools/ai-coding/index.html
@@ -628,90 +628,72 @@
     <!-- Categories -->
     <div class="categories">
       <button class="category-btn active" data-category="all"><span>全部</span></button>
-      <button class="category-btn" data-category="ide"><span>IDE/编辑器</span></button>
       <button class="category-btn" data-category="terminal"><span>终端工具</span></button>
-      <button class="category-btn" data-category="online"><span>在线平台</span></button>
-      <button class="category-btn" data-category="plugin"><span>插件扩展</span></button>
-      <button class="category-btn" data-category="config"><span>配置增强</span></button>
+      <button class="category-btn" data-category="config"><span>Wiki 教程</span></button>
       <button class="category-btn" data-category="learn"><span>学习资源</span></button>
     </div>
 
     <!-- Tools Grid -->
     <div class="tools-grid" id="tools-grid">
       
-      <!-- IDE/编辑器 -->
-      <a href="https://cursor.com" target="_blank" rel="noopener" class="tool-card" data-category="ide" data-keywords="cursor ai ide 编辑器 vscode">
+      <!-- Wiki 教程 -->
+      <a href="wiki/ai-ide.html" class="tool-card" data-category="config" data-keywords="ai ide 编辑器 在线平台 vscode 插件 cursor windsurf cline bolt v0">
         <div class="tool-card-header">
-          <div class="tool-icon">⌨️</div>
-          <h3>Cursor</h3>
+          <div class="tool-icon">💻</div>
+          <h3>AI IDE 环境指南</h3>
         </div>
-        <p>基于 VS Code 的 AI 代码编辑器，深度集成 AI 能力，支持 Composer 多文件编辑</p>
+        <p>全面介绍 AI 编程环境：在线平台、桌面 IDE、VSCode 插件，助你选择最适合的工具</p>
         <div class="tool-card-footer">
           <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">ide</span>
+            <span class="tool-tag wiki">Wiki 教程</span>
+            <span class="tool-tag">新</span>
           </div>
-          <span class="external-link">↗</span>
+          <span class="external-link">→</span>
         </div>
       </a>
 
-      <a href="https://codeium.com/windsurf" target="_blank" rel="noopener" class="tool-card" data-category="ide" data-keywords="windsurf codeium ai ide 编辑器">
+      <a href="wiki/claude-skills.html" class="tool-card" data-category="config" data-keywords="claude skills 技能 anthropic 配置">
         <div class="tool-card-header">
-          <div class="tool-icon">🏄</div>
-          <h3>Windsurf</h3>
+          <div class="tool-icon">🎯</div>
+          <h3>Claude Skills 指南</h3>
         </div>
-        <p>Codeium 出品的 AI IDE，Cascade 功能支持多步骤自动编码，新用户免费额度</p>
+        <p>Anthropic 官方技能系统详解：安装方法、推荐技能、自定义技能编写</p>
         <div class="tool-card-footer">
           <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">ide</span>
+            <span class="tool-tag wiki">Wiki 教程</span>
+            <span class="tool-tag">claude</span>
           </div>
-          <span class="external-link">↗</span>
+          <span class="external-link">→</span>
         </div>
       </a>
 
-      <a href="https://github.com/cline/cline" target="_blank" rel="noopener" class="tool-card" data-category="ide" data-keywords="cline vscode 插件 agent 自主编程">
+      <a href="wiki/cursor-rules.html" class="tool-card" data-category="config" data-keywords="cursor rules 规则 配置 .cursorrules">
         <div class="tool-card-header">
-          <div class="tool-icon">🤖</div>
-          <h3>Cline</h3>
+          <div class="tool-icon">📋</div>
+          <h3>Cursor Rules 指南</h3>
         </div>
-        <p>VS Code 自主编程代理插件，可创建/编辑文件、执行命令、浏览器调试，支持多种 LLM</p>
+        <p>Cursor 规则配置详解：User Rule、Project Rule、最佳实践模板</p>
         <div class="tool-card-footer">
           <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">vscode</span>
+            <span class="tool-tag wiki">Wiki 教程</span>
+            <span class="tool-tag">cursor</span>
           </div>
-          <span class="external-link">↗</span>
+          <span class="external-link">→</span>
         </div>
       </a>
 
-      <a href="https://github.com/RooVetGit/Roo-Cline" target="_blank" rel="noopener" class="tool-card" data-category="ide" data-keywords="roo-cline cline fork 增强">
+      <a href="wiki/mcp-servers.html" class="tool-card" data-category="config" data-keywords="mcp model context protocol 服务器">
         <div class="tool-card-header">
-          <div class="tool-icon">🦘</div>
-          <h3>Roo-Cline</h3>
+          <div class="tool-icon">🔌</div>
+          <h3>MCP Servers 指南</h3>
         </div>
-        <p>Cline 的增强 Fork 版本，新增命令行交互、浏览器自动化测试等功能</p>
+        <p>Model Context Protocol 服务器详解：推荐服务器、安装配置、使用场景</p>
         <div class="tool-card-footer">
           <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">vscode</span>
+            <span class="tool-tag wiki">Wiki 教程</span>
+            <span class="tool-tag">mcp</span>
           </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://github.com/Kilo-Org/kilocode" target="_blank" rel="noopener" class="tool-card" data-category="ide" data-keywords="kilo code vscode 开源">
-        <div class="tool-card-header">
-          <div class="tool-icon">📐</div>
-          <h3>Kilo Code</h3>
-        </div>
-        <p>VS Code 开源 AI 助手，用于规划、构建和修复代码，类似 Cline</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">vscode</span>
-          </div>
-          <span class="external-link">↗</span>
+          <span class="external-link">→</span>
         </div>
       </a>
 
@@ -776,174 +758,6 @@
         </div>
       </a>
 
-      <!-- 在线平台 -->
-      <a href="https://bolt.new" target="_blank" rel="noopener" class="tool-card" data-category="online" data-keywords="bolt.new stackblitz 在线 全栈">
-        <div class="tool-card-header">
-          <div class="tool-icon">⚡</div>
-          <h3>Bolt.new</h3>
-        </div>
-        <p>StackBlitz 出品的在线 AI 开发平台，浏览器内全栈开发，无需本地环境</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">web</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://v0.dev" target="_blank" rel="noopener" class="tool-card" data-category="online" data-keywords="v0 vercel ui 前端 组件">
-        <div class="tool-card-header">
-          <div class="tool-icon">🎨</div>
-          <h3>v0.dev</h3>
-        </div>
-        <p>Vercel 出品的 AI UI 生成器，自然语言生成 React/Tailwind 组件</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">ui</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://replit.com" target="_blank" rel="noopener" class="tool-card" data-category="online" data-keywords="replit 在线 ide 云端">
-        <div class="tool-card-header">
-          <div class="tool-icon">🔄</div>
-          <h3>Replit</h3>
-        </div>
-        <p>云端 IDE，支持多语言，内置 AI 助手 Ghostwriter，一键部署</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">cloud</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://lovable.dev" target="_blank" rel="noopener" class="tool-card" data-category="online" data-keywords="lovable 全栈 应用 生成">
-        <div class="tool-card-header">
-          <div class="tool-icon">💜</div>
-          <h3>Lovable</h3>
-        </div>
-        <p>AI 全栈应用生成平台，从描述到可部署应用，支持数据库和认证</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag free">免费额度</span>
-            <span class="tool-tag">fullstack</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <!-- 插件扩展 -->
-      <a href="https://github.com/continuedev/continue" target="_blank" rel="noopener" class="tool-card" data-category="plugin" data-keywords="continue 插件 vscode jetbrains 开源">
-        <div class="tool-card-header">
-          <div class="tool-icon">▶</div>
-          <h3>Continue</h3>
-        </div>
-        <p>领先的开源 AI 代码助手插件，支持 VS Code 和 JetBrains，可连接任意 LLM</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">20k+ stars</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://github.com/TabbyML/tabby" target="_blank" rel="noopener" class="tool-card" data-category="plugin" data-keywords="tabby 自托管 代码补全 本地">
-        <div class="tool-card-header">
-          <div class="tool-icon">🐱</div>
-          <h3>TabbyML</h3>
-        </div>
-        <p>自托管的开源 AI 编程助手，GitHub Copilot 的本地替代方案</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">self-host</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://codeium.com" target="_blank" rel="noopener" class="tool-card" data-category="plugin" data-keywords="codeium 代码补全 免费 copilot">
-        <div class="tool-card-header">
-          <div class="tool-icon">🚀</div>
-          <h3>Codeium</h3>
-        </div>
-        <p>免费的 AI 代码补全工具，支持 70+ IDE 和编辑器，无使用限制</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag free">永久免费</span>
-            <span class="tool-tag">autocomplete</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://github.com/rjmacarthy/twinny" target="_blank" rel="noopener" class="tool-card" data-category="plugin" data-keywords="twinny ollama 本地 vscode">
-        <div class="tool-card-header">
-          <div class="tool-icon">👯</div>
-          <h3>Twinny</h3>
-        </div>
-        <p>基于 Ollama 的 VS Code AI 代码补全插件，完全本地运行</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">local</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <!-- 配置增强 (Wiki) -->
-      <a href="wiki/claude-skills.html" class="tool-card" data-category="config" data-keywords="claude skills 技能 anthropic 配置">
-        <div class="tool-card-header">
-          <div class="tool-icon">🎯</div>
-          <h3>Claude Skills 指南</h3>
-        </div>
-        <p>Anthropic 官方技能系统详解：安装方法、推荐技能、自定义技能编写</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag wiki">Wiki 教程</span>
-            <span class="tool-tag">claude</span>
-          </div>
-          <span class="external-link">→</span>
-        </div>
-      </a>
-
-      <a href="wiki/cursor-rules.html" class="tool-card" data-category="config" data-keywords="cursor rules 规则 配置 .cursorrules">
-        <div class="tool-card-header">
-          <div class="tool-icon">📋</div>
-          <h3>Cursor Rules 指南</h3>
-        </div>
-        <p>Cursor 规则配置详解：User Rule、Project Rule、最佳实践模板</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag wiki">Wiki 教程</span>
-            <span class="tool-tag">cursor</span>
-          </div>
-          <span class="external-link">→</span>
-        </div>
-      </a>
-
-      <a href="wiki/mcp-servers.html" class="tool-card" data-category="config" data-keywords="mcp model context protocol 服务器">
-        <div class="tool-card-header">
-          <div class="tool-icon">🔌</div>
-          <h3>MCP Servers 指南</h3>
-        </div>
-        <p>Model Context Protocol 服务器详解：推荐服务器、安装配置、使用场景</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag wiki">Wiki 教程</span>
-            <span class="tool-tag">mcp</span>
-          </div>
-          <span class="external-link">→</span>
-        </div>
-      </a>
-
       <!-- 学习资源 -->
       <a href="https://github.com/datawhalechina/vibe-vibe" target="_blank" rel="noopener" class="tool-card" data-category="learn" data-keywords="vibe vibe 教程 datawhale 入门">
         <div class="tool-card-header">
@@ -990,31 +804,16 @@
         </div>
       </a>
 
-      <a href="https://github.com/anthropics/skills" target="_blank" rel="noopener" class="tool-card" data-category="learn" data-keywords="anthropic skills 官方 示例">
+      <a href="https://github.com/PatrickJS/awesome-cursorrules" target="_blank" rel="noopener" class="tool-card" data-category="learn" data-keywords="cursor rules 社区 模板 awesome">
         <div class="tool-card-header">
-          <div class="tool-icon">🏢</div>
-          <h3>Anthropic Skills 仓库</h3>
+          <div class="tool-icon">📝</div>
+          <h3>awesome-cursorrules</h3>
         </div>
-        <p>Claude 技能系统官方仓库，包含 16+ 示例技能和规范文档</p>
+        <p>Cursor Rules 社区精选集，各种编程语言和框架的最佳实践规则模板</p>
         <div class="tool-card-footer">
           <div class="tool-tags">
             <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">official</span>
-          </div>
-          <span class="external-link">↗</span>
-        </div>
-      </a>
-
-      <a href="https://github.com/modelcontextprotocol/servers" target="_blank" rel="noopener" class="tool-card" data-category="learn" data-keywords="mcp servers 官方 列表">
-        <div class="tool-card-header">
-          <div class="tool-icon">🔗</div>
-          <h3>MCP Servers 官方仓库</h3>
-        </div>
-        <p>Model Context Protocol 官方服务器仓库，400+ 官方和社区服务器</p>
-        <div class="tool-card-footer">
-          <div class="tool-tags">
-            <span class="tool-tag opensource">开源</span>
-            <span class="tool-tag">official</span>
+            <span class="tool-tag">6k+ stars</span>
           </div>
           <span class="external-link">↗</span>
         </div>

--- a/tools/ai-coding/wiki/ai-ide.html
+++ b/tools/ai-coding/wiki/ai-ide.html
@@ -1,0 +1,1002 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AI IDE 环境指南 - AI Coding Wiki</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-deep: #0a0a0f;
+      --bg-surface: #12121a;
+      --bg-card: #1a1a24;
+      --bg-code: #0e0e14;
+      --text-primary: #e8e8ed;
+      --text-secondary: #8888a0;
+      --text-muted: #55556a;
+      --border-subtle: #2a2a3a;
+      --border-strong: #3a3a4a;
+      --accent-cyan: #00f5d4;
+      --accent-magenta: #f72585;
+      --accent-yellow: #fee440;
+      --accent-blue: #4cc9f0;
+      --accent-purple: #7b2cbf;
+      --accent-green: #10b981;
+      --accent-orange: #f97316;
+      --glow-cyan: rgb(0, 245, 212, 0.15);
+      --radius-sm: 4px;
+      --radius-md: 8px;
+      --radius-lg: 12px;
+    }
+
+    [data-theme="light"] {
+      --bg-deep: #fafafa;
+      --bg-surface: #fff;
+      --bg-card: #fff;
+      --bg-code: #f5f5f5;
+      --text-primary: #1a1a1a;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-subtle: #e5e5e5;
+      --border-strong: #d4d4d4;
+      --accent-cyan: #00d4b8;
+      --accent-magenta: #e63975;
+      --accent-yellow: #f5c518;
+      --accent-blue: #0ea5e9;
+      --accent-purple: #9333ea;
+      --accent-green: #059669;
+      --accent-orange: #ea580c;
+      --glow-cyan: rgb(0, 212, 184, 0.1);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: var(--bg-deep);
+      color: var(--text-primary);
+      min-height: 100vh;
+      line-height: 1.8;
+    }
+
+    .bg-grid {
+      position: fixed;
+      inset: 0;
+      background-image: 
+        linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+        linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+      background-size: 40px 40px;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .container {
+      position: relative;
+      z-index: 1;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 40px 24px 80px;
+    }
+
+    /* Navigation */
+    .nav {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 40px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      text-decoration: none;
+      padding: 8px 14px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      transition: all 0.2s ease;
+    }
+
+    .nav-link:hover {
+      border-color: var(--accent-cyan);
+      color: var(--accent-cyan);
+    }
+
+    .nav-separator {
+      color: var(--text-muted);
+    }
+
+    .theme-toggle {
+      margin-left: auto;
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
+      color: var(--text-primary);
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px var(--glow-cyan);
+      transform: rotate(-5deg);
+    }
+
+    .nav-current {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--accent-cyan);
+    }
+
+    /* Article Header */
+    .article-header {
+      margin-bottom: 48px;
+      padding-bottom: 32px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .article-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      font-weight: 500;
+      padding: 4px 10px;
+      background: var(--accent-blue);
+      border-radius: 12px;
+      color: white;
+      margin-bottom: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+
+    .article-header h1 {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: clamp(1.8rem, 4vw, 2.5rem);
+      font-weight: 700;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, var(--text-primary) 0%, var(--accent-cyan) 100%);
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .article-meta {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .article-meta span {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    /* Table of Contents */
+    .toc {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: 24px;
+      margin-bottom: 48px;
+    }
+
+    .toc-title {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .toc-list {
+      list-style: none;
+    }
+
+    .toc-list li {
+      margin-bottom: 8px;
+    }
+
+    .toc-list a {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: color 0.2s ease;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .toc-list a::before {
+      content: '→';
+      color: var(--accent-cyan);
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .toc-list a:hover {
+      color: var(--accent-cyan);
+    }
+
+    .toc-list a:hover::before {
+      opacity: 1;
+    }
+
+    /* Article Content */
+    .article-content h2 {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin: 48px 0 24px;
+      padding-bottom: 12px;
+      border-bottom: 2px solid var(--border-subtle);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .article-content h2 .icon {
+      font-size: 1.2rem;
+    }
+
+    .article-content h3 {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin: 32px 0 16px;
+    }
+
+    .article-content p {
+      margin-bottom: 16px;
+      color: var(--text-secondary);
+    }
+
+    .article-content ul, .article-content ol {
+      margin-bottom: 16px;
+      padding-left: 24px;
+      color: var(--text-secondary);
+    }
+
+    .article-content li {
+      margin-bottom: 8px;
+    }
+
+    .article-content strong {
+      color: var(--text-primary);
+      font-weight: 600;
+    }
+
+    .article-content a {
+      color: var(--accent-cyan);
+      text-decoration: none;
+      border-bottom: 1px dashed var(--accent-cyan);
+      transition: all 0.2s ease;
+    }
+
+    .article-content a:hover {
+      border-bottom-style: solid;
+    }
+
+    /* Info Box */
+    .info-box {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-left: 4px solid var(--accent-cyan);
+      border-radius: var(--radius-md);
+      padding: 20px;
+      margin: 24px 0;
+    }
+
+    .info-box.warning {
+      border-left-color: var(--accent-yellow);
+    }
+
+    .info-box.tip {
+      border-left-color: var(--accent-green);
+    }
+
+    .info-box-title {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .info-box p {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+
+    /* Table */
+    .table-wrapper {
+      overflow-x: auto;
+      margin: 24px 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    th, td {
+      padding: 12px 16px;
+      text-align: left;
+      border: 1px solid var(--border-subtle);
+    }
+
+    th {
+      background: var(--bg-surface);
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    td {
+      color: var(--text-secondary);
+    }
+
+    td code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      padding: 2px 6px;
+      background: var(--bg-code);
+      border-radius: var(--radius-sm);
+      color: var(--accent-cyan);
+    }
+
+    /* Tool Cards */
+    .tools-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 16px;
+      margin: 24px 0;
+    }
+
+    .tool-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: 20px;
+      transition: all 0.2s ease;
+      text-decoration: none;
+      display: block;
+    }
+
+    .tool-card:hover {
+      border-color: var(--accent-cyan);
+      transform: translateY(-2px);
+    }
+
+    .tool-card-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .tool-card-icon {
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface);
+      border-radius: var(--radius-sm);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.2rem;
+    }
+
+    .tool-card h4 {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin: 0;
+    }
+
+    .tool-card p {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin: 0 0 12px;
+      line-height: 1.5;
+    }
+
+    .tool-card-tags {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .tool-tag {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      padding: 3px 8px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: 10px;
+      color: var(--text-muted);
+    }
+
+    .tool-tag.free {
+      background: var(--accent-green);
+      border-color: var(--accent-green);
+      color: white;
+    }
+
+    .tool-tag.opensource {
+      background: var(--accent-purple);
+      border-color: var(--accent-purple);
+      color: white;
+    }
+
+    /* Decision Flow */
+    .decision-box {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: 24px;
+      margin: 24px 0;
+    }
+
+    .decision-box h4 {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 16px;
+    }
+
+    .decision-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 12px 0;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .decision-item:last-child {
+      border-bottom: none;
+    }
+
+    .decision-icon {
+      font-size: 1.2rem;
+      flex-shrink: 0;
+    }
+
+    .decision-content strong {
+      color: var(--text-primary);
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    .decision-content span {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    /* Footer */
+    .article-footer {
+      margin-top: 64px;
+      padding-top: 32px;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .related-links {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .related-link {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      text-decoration: none;
+      padding: 12px 20px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      transition: all 0.2s ease;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .related-link:hover {
+      border-color: var(--accent-cyan);
+      color: var(--accent-cyan);
+    }
+
+    /* Responsive */
+    @media (width <= 640px) {
+      .container {
+        padding: 24px 16px 60px;
+      }
+
+      .tools-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="bg-grid"></div>
+  
+  <div class="container">
+    <!-- Navigation -->
+    <nav class="nav">
+      <a href="../../../index.html" class="nav-link">首页</a>
+      <span class="nav-separator">/</span>
+      <a href="../index.html" class="nav-link">AI Coding</a>
+      <span class="nav-separator">/</span>
+      <span class="nav-current">AI IDE 环境</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="切换主题">
+        <span class="theme-icon">🌙</span>
+      </button>
+    </nav>
+
+    <!-- Article Header -->
+    <header class="article-header">
+      <span class="article-badge">Wiki 教程</span>
+      <h1>AI IDE 环境完全指南</h1>
+      <div class="article-meta">
+        <span>📅 更新于 2024-12</span>
+        <span>⏱️ 阅读约 10 分钟</span>
+        <span>🏷️ IDE / 开发环境</span>
+      </div>
+    </header>
+
+    <!-- Table of Contents -->
+    <div class="toc">
+      <div class="toc-title">📑 目录</div>
+      <ul class="toc-list">
+        <li><a href="#what-is-ai-ide">什么是 AI IDE</a></li>
+        <li><a href="#online-platforms">在线平台</a></li>
+        <li><a href="#desktop-ide">桌面 IDE</a></li>
+        <li><a href="#vscode-plugins">VSCode 插件</a></li>
+        <li><a href="#how-to-choose">如何选择</a></li>
+        <li><a href="#resources">相关资源</a></li>
+      </ul>
+    </div>
+
+    <!-- Article Content -->
+    <article class="article-content">
+      <h2 id="what-is-ai-ide"><span class="icon">🎯</span> 什么是 AI IDE</h2>
+      
+      <p>AI IDE（AI 集成开发环境）是将人工智能深度融入代码编辑、调试、测试全流程的新一代开发工具。它们通过 LLM（大语言模型）理解你的意图，自动生成、补全、重构代码，让开发者从"写代码"转变为"指挥 AI 写代码"。</p>
+      
+      <div class="info-box tip">
+        <div class="info-box-title">💡 Vibe Coding 理念</div>
+        <p>"完全沉浸于编程的'氛围'中，忘记代码的存在。从 Coder 到 Commander，用自然语言与 AI 对话创作。" — Andrej Karpathy</p>
+      </div>
+
+      <p><strong>AI IDE 的核心能力：</strong></p>
+      <ul>
+        <li><strong>智能代码补全</strong>：基于上下文预测你想写的代码</li>
+        <li><strong>自然语言编程</strong>：用中文/英文描述需求，AI 生成代码</li>
+        <li><strong>代码解释和重构</strong>：理解复杂代码，建议优化方案</li>
+        <li><strong>上下文感知</strong>：理解整个项目结构，提供一致性建议</li>
+        <li><strong>多文件编辑</strong>：一次修改多个相关文件，保持代码同步</li>
+      </ul>
+
+      <h2 id="online-platforms"><span class="icon">🌐</span> 在线平台</h2>
+      
+      <p>在线 AI 开发平台的最大优势是<strong>零配置</strong>：打开浏览器即可开始开发，无需安装任何软件，非常适合快速原型开发和学习。</p>
+
+      <div class="tools-grid">
+        <a href="https://bolt.new" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">⚡</div>
+            <h4>Bolt.new</h4>
+          </div>
+          <p>StackBlitz 出品的在线 AI 全栈开发平台，基于 WebContainer 技术在浏览器内运行完整 Node.js 环境</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费额度</span>
+            <span class="tool-tag">全栈</span>
+            <span class="tool-tag">即时部署</span>
+          </div>
+        </a>
+
+        <a href="https://v0.dev" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🎨</div>
+            <h4>v0.dev</h4>
+          </div>
+          <p>Vercel 出品的 AI UI 生成器，用自然语言描述界面，自动生成 React + Tailwind 组件代码</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费额度</span>
+            <span class="tool-tag">UI 生成</span>
+            <span class="tool-tag">React</span>
+          </div>
+        </a>
+
+        <a href="https://replit.com" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🔄</div>
+            <h4>Replit</h4>
+          </div>
+          <p>云端 IDE 先驱，支持 50+ 编程语言，内置 AI 助手 Ghostwriter，一键部署到云端</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费版</span>
+            <span class="tool-tag">多语言</span>
+            <span class="tool-tag">协作</span>
+          </div>
+        </a>
+
+        <a href="https://lovable.dev" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">💜</div>
+            <h4>Lovable</h4>
+          </div>
+          <p>AI 全栈应用生成平台，从自然语言描述到可部署应用，支持数据库、认证、支付集成</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费额度</span>
+            <span class="tool-tag">全栈</span>
+            <span class="tool-tag">SaaS</span>
+          </div>
+        </a>
+      </div>
+
+      <h3>在线平台对比</h3>
+      
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>平台</th>
+              <th>最佳用途</th>
+              <th>技术栈</th>
+              <th>特色功能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Bolt.new</strong></td>
+              <td>快速全栈原型</td>
+              <td>React, Vue, Node.js</td>
+              <td>浏览器内 Node.js</td>
+            </tr>
+            <tr>
+              <td><strong>v0.dev</strong></td>
+              <td>UI 组件设计</td>
+              <td>React, Tailwind</td>
+              <td>可视化迭代</td>
+            </tr>
+            <tr>
+              <td><strong>Replit</strong></td>
+              <td>学习和协作</td>
+              <td>50+ 语言</td>
+              <td>实时多人协作</td>
+            </tr>
+            <tr>
+              <td><strong>Lovable</strong></td>
+              <td>SaaS 应用</td>
+              <td>全栈 + 后端服务</td>
+              <td>内置认证/支付</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="desktop-ide"><span class="icon">💻</span> 桌面 IDE</h2>
+      
+      <p>桌面 AI IDE 提供<strong>完整的开发体验</strong>：本地文件系统访问、终端集成、Git 支持、扩展生态，适合专业开发和大型项目。</p>
+
+      <div class="tools-grid">
+        <a href="https://cursor.com" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🖱️</div>
+            <h4>Cursor</h4>
+          </div>
+          <p>最受欢迎的 AI-first 代码编辑器，基于 VSCode 构建，深度集成 GPT-4 和 Claude，支持多文件编辑、代码库问答</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费版</span>
+            <span class="tool-tag">GPT-4</span>
+            <span class="tool-tag">Claude</span>
+          </div>
+        </a>
+
+        <a href="https://codeium.com/windsurf" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🏄</div>
+            <h4>Windsurf</h4>
+          </div>
+          <p>Codeium 推出的 AI IDE，主打"心流"编程体验，智能预测开发者意图，支持 Cascade 多步骤任务执行</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">免费版</span>
+            <span class="tool-tag">Cascade</span>
+            <span class="tool-tag">心流模式</span>
+          </div>
+        </a>
+      </div>
+
+      <h3>桌面 IDE 对比</h3>
+      
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>特性</th>
+              <th>Cursor</th>
+              <th>Windsurf</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>基础</strong></td>
+              <td>VSCode 分支</td>
+              <td>VSCode 分支</td>
+            </tr>
+            <tr>
+              <td><strong>AI 模型</strong></td>
+              <td>GPT-4, Claude, 自定义</td>
+              <td>Codeium 模型</td>
+            </tr>
+            <tr>
+              <td><strong>代码补全</strong></td>
+              <td>Tab 补全 + Composer</td>
+              <td>智能预测 + Cascade</td>
+            </tr>
+            <tr>
+              <td><strong>多文件编辑</strong></td>
+              <td>支持</td>
+              <td>支持</td>
+            </tr>
+            <tr>
+              <td><strong>代码库索引</strong></td>
+              <td>支持（付费）</td>
+              <td>支持</td>
+            </tr>
+            <tr>
+              <td><strong>定价</strong></td>
+              <td>免费 / $20/月</td>
+              <td>免费 / $15/月</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="info-box">
+        <div class="info-box-title">💡 选择建议</div>
+        <p>如果你需要灵活选择 AI 模型（GPT-4、Claude 等），选 <strong>Cursor</strong>；如果你追求开箱即用的流畅体验，选 <strong>Windsurf</strong>。</p>
+      </div>
+
+      <h2 id="vscode-plugins"><span class="icon">🔌</span> VSCode 插件</h2>
+      
+      <p>如果你已经习惯 VSCode，不想换编辑器，可以通过安装 AI 插件来增强现有工作流。这些插件大多<strong>开源免费</strong>，可灵活组合。</p>
+
+      <div class="tools-grid">
+        <a href="https://github.com/cline/cline" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🤖</div>
+            <h4>Cline</h4>
+          </div>
+          <p>VSCode 中的 AI 编程助手，支持 Claude、GPT-4 等多种模型，可执行终端命令、编辑文件、浏览网页</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag opensource">开源</span>
+            <span class="tool-tag">多模型</span>
+            <span class="tool-tag">15k+ stars</span>
+          </div>
+        </a>
+
+        <a href="https://github.com/RooVetGit/Roo-Cline" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🦘</div>
+            <h4>Roo-Cline</h4>
+          </div>
+          <p>Cline 的增强版分支，优化提示词、增加模式切换、支持本地模型，社区活跃</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag opensource">开源</span>
+            <span class="tool-tag">Cline 增强</span>
+          </div>
+        </a>
+
+        <a href="https://github.com/continuedev/continue" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">➡️</div>
+            <h4>Continue</h4>
+          </div>
+          <p>开源 AI 代码助手，支持 VSCode 和 JetBrains，可连接任意 LLM（包括本地模型），高度可定制</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag opensource">开源</span>
+            <span class="tool-tag">20k+ stars</span>
+            <span class="tool-tag">JetBrains</span>
+          </div>
+        </a>
+
+        <a href="https://github.com/TabbyML/tabby" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">🐱</div>
+            <h4>TabbyML</h4>
+          </div>
+          <p>自托管的 AI 代码助手，完全本地运行，支持 GPU 加速，适合企业内网和隐私敏感场景</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag opensource">开源</span>
+            <span class="tool-tag">自托管</span>
+            <span class="tool-tag">本地模型</span>
+          </div>
+        </a>
+
+        <a href="https://codeium.com" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">⚡</div>
+            <h4>Codeium</h4>
+          </div>
+          <p>免费的 AI 代码补全工具，支持 70+ 语言和 40+ IDE，响应速度快，无使用限制</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag free">完全免费</span>
+            <span class="tool-tag">快速补全</span>
+          </div>
+        </a>
+
+        <a href="https://github.com/rjmacarthy/twinny" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header">
+            <div class="tool-card-icon">👯</div>
+            <h4>Twinny</h4>
+          </div>
+          <p>本地优先的 AI 代码助手，连接 Ollama 等本地模型，完全离线使用，隐私友好</p>
+          <div class="tool-card-tags">
+            <span class="tool-tag opensource">开源</span>
+            <span class="tool-tag">本地模型</span>
+            <span class="tool-tag">离线</span>
+          </div>
+        </a>
+      </div>
+
+      <h3>插件安装方法</h3>
+      
+      <p>在 VSCode 中安装 AI 插件非常简单：</p>
+      <ol>
+        <li>打开 VSCode，按 <code>Ctrl+Shift+X</code>（Mac: <code>Cmd+Shift+X</code>）打开扩展面板</li>
+        <li>搜索插件名称（如 "Cline" 或 "Continue"）</li>
+        <li>点击 "Install" 安装</li>
+        <li>根据插件提示配置 API Key（如需要）</li>
+      </ol>
+
+      <div class="info-box warning">
+        <div class="info-box-title">⚠️ 注意</div>
+        <p>使用云端 AI 模型需要 API Key。Cline/Continue 等插件支持 OpenAI、Anthropic、OpenRouter 等多种 API 提供商。如果你关注隐私，可以选择 TabbyML 或 Twinny 配合本地模型使用。</p>
+      </div>
+
+      <h2 id="how-to-choose"><span class="icon">🎯</span> 如何选择</h2>
+      
+      <p>选择 AI IDE 工具时，考虑以下因素：</p>
+
+      <div class="decision-box">
+        <h4>📋 决策指南</h4>
+        
+        <div class="decision-item">
+          <span class="decision-icon">🚀</span>
+          <div class="decision-content">
+            <strong>快速原型 / 学习</strong>
+            <span>→ 在线平台（Bolt.new, v0.dev, Replit）</span>
+          </div>
+        </div>
+
+        <div class="decision-item">
+          <span class="decision-icon">💼</span>
+          <div class="decision-content">
+            <strong>专业开发 / 大型项目</strong>
+            <span>→ 桌面 IDE（Cursor, Windsurf）</span>
+          </div>
+        </div>
+
+        <div class="decision-item">
+          <span class="decision-icon">🔧</span>
+          <div class="decision-content">
+            <strong>已有 VSCode 工作流</strong>
+            <span>→ VSCode 插件（Cline, Continue, Codeium）</span>
+          </div>
+        </div>
+
+        <div class="decision-item">
+          <span class="decision-icon">🔒</span>
+          <div class="decision-content">
+            <strong>隐私敏感 / 离线使用</strong>
+            <span>→ 本地方案（TabbyML, Twinny + Ollama）</span>
+          </div>
+        </div>
+
+        <div class="decision-item">
+          <span class="decision-icon">💰</span>
+          <div class="decision-content">
+            <strong>完全免费</strong>
+            <span>→ Codeium, Continue + 免费 API, 开源插件</span>
+          </div>
+        </div>
+      </div>
+
+      <h2 id="resources"><span class="icon">📚</span> 相关资源</h2>
+      
+      <ul>
+        <li><a href="https://github.com/sourcegraph/awesome-code-ai" target="_blank">Awesome Code AI</a> - AI 编程工具精选列表</li>
+        <li><a href="https://github.com/datawhalechina/vibe-vibe" target="_blank">Vibe Vibe 教程</a> - 中文 Vibe Coding 入门指南</li>
+        <li><a href="https://cursor.directory" target="_blank">Cursor Directory</a> - Cursor Rules 社区分享</li>
+        <li><a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank">Claude Code 文档</a> - 终端 AI 编程工具</li>
+      </ul>
+
+    </article>
+
+    <!-- Footer -->
+    <footer class="article-footer">
+      <div class="related-links">
+        <a href="claude-skills.html" class="related-link">
+          <span>Claude Skills 指南</span>
+          <span>→</span>
+        </a>
+        <a href="cursor-rules.html" class="related-link">
+          <span>Cursor Rules 指南</span>
+          <span>→</span>
+        </a>
+        <a href="mcp-servers.html" class="related-link">
+          <span>MCP Servers 指南</span>
+          <span>→</span>
+        </a>
+        <a href="../index.html" class="related-link">
+          <span>← 返回资源导航</span>
+        </a>
+      </div>
+    </footer>
+  </div>
+
+  <script>
+    // Theme management
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const htmlElement = document.documentElement;
+
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      htmlElement.setAttribute('data-theme', 'light');
+      themeIcon.textContent = '☀️';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = htmlElement.getAttribute('data-theme');
+      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+      if (newTheme === 'light') {
+        htmlElement.setAttribute('data-theme', 'light');
+        themeIcon.textContent = '☀️';
+      } else {
+        htmlElement.removeAttribute('data-theme');
+        themeIcon.textContent = '🌙';
+      }
+
+      localStorage.setItem('theme', newTheme);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 新增 AI IDE 环境指南 Wiki 页面，整合了原本分散的外部链接
- 简化主导航页面，移除过多的外部跳转卡片

## Changes

### 新增文件
- `tools/ai-coding/wiki/ai-ide.html`: 全面的 AI IDE 指南
  - 在线平台：Bolt.new, v0.dev, Replit, Lovable
  - 桌面 IDE：Cursor, Windsurf
  - VSCode 插件：Cline, Roo-Cline, Continue, TabbyML, Codeium, Twinny
  - 包含对比表格和选择指南

### 修改文件
- `tools/ai-coding/index.html`: 简化资源导航
  - 移除 IDE/编辑器、在线平台、插件扩展 分类
  - 新增 AI IDE Wiki 卡片作为统一入口
  - 分类从 7 个精简为 4 个（全部、终端工具、Wiki 教程、学习资源）

## Why
用户反馈原本的设计"感觉一些纯网页放在一个教程卡片就可以，这样感觉刻意了字节跳转到别人的站点"，因此将外部工具链接整合到一个 Wiki 教程页面中。