### PR TITLE
性能: 优化悬浮外壳渲染开销，消除点击/主题切换卡顿

### DIFF
--- a/assets/css/tool-base.css
+++ b/assets/css/tool-base.css
@@ -71,7 +71,7 @@
   --transition: 200ms ease;
 
   /* 玻璃外壳 */
-  --tb-glass-bg: rgb(20 20 28 / 82%);
+  --tb-glass-bg: rgb(20 20 28 / 92%);
   --tb-glass-border: rgb(255 255 255 / 10%);
   --tb-fab-shadow: 0 8px 24px rgb(0 0 0 / 38%);
 
@@ -101,7 +101,7 @@
   --shadow-sm: 0 1px 2px rgb(0 0 0 / 6%);
   --shadow-md: 0 4px 12px rgb(0 0 0 / 8%);
   --shadow-lg: 0 8px 32px rgb(0 0 0 / 12%);
-  --tb-glass-bg: rgb(255 255 255 / 86%);
+  --tb-glass-bg: rgb(255 255 255 / 94%);
   --tb-glass-border: rgb(0 0 0 / 8%);
   --tb-fab-shadow: 0 8px 24px rgb(0 0 0 / 12%);
 }
@@ -170,6 +170,19 @@ body {
   color: var(--text-primary);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* 移除移动端点击的双击缩放延迟与高亮闪烁，点击更跟手 */
+button,
+a,
+label,
+input,
+select,
+textarea,
+summary,
+[role='button'] {
+  touch-action: manipulation;
 }
 
 /* ---------- 5. 共享组件（新工具可直接使用 .tb-* 类）---------- */
@@ -251,11 +264,9 @@ body {
 }
 
 /* ---------- 6. 悬浮外壳：返回首页 + 主题切换（由 tool-chrome.js 注入）---------- */
+/* 分组容器自身不生成盒子，避免多一个视口大小的合成层 */
 #tbChrome {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 2147483000;
+  display: contents;
 }
 
 .tb-fab {
@@ -274,9 +285,10 @@ body {
   border: 1px solid var(--tb-glass-border);
   box-shadow: var(--tb-fab-shadow);
   cursor: pointer;
-  pointer-events: auto;
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  backdrop-filter: blur(16px) saturate(180%);
+  z-index: 2147483000;
+  will-change: transform;
+  -webkit-backdrop-filter: blur(8px) saturate(150%);
+  backdrop-filter: blur(8px) saturate(150%);
   transition:
     transform var(--transition),
     border-color var(--transition),
@@ -368,9 +380,22 @@ body {
   }
 }
 
+/* 切换主题时临时关闭全页过渡，避免大面积颜色渐变造成的卡顿 */
+.tb-anim-off,
+.tb-anim-off *,
+.tb-anim-off *::before,
+.tb-anim-off *::after {
+  transition: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .tb-fab {
-    transition: none;
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/assets/js/tool-chrome.js
+++ b/assets/js/tool-chrome.js
@@ -39,6 +39,8 @@
   }
 
   function applyTheme(theme) {
+    // 切换瞬间关闭全页过渡，避免大面积颜色渐变造成的卡顿
+    root.classList.add('tb-anim-off');
     root.setAttribute('data-theme', theme);
     try {
       localStorage.setItem(THEME_KEY, theme);
@@ -49,6 +51,11 @@
     if (btn) {
       btn.setAttribute('aria-label', theme === 'light' ? '切换到暗色主题' : '切换到亮色主题');
     }
+    // 提交无过渡状态后，下一帧恢复过渡
+    void root.offsetWidth;
+    requestAnimationFrame(function () {
+      root.classList.remove('tb-anim-off');
+    });
   }
 
   /* ---------- 2. 注入悬浮外壳 ---------- */
@@ -149,7 +156,12 @@
   /* ---------- 启动 ---------- */
   function start() {
     injectChrome();
-    injectSchema();
+    // 结构化数据非关键路径，放到空闲时再注入，避免占用首屏主线程
+    if (window.requestIdleCallback) {
+      window.requestIdleCallback(injectSchema);
+    } else {
+      window.setTimeout(injectSchema, 200);
+    }
   }
 
   if (doc.readyState === 'loading') {


### PR DESCRIPTION
## 背景

反馈「点击不丝滑」。定位到几处真实 jank 源,均在共享外壳层,改两个文件即全站生效。

## 改动(`assets/css/tool-base.css` + `assets/js/tool-chrome.js`)

| 问题 | 优化 |
|---|---|
| 两个 `fixed` FAB 用 `backdrop-filter: blur(16px)`,滚动时每帧重采样背景 | blur 降到 8px + 提高底色不透明度(92%/94%),加 `will-change`/`z-index` 独立合成 |
| `#tbChrome` 是覆盖全视口的 `fixed` 层 | 改 `display: contents`,去掉多余合成层 |
| 主题切换时全页 CSS 变量重算 + 旧工具大量 `transition:all` 跟着渐变,整页颜色"爬行" | 切换瞬间给 `<html>` 加 `.tb-anim-off` 关闭全页过渡,切换变为瞬时 |
| 移动端点击有双击缩放延迟 + 高亮闪烁 | 交互元素加 `touch-action: manipulation` + `tap-highlight` 透明 |
| 结构化数据注入占首屏主线程 | 改到 `requestIdleCallback` |
| `prefers-reduced-motion` 仅覆盖 FAB | 全局收敛动画 |

## 验证

- `npm run lint` ✓ · `npm run format:check` ✓ · `npm test` ✓ (53/53)
- 浏览器实测:FAB 位置正常、主题切换瞬时生效、无渲染回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)