### PR TITLE
feat: 脚本生成 34 个分类落地页（路线 A 步骤 3）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,10 @@ npm test                   # 运行测试套件（tools.json/数据质量/同步
 - `manifest.json` 中的描述
 - `llms.txt` 工具列表
 - `i18n/*.json` 副标题中的工具数
+- `tools/<分类>/index.html` 分类落地页（从 `tools.json` 的 `categories[].intro` + 工具列表用模板生成；已登记为工具的分类首页如 `ai-coding` 不覆盖）
 
-**CI 会检查同步状态，不同步则构建失败。**
+**CI 会检查同步状态，不同步则构建失败。** 分类落地页是生成产物、不登记进 `tools.json`，
+故测试对 `tools/*/index.html` 跳过「游离文件」检查。
 
 ### index.html 主页
 

--- a/scripts/sync-all.js
+++ b/scripts/sync-all.js
@@ -94,6 +94,276 @@ function getSortedCategories(categories) {
   return sorted;
 }
 
+/* ---------- 分类落地页 ---------- */
+
+/** HTML 文本转义 */
+function escapeHtml(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** HTML 属性值转义 */
+function escapeAttr(str) {
+  return escapeHtml(str).replace(/"/g, '&quot;');
+}
+
+/** 把对象序列化为可安全内嵌 <script> 的 JSON-LD 文本 */
+function toJsonLd(obj) {
+  return JSON.stringify(obj, null, 2).replace(/</g, '\\u003c');
+}
+
+/** 分类落地页的内联样式（与 tool-base.css 设计 token 一致） */
+const CATEGORY_PAGE_CSS = `
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+`;
+
+/** 计算从 tools/<catId>/index.html 到目标工具的相对链接 */
+function relToolHref(catId, toolPath) {
+  return path.posix.relative('tools/' + catId, toolPath);
+}
+
+/**
+ * 生成单个分类落地页 HTML
+ */
+function categoryPageHtml(catId, cat, catTools) {
+  const name = cat.name;
+  const intro = cat.intro || `${name}相关的在线工具集合。`;
+  const icon = cat.icon || '📦';
+  const count = catTools.length;
+  const canonical = `${SITE_URL}/tools/${catId}/index.html`;
+  const title = `${name} - 在线工具合集（${count}个）| WebUtils`;
+
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: '首页', item: SITE_URL + '/' },
+      { '@type': 'ListItem', position: 2, name: name, item: canonical }
+    ]
+  };
+  const collection = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description: intro,
+    url: canonical,
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: count,
+      itemListElement: catTools.map((t, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: t.name,
+        url: `${SITE_URL}/${t.path}`
+      }))
+    }
+  };
+
+  const cards = catTools
+    .map((t) => {
+      const href = escapeAttr(relToolHref(catId, t.path));
+      return `        <a class="cat-card" href="${href}">
+          <span class="cat-card-icon">${escapeHtml(t.icon || '🔧')}</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">${escapeHtml(t.name)}</span>
+            <span class="cat-card-desc">${escapeHtml(t.description || t.name)}</span>
+          </span>
+        </a>`;
+    })
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>${escapeHtml(title)}</title>
+    <meta name="description" content="${escapeAttr(intro)}" />
+    <meta name="keywords" content="${escapeAttr(name + ',在线工具,免费工具,' + name + '大全')}" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="${canonical}" />
+    <meta property="og:title" content="${escapeAttr(title)}" />
+    <meta property="og:description" content="${escapeAttr(intro)}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${canonical}" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="${SITE_URL}/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="${escapeAttr(title)}" />
+    <meta name="twitter:description" content="${escapeAttr(intro)}" />
+    <meta name="twitter:image" content="${SITE_URL}/social-preview.png" />
+    <script type="application/ld+json">
+${toJsonLd(breadcrumb)}
+    </script>
+    <script type="application/ld+json">
+${toJsonLd(collection)}
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>${CATEGORY_PAGE_CSS}    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">${escapeHtml(icon)}</div>
+        <h1>${escapeHtml(name)}</h1>
+        <p class="cat-intro">${escapeHtml(intro)}</p>
+        <p class="cat-meta">${count} 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+${cards}
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>
+`;
+}
+
+/**
+ * 生成全部分类落地页 tools/<cat>/index.html
+ * 已作为工具登记的分类首页（如 ai-coding 的手工导航页）不覆盖。
+ * @returns {string[]} 生成的页面相对路径列表
+ */
+function generateCategoryPages(categories, groupedTools, registeredPaths) {
+  const generated = [];
+  for (const catId of Object.keys(categories)) {
+    const rel = `tools/${catId}/index.html`;
+    if (registeredPaths.has(rel)) continue;
+    const catTools = groupedTools[catId] || [];
+    if (catTools.length === 0) continue;
+    const html = categoryPageHtml(catId, categories[catId], catTools);
+    const abs = path.join(ROOT_DIR, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, html);
+    generated.push(rel);
+  }
+  // 统一用 prettier 格式化，确保与项目代码风格一致、且每次输出稳定（CI 同步检查依赖此稳定性）
+  if (generated.length > 0) {
+    try {
+      execFileSync(
+        'npx',
+        ['prettier', '--write', ...generated.map((p) => path.join(ROOT_DIR, p))],
+        {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe']
+        }
+      );
+    } catch {
+      // prettier 不可用时静默失败
+    }
+  }
+  console.log(`✅ 分类落地页: ${generated.length} 个`);
+  return generated;
+}
+
 /**
  * 主函数
  */
@@ -167,11 +437,15 @@ function main() {
 
   const toolsJs = `const TOOLS = [\n${toolsLines.join('\n')}\n    ];`;
 
+  // 生成分类落地页（须在 sitemap 之前，sitemap 要纳入这些页面的 URL）
+  const registeredPaths = new Set(tools.map((t) => t.path));
+  const categoryPages = generateCategoryPages(categories, groupedTools, registeredPaths);
+
   // 执行所有同步
   const results = {
     indexHtml: updateIndexHtml(categoriesJs, toolsJs, toolCount, categoryCount),
     readme: updateReadme(toolCount, categoryCount),
-    sitemap: updateSitemap(tools, toolCount),
+    sitemap: updateSitemap(tools, toolCount, categoryPages),
     manifest: updateManifest(toolCount),
     i18n: updateI18n(toolCount),
     llmsTxt: updateLlmsTxt(toolCount, categories, groupedTools, sortedCategories),
@@ -318,7 +592,7 @@ function updateReadme(toolCount, categoryCount) {
 /**
  * 更新 sitemap.xml
  */
-function updateSitemap(tools, toolCount) {
+function updateSitemap(tools, toolCount, categoryPages = []) {
   const today = new Date().toISOString().split('T')[0];
 
   let xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -331,6 +605,17 @@ function updateSitemap(tools, toolCount) {
     <priority>1.0</priority>
   </url>
 `;
+
+  // 分类落地页
+  for (const page of categoryPages) {
+    xml += `
+  <url>
+    <loc>${SITE_URL}/${page}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>`;
+  }
 
   // 添加每个工具页面
   for (const tool of tools) {
@@ -357,7 +642,7 @@ function updateSitemap(tools, toolCount) {
   }
 
   fs.writeFileSync(SITEMAP_XML, xml);
-  console.log(`✅ sitemap.xml: ${toolCount + 1} URLs`);
+  console.log(`✅ sitemap.xml: ${toolCount + 1 + categoryPages.length} URLs`);
   return true;
 }
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,6524 +3,6728 @@
   <!-- 首页 -->
   <url>
     <loc>https://tools.realtime-ai.chat/</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
+    <loc>https://tools.realtime-ai.chat/tools/dev/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/text/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/time/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/generator/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/media/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/privacy/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/security/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/network/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/calculator/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/converter/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/extractor/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/ai/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/seo/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/fun/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/game/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/life/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/finance/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/health/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/education/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/food/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/chinese/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/realestate/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/business/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/crypto/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/legal/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/social-media/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/team-tools/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/data/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/office/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/travel/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/design/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/math/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/productivity/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tools.realtime-ai.chat/tools/pets/index.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://tools.realtime-ai.chat/tools/ai-coding/index.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai-coding/wiki/ai-ide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai-coding/wiki/claude-skills.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai-coding/wiki/cursor-rules.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai-coding/wiki/mcp-servers.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/agi-2026-outlook.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-agent-2025-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-agent-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-coding-tools-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-coding-tools.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-image-generation-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-models.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-pricing.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ai-video-generation-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/china-llm-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/claude-4-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/claude-code-ecosystem.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/claude-skills.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/cursor-shortcuts.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/deepseek-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/deepseek-v3-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/doubao-1.8-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/gemini-2.5-pro-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/gemini3-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/gpt5-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/grok4-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/humanoid-robots-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/kimi-k2-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/llama-4-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/mcp-clients.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/mcp-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/mcp-protocol-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/midjourney-v7-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/nemotron-3-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/notebooklm-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/openai-o3-o4-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/openai-reasoning-models-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/perplexity-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/prompt-templates.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/prompt-tips-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/rag-technology-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/sora-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/suno-ai-music-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/token-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/tts-tools-2025.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/ui-ux-design-resources.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/vibe-coding-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/ai/wanxiang-2.6-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/easing-visualizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/age-diff-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/aspect-ratio-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/base-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/bitwise-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/bmi-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/electricity-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/function-plotter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/loan-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/math-evaluator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/percentage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/progress.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/salary-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/speed-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/statistics-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/storage-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/time-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/triangle-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/angle-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/csv-json.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/curl-to-code.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/data-size-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/data-size.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/data-url-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/file-size.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/html-to-markdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/json-yaml.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/number-words.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/pressure-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/unit-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/api-mock.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/arrow-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ascii-art.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ascii-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/base64.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/basic-auth-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/box-shadow.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/browser-storage-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/changelog-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/charset-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/chmod-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/clipboard-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/code-diff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/code-stats.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-blindness.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-mixer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-names.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-palette-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/color-palette.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/contrast-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/cron-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/cron-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/crontab-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-animation-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-border-radius.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-box-shadow.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-clip-path.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-filter-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-filter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-grid-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-grid.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-minifier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-selector-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-sprites.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-text-shadow.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-transform.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-unit-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/cubic-bezier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/curl-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/diff-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/docker-compose-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/docker-compose-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/dockerfile-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/editorconfig-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/emoji-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/env-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/excel-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/favicon-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/flexbox-playground.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/git-cheatsheet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/github-actions-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/gitignore-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/glassmorphism.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/glob-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/graphql-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/graphql-playground.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/hash-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/hex-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/hmac-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/htaccess-nginx.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-entities.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-entity.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-minify.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-table-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-template.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-to-jsx.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/http-status.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/i18n-key-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ip-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-ast-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-minifier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-minify.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-obfuscator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/js-playground.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-diff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-minifier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-minify.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-path-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-schema-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-to-go.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-to-sql.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-to-typescript.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-tree.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-typescript.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-yaml.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/jsonpath-query.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/jsonpath-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/keyboard-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/keycode.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/license-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/markdown-to-html.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/math-symbols.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/meta-viewport.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/mime-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/neumorphism.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/nginx-config.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/nginx-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/openapi-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/otp-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/package-json-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/package-json-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/protobuf-decoder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/punycode.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/readme-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/readme-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-cheatsheet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-explainer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-visualizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/responsive-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/rsa-keygen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/semver-compare.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/shortcuts-cheatsheet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/slug-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sql-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sql-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sql-playground.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sql-to-mongo.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sse-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/string-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/svg-optimizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/svg-path-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/symbols-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/table-border.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/tailwind-config-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/tailwind-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/toml-yaml-json.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/tsconfig-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/unicode-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/unicode-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/url-codec.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/url-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/webhook-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/websocket-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/xml-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/xml-json.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/xpath-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/extractor/favicon-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/extractor/link-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/extractor/regex-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/extractor/text-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/aim-trainer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/coin-flip.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/dice-roller.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/number-memory.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/reaction-time.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/sequence-memory.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/what-to-eat.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/wheel-spinner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/yes-or-no.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/game-2048.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/game-minesweeper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/game-snake.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/game-sudoku.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/game-tetris.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/avatar-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/barcode.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/business-card.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/certificate-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/code-card.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/email-signature.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/fake-data.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/github-contrib.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/gradient-card.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/invoice-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/logo-text.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/meme-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/mesh-gradient.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/mock-data.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/nanoid-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/noise-texture.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/password-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/pixel-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/placeholder-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/progress-bar-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/qrcode-batch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/qrcode-scanner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/resume-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/signature-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/slug-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/social-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/stamp-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/svg-blob.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/text-to-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/uuid-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/vcard-qr.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/wave-bg.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/white-noise.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/wifi-qr.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/favicon-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/gif-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/gif-splitter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/id-photo.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-blur.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-border.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-collage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-compressor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-cropper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-filter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-flip.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-mosaic.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-resizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-rotate.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-round-corner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-sketch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-split.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-text.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-to-base64.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/annual-leave.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/bank-card-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/classroom-danmaku.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/color-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/date-diff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/electricity-bill.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/fitness-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/id-card-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/income-tax-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/license-plate-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/money-uppercase.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/mortgage-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/password-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/random-number.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/random-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/relative-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/retirement-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/student-grouping.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/word-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/audio-cutter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/audio-visualizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/base64-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/batch-resize.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/camera-demo.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/color-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/exif-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/ico-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-base64.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-color-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-compare.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-crop.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-format-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-pixelate.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-resize.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-to-ascii.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-watermark.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/screen-recorder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/screenshot-beautifier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/speech-to-text.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/svg-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/svg-placeholder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/svg-render.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/svg-to-png.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/text-to-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/text-to-speech.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/video-thumbnail.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/device-info.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/dns-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/http-header-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ip-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ip-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ip-tools.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/mac-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/port-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/rest-client.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/sse-client.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ssl-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/subnet-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/user-agent.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/websocket-client.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/credit-card.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/encrypt-decrypt.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/exif-remover.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/file-hash.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/idcard-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/log-masker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/metadata-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/password-strength.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/random-identity.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/random-key.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/rsa-tool.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/steganography.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/text-encrypt.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/bcrypt-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/cookie-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/cors-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/csp-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/hash-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/header-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/headers-check.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/password-strength.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/sitemap-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/totp-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/url-defang.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/heading-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/image-alt-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/keyword-density.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/link-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/meta-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/meta-tags-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/robots-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/bbcode-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/case-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/chinese-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/cn-convert.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/column-processor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/diff-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/emoji-search.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/frequency-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/homophone-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/html-markdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/latex-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/line-number.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/line-sorter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/markdown-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/markdown-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/markdown-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/md-to-html.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/morse-code.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/nato-alphabet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/number-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/pangu-spacing.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/pinyin-sort.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/placeholder-text.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/random-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/reading-time.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/richtext-to-plain.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/roman-numeral.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/shuangpin-trainer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/slugify.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/string-escape.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/template-filler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-cipher.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-columns.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-compare.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-dedup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-diff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-encrypt.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-frequency.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-merge.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-randomizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-repeat.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-reverse.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-similarity.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-sort.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-splitter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-stats.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-to-binary.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-truncate.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/whitespace-cleaner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/word-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/word-frequency.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/chinese-calendar.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/countdown-event.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/countdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/cron-parser.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/date-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/meeting-scheduler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/pomodoro.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/stopwatch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/timestamp.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/timezone-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/work-hours.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/world-clock.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/clipboard-history.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/file-merger.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/multi-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/quick-notes.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/code-screenshot.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/chart-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/pdf-merge.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/pdf-split.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/http-client.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/tweet-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/social-size-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/tea-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/calorie-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/stock-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/currency-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/tax-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/budget-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/investment-return.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/debt-payoff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/retirement-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/profit-margin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/tip-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/exchange-split.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/savings-goal.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/depreciation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/menstrual-cycle.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/body-fat.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/water-intake.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/calorie-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/blood-pressure.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/sleep-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/ideal-weight.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/alcohol-metabolism.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/medication-reminder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/vision-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/hearing-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/bac-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/gpa-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/grade-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/study-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/flashcard.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/citation-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/reading-speed.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/math-solver.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/unit-circle.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/periodic-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/physics-formulas.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/chemical-equation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/statistics.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/binary-tree.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/cooking-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/recipe-scaler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/nutrition-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/baking-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/coffee-ratio.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/wine-pairing.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/meat-temperature.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/food-cost.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/shopping-list.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/meal-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/fermentation-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/serving-size.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/food-storage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/drink-mixer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/idcard-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/idcard-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/uscc-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/license-plate.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/lunar-calendar.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/chinese-zodiac.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/bank-card-bin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/phone-attribution.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/chinese-number.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/idiom-dictionary.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/ancient-poetry.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/stroke-order.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/pinyin-tone.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/radicals.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/chinese/couplet-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/extractor/json-path-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/fortune-teller.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/memory-match.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/instagram-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/pdf-compress.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/duplicate-remover.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/upside-down-text.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/utm-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/whatsapp-link.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/youtube-timestamp.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/gravatar-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/age-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/compound-interest.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/currency.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/discount-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/equation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/fuel-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/matrix-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/mortgage-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/permutation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/probability.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/programmer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/salary-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/scientific.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/unit-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/area.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/length.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/number-base.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/speed.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/temperature.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/time.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/volume.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/weight.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/chart-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/gradient-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/http-client.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-schema-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/number-base.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/color-extractor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/gradient-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/pattern-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/bmr-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/due-date.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/color-picker-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-filters.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-stitcher.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/meta-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/og-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/divider.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/lorem-ipsum.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/pinyin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/typing-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/binary-translator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/countdown-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/snake-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/diff-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/mortgage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/down-payment.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/prepayment.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/loan-compare.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/combo-loan.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/deed-tax.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/property-tax.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/rental-cost.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/rent-yield.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/rent-vs-buy.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/property-roi.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/lpr-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/property-fee.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/decoration-budget.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/material-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/profit-margin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/breakeven.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/roi.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/npv.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/inventory.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/receivables.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/cashflow.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/pricing.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/cost-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/salary.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/invoice.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/equity-dilution.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/valuation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/business-scope.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/profit-loss.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/dca.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/leverage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/liquidation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/impermanent-loss.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/apy-apr.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/gas-fee.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/compound.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/mining.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/trading-fee.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/position-size.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/grid-trading.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/unit-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/address-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/crypto/ico-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/privacy-policy.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/terms-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/nda-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/disclaimer-gen.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/cookie-policy.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/gdpr-checklist.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/contract-review.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/legal-deadline.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/lawyer-fee.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/legal-glossary.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/agreement-compare.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/signature-date.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/hashtag-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/post-scheduler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/caption-writer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/thread-splitter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/bio-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/social-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/username-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/engagement-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/follower-growth.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/post-length.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/emoji-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/social-color.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/meeting-agenda.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/sprint-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/task-breakdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/decision-matrix.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/raci-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/standup-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/retrospective.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/team-vote.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/workload-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/milestone-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/icebreaker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/team-tools/feedback-form.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/countdown-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/stopwatch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/todo-list.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/notes.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/bookmark-manager.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/electricity-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/fuel-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/keyboard-codes.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/license-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/gitignore-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/number-base-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/color-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/whois-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ssl-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/memory-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/click-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/flip-coin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/typing-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/unix-timestamp.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/expense-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/percentage-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/reaction-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/color-blind-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/url-encoder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/temperature-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/speed-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/color-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/lorem-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/number-guessing.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/markdown-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/pomodoro.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/packing-list.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/jet-lag-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/travel-budget.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/currency-tips.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/sports/running-pace.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/sports/calories-burned.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/music/metronome.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/pomodoro-plus.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/habit-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/meeting-scheduler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/work-hours.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/invoice-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/pet-age.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/pet-food-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/legal/lawsuit-fee.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/photography/exposure-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/shopping/unit-price.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/gomoku.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/memory-cards.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/language/vocabulary-test.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/language/pinyin-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/art/color-wheel.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social/split-bill.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social/event-countdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/parenting/baby-food.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/diy/paint-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/diy/knitting-counter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/weather/feels-like-temp.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/weather/uv-index.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/symptom-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/loan-early-repay.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/astronomy/moon-phase.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/automotive/fuel-cost.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/gardening/plant-watering.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/recipe-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fitness/workout-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/water-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/reading-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/timezone-meeting.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/table-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/photography/golden-hour.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/compound-interest.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/roi-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/shopping/discount-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/pomodoro-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/visa-requirements.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/habit-tracker-checkin.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/shopping/price-comparison.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/pet-age-calculator-cn.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/dice-roller.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/emergency-contacts.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/phrase-book.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/size-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/power-adapter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/driving-side.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/passport-photo.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/baggage-limit.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/sim-card-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/travel-checklist.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-picker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/gradient-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/box-shadow-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-palette.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/contrast-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-grid-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/flexbox-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/border-radius-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-filter-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/animation-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/text-shadow-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-blindness-simulator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/font-pair-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/spacing-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/glassmorphism-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/neumorphism-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/clip-path-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/transform-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/transition-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/cursor-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/scrollbar-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/triangle-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/blob-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/wave-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/pattern-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/loader-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/button-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/card-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/text-gradient-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/date-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/discount-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/percentage-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/subnet-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/area-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/currency-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/data-storage-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/energy-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/frequency-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/length-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/power-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/time-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/volume-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/weight-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/bar-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/chart-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/csv-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-aggregator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-cleaner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-diff.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-exporter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-filter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-importer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-merger.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-normalizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-sampler.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-sorter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-transformer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/data-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/duplicate-remover.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/excel-to-json.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/heatmap-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/histogram-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/json-flattener.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/json-to-csv.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/json-unflatten.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/line-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/outlier-detector.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/pie-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/pivot-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/scatter-plot.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/sql-query-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/data/statistics-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/aspect-ratio-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-contrast-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/automotive/tire-pressure-calc.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-animation-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-button-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-clip-path-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/css-transform-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/font-preview.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/palette-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/svg-path-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/api-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-animation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-flexbox.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-gradient-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/curl-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/docker-command-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/env-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/git-command-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/git-command-helper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/htaccess-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-entity-encoder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/html-minifier.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/http-status-codes.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-path-finder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-path-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/lorem-ipsum.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/nginx-config-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/npm-command-helper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sql-keywords.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/string-escape.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/yaml-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/name-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/quiz-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fun/wheel-of-fortune.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/breakout-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/color-match.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/flappy-bird.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/guess-number.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/math-challenge.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/pinball-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/reaction-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/shooter-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/tic-tac-toe.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/typing-game.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/word-chain.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/game/word-scramble.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/barcode-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/credit-card-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/fake-data-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/favicon-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/htaccess-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/iban-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/lorem-ipsum.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/markdown-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/meta-tag-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/random-name-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/robots-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/generator/robots-txt-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/countdown-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/decision-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/habit-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/pomodoro-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/stopwatch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/unit-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/world-clock.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/binary-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/equation-solver.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/factorial-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/fraction-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/gcd-lcm-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/logarithm-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/matrix-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/number-base-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/percentage-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/permutation-combination.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/prime-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/quadratic-equation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/statistics-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/trigonometry-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/unit-circle.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/ip-subnet-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/port-info.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/port-scanner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/agenda-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/attendance-sheet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/barcode-label.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/business-card-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/checklist-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/contract-template.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/expense-report.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/gantt-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/invoice-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/label-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/leave-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/letter-template.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/letterhead-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/meeting-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/minutes-template.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/org-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/overtime-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/presentation-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/project-timeline.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/purchase-order.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/quotation-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/receipt-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/resume-maker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/seating-chart.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/signature-pad.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/slide-notes.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/stamp-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/task-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/timesheet.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/work-log.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/realestate/rent-vs-buy-cn.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/slug-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-case-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-statistics.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/unicode-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/baggage-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/currency-exchange.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/distance-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/flight-time.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/fuel-cost.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/hotel-cost.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/itinerary-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/season-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/time-difference.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/timezone-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/tip-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/toll-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/travel-insurance.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/trip-budget.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/vaccine-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/visa-checker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/weather-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/world-clock.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/multiplication-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/calorie-burn-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/office/meeting-cost-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/lifestyle/birthday-reminder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/lifestyle/daily-affirmation.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/lifestyle/water-intake-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-palette-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/budget-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/focus-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/reading-time.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/language/vocabulary-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social/gift-idea-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/parenting/growth-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/weather/uv-index-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/art/color-mixer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/automotive/fuel-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/gardening/watering-schedule.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/fitness/workout-logger.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/sports/score-keeper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/pet-age-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/parenting/baby-sleep-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/event-countdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/breathing-exercise.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/feeding-schedule.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/diy/material-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/music/chord-finder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/gardening/plant-care-guide.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/food/recipe-timer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/astronomy/stargazing-tonight.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/time/new-year-countdown.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-name-finder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/color-temperature.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/image-to-pdf.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/media/pdf-to-image.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-specificity-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/fluid-typography-clamp-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/media-query-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/px-rem-em-converter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/type-scale-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-container-query-builder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/css-z-index-stacking-visualizer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/svg-sprite-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/svg-to-data-uri.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/sri-hash-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/regex-find-replace-tester.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/har-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-merge-patch.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ndjson-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ini-file-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/java-properties-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/access-log-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/ssh-keygen-helper.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/po-file-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/security/pgp-encrypt-decrypt.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/network/email-header-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/email-address-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/phone-number-formatter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/swift-bic-lookup.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/privacy/zero-width-text-steganography.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/vigenere-cipher.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/converter/braille-translator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/geojson-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/gpx-track-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/isbn-validator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/productivity/ics-calendar-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/text-readability-analyzer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/crc32-checksum-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/dividend-pe-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/vat-gst-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/import-duty-estimator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/ohms-law-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/oklch-color-editor.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/solar-system-explorer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/dew-point-humidity-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/music-scale-finder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/chord-progression-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/pi-digits-explorer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/fibonacci-sequence-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/prime-factorization.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/math/matrix-determinant-inverse.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/normal-distribution-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/hypothesis-testing-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/caffeine-half-life-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/travel/tide-chart-viewer.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/social-media/og-image-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/favicon-ico-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/screen-resolution-reference.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/print-size-dpi-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/amortization-table.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/inflation-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/nps-csat-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/markdown-linter.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/json-schema-to-form.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/design/text-to-svg-path.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/resistor-color-code.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/capacitor-code-decoder.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/voltage-divider-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/wire-gauge-awg-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/battery-runtime-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/molar-mass-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/calculator/ph-scale-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/tdee-calorie-deficit-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/one-rep-max-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/blood-pressure-log.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/blood-glucose-tracker.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/cholesterol-ratio-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/macro-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/health/vo2max-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/cagr-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/budget-50-30-20-planner.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/finance/payback-period-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/seo/schema-org-generator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/text/anagram-solver.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/life/carbon-footprint-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/business/salary-negotiation-calculator.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/dev/cors-preflight-debugger.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/pets/pet-medication-dosage.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tools.realtime-ai.chat/tools/education/geography-country-quiz.html</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/tests/data-quality.test.js
+++ b/tests/data-quality.test.js
@@ -116,6 +116,9 @@ test('popularity 若存在则为非负有限数', () => {
 
 test('tools/ 下的 .html 文件都已登记在 tools.json（无游离文件）', () => {
   const registered = new Set(entries.map(([, t]) => t.path));
-  const orphans = listToolHtmlFiles().filter((f) => !registered.has(f));
+  // 分类落地页 tools/<cat>/index.html 由 sync 脚本生成，是独立页面类型，不登记为工具
+  const orphans = listToolHtmlFiles().filter(
+    (f) => !registered.has(f) && !/\/index\.html$/.test(f)
+  );
   assert(orphans.length === 0, `未登记的文件:\n${orphans.join('\n')}`);
 });

--- a/tests/sync.test.js
+++ b/tests/sync.test.js
@@ -54,11 +54,18 @@ test(`index.html category-count 数字与活跃分类数一致 (${activeCategory
   assert(Number(m[1]) === activeCategoryCount, `显示 ${m[1]}，应为 ${activeCategoryCount}`);
 });
 
-test(`sitemap.xml <loc> 数量为 工具数 + 首页 (${toolCount + 1})`, () => {
+// 分类落地页：每个分类生成 tools/<cat>/index.html，已登记为工具的分类首页（如 ai-coding）除外
+const registeredPaths = new Set(toolPaths);
+const categoryPagePaths = Object.keys(data.categories)
+  .map((c) => `tools/${c}/index.html`)
+  .filter((p) => !registeredPaths.has(p));
+const expectedLocs = toolCount + 1 + categoryPagePaths.length;
+
+test(`sitemap.xml <loc> 数量为 工具数 + 首页 + 分类落地页 (${expectedLocs})`, () => {
   const locs = sitemap.match(/<loc>/g) || [];
   assert(
-    locs.length === toolCount + 1,
-    `sitemap 有 ${locs.length} 个 <loc>，应为 ${toolCount + 1} —— 请运行 npm run sync:tools`
+    locs.length === expectedLocs,
+    `sitemap 有 ${locs.length} 个 <loc>，应为 ${expectedLocs} —— 请运行 npm run sync:tools`
   );
 });
 
@@ -69,6 +76,11 @@ test('sitemap.xml 含首页 URL', () => {
 test('每个工具 path 都出现在 sitemap.xml 中', () => {
   const missing = toolPaths.filter((p) => !sitemap.includes(`<loc>${SITE}/${p}</loc>`));
   assert(missing.length === 0, `sitemap.xml 缺少:\n${missing.slice(0, 20).join('\n')}`);
+});
+
+test('每个分类落地页都出现在 sitemap.xml 中', () => {
+  const missing = categoryPagePaths.filter((p) => !sitemap.includes(`<loc>${SITE}/${p}</loc>`));
+  assert(missing.length === 0, `sitemap.xml 缺少分类落地页:\n${missing.join('\n')}`);
 });
 
 test(`manifest.json 描述含工具数 "${toolCount}+"`, () => {

--- a/tools.json
+++ b/tools.json
@@ -2,179 +2,211 @@
   "categories": {
     "dev": {
       "name": "开发工具",
+      "intro": "面向程序员的在线开发工具集合，涵盖 JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。",
       "icon": "⚡",
       "color": "cyan"
     },
     "text": {
       "name": "文本工具",
+      "intro": "在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。",
       "icon": "📝",
       "color": "yellow"
     },
     "time": {
       "name": "时间工具",
+      "intro": "时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。",
       "icon": "⏰",
       "color": "magenta"
     },
     "generator": {
       "name": "生成器",
+      "intro": "各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。",
       "icon": "🎲",
       "color": "purple"
     },
     "media": {
       "name": "媒体工具",
+      "intro": "在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64 编码等，无需上传即可在浏览器内完成。",
       "icon": "🖼️",
       "color": "blue"
     },
     "privacy": {
       "name": "隐私安全",
+      "intro": "注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。",
       "icon": "🔒",
       "color": "green"
     },
     "security": {
       "name": "安全工具",
+      "intro": "在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。",
       "icon": "🛡️",
       "color": "red"
     },
     "network": {
       "name": "网络工具",
+      "intro": "网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL 解析、端口参考等，便于排查与配置网络。",
       "icon": "🌐",
       "color": "cyan"
     },
     "calculator": {
       "name": "计算器",
+      "intro": "各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。",
       "icon": "🔢",
       "color": "yellow"
     },
     "converter": {
       "name": "转换器",
+      "intro": "在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。",
       "icon": "🔄",
       "color": "purple"
     },
     "extractor": {
       "name": "提取器",
+      "intro": "在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。",
       "icon": "📤",
       "color": "blue"
     },
     "ai": {
       "name": "AI 工具",
+      "intro": "与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。",
       "icon": "🤖",
       "color": "magenta"
     },
     "seo": {
       "name": "SEO 工具",
+      "intro": "面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap 等，助力搜索引擎排名。",
       "icon": "📈",
       "color": "green"
     },
     "fun": {
       "name": "趣味工具",
+      "intro": "轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。",
       "icon": "🎯",
       "color": "orange"
     },
     "game": {
       "name": "小游戏",
+      "intro": "浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。",
       "icon": "🎮",
       "color": "purple"
     },
     "life": {
       "name": "生活工具",
+      "intro": "贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。",
       "icon": "🏠",
       "color": "green"
     },
     "finance": {
       "name": "财务工具",
+      "intro": "个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。",
       "icon": "💰",
       "color": "green"
     },
     "health": {
       "name": "医疗健康",
+      "intro": "健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。",
       "icon": "⚕️",
       "color": "red"
     },
     "education": {
       "name": "教育学习",
+      "intro": "面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。",
       "icon": "📚",
       "color": "blue"
     },
     "food": {
       "name": "餐饮食品",
+      "intro": "与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。",
       "icon": "🍳",
       "color": "orange"
     },
     "chinese": {
       "name": "中文工具",
+      "intro": "专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。",
       "icon": "中",
       "color": "red"
     },
     "ai-coding": {
       "name": "AI 编程",
+      "intro": "AI 编程与 Vibe Coding 资源导航，汇集 AI IDE、Claude Skills、Cursor Rules、MCP 等工具与指南。",
       "icon": "🤖",
       "color": "purple"
     },
     "realestate": {
       "name": "房产工具",
+      "intro": "房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。",
       "icon": "🏠",
       "color": "blue"
     },
     "business": {
       "name": "商业工具",
+      "intro": "面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。",
       "icon": "💼",
       "color": "cyan"
     },
     "crypto": {
       "name": "加密货币",
+      "intro": "加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。",
       "icon": "₿",
       "color": "orange"
     },
     "legal": {
       "name": "法律合规",
+      "intro": "法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。",
       "icon": "⚖️",
       "color": "purple"
     },
     "social-media": {
       "name": "社交媒体",
+      "intro": "面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。",
       "icon": "📱",
       "color": "pink"
     },
     "team-tools": {
       "name": "团队协作",
+      "intro": "面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。",
       "icon": "👥",
       "color": "teal"
     },
     "data": {
       "name": "数据工具",
+      "intro": "在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。",
       "icon": "📊",
       "color": "blue"
     },
     "office": {
       "name": "办公效率",
+      "intro": "提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。",
       "icon": "📊",
       "color": "blue"
     },
     "travel": {
       "name": "旅行工具",
+      "intro": "旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。",
       "icon": "✈️",
       "color": "cyan"
     },
     "design": {
       "name": "设计工具",
+      "intro": "面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。",
       "icon": "🎨",
-      "color": "pink",
-      "description": "CSS 设计、UI 效果生成器"
+      "color": "pink"
     },
     "math": {
       "name": "数学工具",
+      "intro": "数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。",
       "icon": "🔢",
-      "description": "数学计算、方程求解、进制转换",
       "color": "blue"
     },
     "productivity": {
       "name": "效率工具",
+      "intro": "提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。",
       "icon": "🎯",
-      "description": "提升工作效率的实用工具",
       "color": "cyan"
     },
     "pets": {
       "name": "宠物工具",
+      "intro": "养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。",
       "icon": "🐾",
       "color": "orange"
     }

--- a/tools/ai/index.html
+++ b/tools/ai/index.html
@@ -1,0 +1,807 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>AI 工具 - 在线工具合集（43个）| WebUtils</title>
+    <meta
+      name="description"
+      content="与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。"
+    />
+    <meta name="keywords" content="AI 工具,在线工具,免费工具,AI 工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/ai/index.html" />
+    <meta property="og:title" content="AI 工具 - 在线工具合集（43个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/ai/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="AI 工具 - 在线工具合集（43个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "AI 工具",
+            "item": "https://tools.realtime-ai.chat/tools/ai/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "AI 工具 - 在线工具合集（43个）| WebUtils",
+        "description": "与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。",
+        "url": "https://tools.realtime-ai.chat/tools/ai/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 43,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "AGI 2026 展望",
+              "url": "https://tools.realtime-ai.chat/tools/ai/agi-2026-outlook.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "AI Agent 2025 年度指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-agent-2025-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "AI Agent 入门指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-agent-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "AI 编程工具 2025",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-coding-tools-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "AI 编程工具对比",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-coding-tools.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "AI 图像生成工具大全",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-image-generation-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "AI 模型对比表",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-models.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "AI API 价格计算器",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-pricing.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "AI 视频生成对比 2025",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ai-video-generation-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "国产大模型 2025",
+              "url": "https://tools.realtime-ai.chat/tools/ai/china-llm-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "Claude 4 使用指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/claude-4-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Claude Code 生态大全",
+              "url": "https://tools.realtime-ai.chat/tools/ai/claude-code-ecosystem.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "Claude Skills 精选",
+              "url": "https://tools.realtime-ai.chat/tools/ai/claude-skills.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Cursor 快捷键速查",
+              "url": "https://tools.realtime-ai.chat/tools/ai/cursor-shortcuts.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "DeepSeek API 使用指南 | 在线工具",
+              "url": "https://tools.realtime-ai.chat/tools/ai/deepseek-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "DeepSeek V3 完整指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/deepseek-v3-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "豆包 1.8 使用指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/doubao-1.8-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "Gemini 2.5 Pro 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/gemini-2.5-pro-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Gemini 3 使用指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/gemini3-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "GPT-5 完整指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/gpt5-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Grok 4 使用指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/grok4-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "人形机器人 2025",
+              "url": "https://tools.realtime-ai.chat/tools/ai/humanoid-robots-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "Kimi K2 完整指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/kimi-k2-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Llama 4 完整指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/llama-4-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "MCP 客户端大全",
+              "url": "https://tools.realtime-ai.chat/tools/ai/mcp-clients.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "MCP 配置指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/mcp-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "MCP 协议指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/mcp-protocol-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "Midjourney V7 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/midjourney-v7-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Nemotron 3 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/nemotron-3-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "NotebookLM 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/notebooklm-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "OpenAI o3/o4-mini 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/openai-o3-o4-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "OpenAI 推理模型指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/openai-reasoning-models-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "Perplexity 指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/perplexity-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "Prompt 模板库",
+              "url": "https://tools.realtime-ai.chat/tools/ai/prompt-templates.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "Prompt 技巧速查 2025",
+              "url": "https://tools.realtime-ai.chat/tools/ai/prompt-tips-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "RAG 技术完全指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/rag-technology-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "Sora 视频生成指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/sora-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "Suno AI 音乐指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/suno-ai-music-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "Token 计数器",
+              "url": "https://tools.realtime-ai.chat/tools/ai/token-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "TTS 语音合成工具大全",
+              "url": "https://tools.realtime-ai.chat/tools/ai/tts-tools-2025.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "UI/UX 设计资源导航",
+              "url": "https://tools.realtime-ai.chat/tools/ai/ui-ux-design-resources.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "Vibe Coding 入门指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/vibe-coding-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "万象 2.6 视频指南",
+              "url": "https://tools.realtime-ai.chat/tools/ai/wanxiang-2.6-guide.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🤖</div>
+        <h1>AI 工具</h1>
+        <p class="cat-intro">
+          与 AI 相关的实用在线工具，包括提示词辅助、文本处理、Token 估算等，提升与大模型协作的效率。
+        </p>
+        <p class="cat-meta">43 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="agi-2026-outlook.html">
+          <span class="cat-card-icon">🔮</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AGI 2026 展望</span>
+            <span class="cat-card-desc">
+              AGI 2026展望：OpenAI/Anthropic/马斯克预测，超级智能时代
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-agent-2025-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI Agent 2025 年度指南</span>
+            <span class="cat-card-desc">
+              2025 AI Agent商业化元年：OpenAI Operator、Google Jarvis、Copilot全解析
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-agent-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI Agent 入门指南</span>
+            <span class="cat-card-desc">
+              AI Agent 2024 入门指南，涵盖主流框架、应用场景和发展趋势
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-coding-tools-2025.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI 编程工具 2025</span>
+            <span class="cat-card-desc">
+              2025 年 AI 编程工具全面对比：Cursor、Windsurf、Claude Code、Copilot
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-coding-tools.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI 编程工具对比</span>
+            <span class="cat-card-desc">
+              Cursor vs Windsurf vs Cline vs Copilot 对比，AI 编程工具选择指南
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-image-generation-2025.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI 图像生成工具大全</span>
+            <span class="cat-card-desc">
+              2025年AI图像生成完整指南：Flux vs Midjourney vs SD对比
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-models.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI 模型对比表</span>
+            <span class="cat-card-desc">
+              AI 模型对比表，在线使用，AI 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-pricing.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI API 价格计算器</span>
+            <span class="cat-card-desc">
+              AI API 价格计算器，快速计算结果，AI 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ai-video-generation-2025.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AI 视频生成对比 2025</span>
+            <span class="cat-card-desc">
+              可灵2.0/Runway Gen-4.5/Sora Turbo/海螺AI/Vidu 2.0 全面对比
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="china-llm-2025.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">国产大模型 2025</span>
+            <span class="cat-card-desc">
+              2025年12月国产大模型最新：GLM-4.7、MiniMax M2.1、DeepSeek、Qwen
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="claude-4-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Claude 4 使用指南</span>
+            <span class="cat-card-desc">Anthropic Claude 4 系列完整指南：Opus 4.5、Sonnet 4.5</span>
+          </span>
+        </a>
+        <a class="cat-card" href="claude-code-ecosystem.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Claude Code 生态大全</span>
+            <span class="cat-card-desc">
+              Claude Code 生态系统完整指南：MCP Servers、Skills、插件市场
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="claude-skills.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Claude Skills 精选</span>
+            <span class="cat-card-desc">Anthropic 官方 Skills 集合，提升 Claude 特定任务表现</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cursor-shortcuts.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cursor 快捷键速查</span>
+            <span class="cat-card-desc">
+              Cursor 快捷键速查，在线使用，AI 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="deepseek-guide.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">DeepSeek API 使用指南 | 在线工具</span>
+            <span class="cat-card-desc">
+              DeepSeek API 使用指南 | 在线工具，在线使用，AI 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="deepseek-v3-guide.html">
+          <span class="cat-card-icon">🐋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">DeepSeek V3 完整指南</span>
+            <span class="cat-card-desc">
+              DeepSeek V3 最新版：6850亿参数MoE架构，557万美元训练成本，MIT开源
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="doubao-1.8-guide.html">
+          <span class="cat-card-icon">🫘</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">豆包 1.8 使用指南</span>
+            <span class="cat-card-desc">字节跳动豆包 1.8 大模型使用指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gemini-2.5-pro-guide.html">
+          <span class="cat-card-icon">💎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gemini 2.5 Pro 指南</span>
+            <span class="cat-card-desc">
+              Google最智能AI模型：首个思考模型，100万token上下文，LMArena第一
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gemini3-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gemini 3 使用指南</span>
+            <span class="cat-card-desc">
+              Google Gemini 3 完整指南：Pro/Flash 版本，万亿参数，100万token上下文
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gpt5-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GPT-5 完整指南</span>
+            <span class="cat-card-desc">
+              OpenAI GPT-5 系列指南：GPT-5.2 三版本策略、Instant/Thinking/Pro 详解
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="grok4-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Grok 4 使用指南</span>
+            <span class="cat-card-desc">
+              xAI Grok 4 完整指南：Grok 4 Heavy AIME满分，博士级AI，年费3000美元
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="humanoid-robots-2025.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">人形机器人 2025</span>
+            <span class="cat-card-desc">
+              2025 年人形机器人发展综述：特斯拉 Optimus、Figure、波士顿动力
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="kimi-k2-guide.html">
+          <span class="cat-card-icon">🌙</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Kimi K2 完整指南</span>
+            <span class="cat-card-desc">月之暗面 Kimi K2：万亿参数开源大模型，Agent时代先驱</span>
+          </span>
+        </a>
+        <a class="cat-card" href="llama-4-guide.html">
+          <span class="cat-card-icon">🦙</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Llama 4 完整指南</span>
+            <span class="cat-card-desc">Meta Llama 4：MoE架构多模态开源模型，千万token上下文</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mcp-clients.html">
+          <span class="cat-card-icon">🖥️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">MCP 客户端大全</span>
+            <span class="cat-card-desc">支持 MCP 的 AI 客户端、IDE 和开发工具汇总</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mcp-guide.html">
+          <span class="cat-card-icon">🔌</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">MCP 配置指南</span>
+            <span class="cat-card-desc">Model Context Protocol 配置教程与热门服务器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mcp-protocol-guide.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">MCP 协议指南</span>
+            <span class="cat-card-desc">Model Context Protocol 完整指南：连接 AI 与外部工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="midjourney-v7-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Midjourney V7 指南</span>
+            <span class="cat-card-desc">
+              Midjourney V7 完整指南：草图模式、语音生图、Omni-Reference 全向参考
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="nemotron-3-guide.html">
+          <span class="cat-card-icon">🟢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Nemotron 3 指南</span>
+            <span class="cat-card-desc">Nvidia Nemotron 3 开源大模型使用指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="notebooklm-guide.html">
+          <span class="cat-card-icon">📓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">NotebookLM 指南</span>
+            <span class="cat-card-desc">Google NotebookLM AI 笔记助手使用指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="openai-o3-o4-guide.html">
+          <span class="cat-card-icon">🧠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">OpenAI o3/o4-mini 指南</span>
+            <span class="cat-card-desc">
+              首个图像思维链推理模型：o3旗舰推理、o4-mini高效推理、Codex CLI
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="openai-reasoning-models-2025.html">
+          <span class="cat-card-icon">🧠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">OpenAI 推理模型指南</span>
+            <span class="cat-card-desc">
+              o1/o3/o4-mini 推理模型完全解析：图像思维链、工具调用、Codex CLI
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="perplexity-guide.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Perplexity 指南</span>
+            <span class="cat-card-desc">Perplexity AI 深度搜索使用指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="prompt-templates.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Prompt 模板库</span>
+            <span class="cat-card-desc">AI 提示词模板库</span>
+          </span>
+        </a>
+        <a class="cat-card" href="prompt-tips-2025.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Prompt 技巧速查 2025</span>
+            <span class="cat-card-desc">
+              2025 年 Prompt Engineering 实用技巧速查，含 10 大核心技术
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="rag-technology-2025.html">
+          <span class="cat-card-icon">📚</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">RAG 技术完全指南</span>
+            <span class="cat-card-desc">
+              2025年RAG技术完整指南：框架、向量库、Embedding模型详解
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sora-guide.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Sora 视频生成指南</span>
+            <span class="cat-card-desc">
+              OpenAI Sora 视频生成入门指南，包含定价、使用教程、Prompt 技巧
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="suno-ai-music-guide.html">
+          <span class="cat-card-icon">🎵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Suno AI 音乐指南</span>
+            <span class="cat-card-desc">Suno V4 AI 音乐生成完整指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="token-counter.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Token 计数器</span>
+            <span class="cat-card-desc">估算 AI 模型 Token 数量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="tts-tools-2025.html">
+          <span class="cat-card-icon">🎙️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">TTS 语音合成工具大全</span>
+            <span class="cat-card-desc">2025年TTS语音合成工具完整指南：开源与商业方案对比</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ui-ux-design-resources.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">UI/UX 设计资源导航</span>
+            <span class="cat-card-desc">
+              UI/UX设计资源综合导航：灵感、组件库、图标、配色、字体、素材一站式指南
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="vibe-coding-guide.html">
+          <span class="cat-card-icon">🎵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Vibe Coding 入门指南</span>
+            <span class="cat-card-desc">
+              2025 Collins 年度词汇 Vibe Coding：AI 辅助编程新范式完全指南
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="wanxiang-2.6-guide.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">万象 2.6 视频指南</span>
+            <span class="cat-card-desc">阿里巴巴万象 2.6 AI 视频生成指南</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/business/index.html
+++ b/tools/business/index.html
@@ -1,0 +1,421 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>商业工具 - 在线工具合集（17个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。"
+    />
+    <meta name="keywords" content="商业工具,在线工具,免费工具,商业工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/business/index.html" />
+    <meta property="og:title" content="商业工具 - 在线工具合集（17个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/business/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="商业工具 - 在线工具合集（17个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "商业工具",
+            "item": "https://tools.realtime-ai.chat/tools/business/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "商业工具 - 在线工具合集（17个）| WebUtils",
+        "description": "面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。",
+        "url": "https://tools.realtime-ai.chat/tools/business/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 17,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "毛利净利计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/profit-margin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "盈亏平衡分析",
+              "url": "https://tools.realtime-ai.chat/tools/business/breakeven.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "ROI 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/roi.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "净现值NPV计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/npv.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "库存周转计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/inventory.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "应收账款账龄分析",
+              "url": "https://tools.realtime-ai.chat/tools/business/receivables.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "现金流预测",
+              "url": "https://tools.realtime-ai.chat/tools/business/cashflow.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "定价策略计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/pricing.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "成本核算计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/cost-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "税后薪资工具(商业版)",
+              "url": "https://tools.realtime-ai.chat/tools/business/salary.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "发票计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/invoice.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "股权稀释计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/equity-dilution.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "企业估值计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/valuation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "经营范围生成器",
+              "url": "https://tools.realtime-ai.chat/tools/business/business-scope.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "ROI 投资回报率计算器(详细)",
+              "url": "https://tools.realtime-ai.chat/tools/business/roi-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "NPS / CSAT 客户满意度计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/nps-csat-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "薪资谈判计算器",
+              "url": "https://tools.realtime-ai.chat/tools/business/salary-negotiation-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">💼</div>
+        <h1>商业工具</h1>
+        <p class="cat-intro">
+          面向企业与创业者的在线工具，涵盖报价、发票、利润、营销文案等日常经营需求。
+        </p>
+        <p class="cat-meta">17 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="profit-margin.html">
+          <span class="cat-card-icon">💹</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">毛利净利计算器</span>
+            <span class="cat-card-desc">计算毛利率和净利率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="breakeven.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">盈亏平衡分析</span>
+            <span class="cat-card-desc">计算盈亏平衡点</span>
+          </span>
+        </a>
+        <a class="cat-card" href="roi.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ROI 计算器</span>
+            <span class="cat-card-desc">计算投资回报率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="npv.html">
+          <span class="cat-card-icon">💵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">净现值NPV计算器</span>
+            <span class="cat-card-desc">计算投资项目的净现值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="inventory.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">库存周转计算器</span>
+            <span class="cat-card-desc">计算库存周转率和周转天数</span>
+          </span>
+        </a>
+        <a class="cat-card" href="receivables.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">应收账款账龄分析</span>
+            <span class="cat-card-desc">分析应收账款账龄结构</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cashflow.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">现金流预测</span>
+            <span class="cat-card-desc">预测企业现金流状况</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pricing.html">
+          <span class="cat-card-icon">🏷️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">定价策略计算器</span>
+            <span class="cat-card-desc">计算产品定价策略</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cost-calc.html">
+          <span class="cat-card-icon">🧮</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">成本核算计算器</span>
+            <span class="cat-card-desc">核算产品或项目成本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="salary.html">
+          <span class="cat-card-icon">💼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">税后薪资工具(商业版)</span>
+            <span class="cat-card-desc">计算税后工资和社保扣款</span>
+          </span>
+        </a>
+        <a class="cat-card" href="invoice.html">
+          <span class="cat-card-icon">🧾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">发票计算器</span>
+            <span class="cat-card-desc">计算发票税额和价税分离</span>
+          </span>
+        </a>
+        <a class="cat-card" href="equity-dilution.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">股权稀释计算器</span>
+            <span class="cat-card-desc">计算融资后的股权稀释比例</span>
+          </span>
+        </a>
+        <a class="cat-card" href="valuation.html">
+          <span class="cat-card-icon">🏢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">企业估值计算器</span>
+            <span class="cat-card-desc">使用多种方法估算企业价值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="business-scope.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">经营范围生成器</span>
+            <span class="cat-card-desc">生成企业经营范围描述</span>
+          </span>
+        </a>
+        <a class="cat-card" href="roi-calculator.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ROI 投资回报率计算器(详细)</span>
+            <span class="cat-card-desc">计算投资回报率(ROI)，评估投资效益</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nps-csat-calculator.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">NPS / CSAT 客户满意度计算器</span>
+            <span class="cat-card-desc">
+              批量输入 NPS 问卷评分（0-10），自动计算净推荐值（Promoter% - Detractor%），并可计算
+              CSAT 和 CES 指标。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="salary-negotiation-calculator.html">
+          <span class="cat-card-icon">💼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">薪资谈判计算器</span>
+            <span class="cat-card-desc">
+              对比多个 offer 的税后实际收入（含五险一金、年终、股票
+              vesting），计算真实年化总薪酬，辅助决策。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/calculator/index.html
+++ b/tools/calculator/index.html
@@ -1,0 +1,982 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>计算器 - 在线工具合集（54个）| WebUtils</title>
+    <meta
+      name="description"
+      content="各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。"
+    />
+    <meta name="keywords" content="计算器,在线工具,免费工具,计算器大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/calculator/index.html" />
+    <meta property="og:title" content="计算器 - 在线工具合集（54个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/calculator/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="计算器 - 在线工具合集（54个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "计算器",
+            "item": "https://tools.realtime-ai.chat/tools/calculator/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "计算器 - 在线工具合集（54个）| WebUtils",
+        "description": "各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。",
+        "url": "https://tools.realtime-ai.chat/tools/calculator/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 54,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "年龄差计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/age-diff-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "宽高比计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/aspect-ratio-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "进制计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/base-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "位运算计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/bitwise-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "BMI 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/bmi-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "电费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/electricity-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "函数图像绘制器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/function-plotter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "贷款计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/loan-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "数学表达式计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/math-evaluator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "百分比计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/percentage.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "进度计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/progress.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "税后工资计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/salary-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "网速计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/speed-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "统计计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/statistics-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "存储单位换算",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/storage-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "时间加减计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/time-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "小费/AA计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "三角函数计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/triangle-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "年龄计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/age-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "复利计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/compound-interest.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "汇率转换器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/currency.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "折扣计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/discount-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "方程求解器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/equation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "油耗计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/fuel-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "矩阵计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/matrix-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "房贷计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/mortgage-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "排列组合计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/permutation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "概率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/probability.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "程序员计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/programmer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "工资计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/salary-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "科学计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/scientific.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "单位换算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/unit-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "电费计算器(详细版)",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/electricity-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "汽车油耗计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/fuel-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "百分比计算",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/percentage-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "Date Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/date-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "Discount Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/discount-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "Percentage Calc",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/percentage-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "Subnet Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/subnet-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "增值税 / GST 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/vat-gst-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "进口关税估算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/import-duty-estimator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "欧姆定律 / 电路计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/ohms-law-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "湿度 / 露点计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/dew-point-humidity-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "正态分布计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/normal-distribution-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "假设检验计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/hypothesis-testing-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "打印尺寸 / DPI 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/print-size-dpi-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "通货膨胀计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/inflation-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "电阻色环计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/resistor-color-code.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": "电容代码解码器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/capacitor-code-decoder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "分压电路计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/voltage-divider-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "导线规格 / AWG 载流计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/wire-gauge-awg-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": "电池续航估算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/battery-runtime-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "摩尔质量计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/molar-mass-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "pH 值计算器",
+              "url": "https://tools.realtime-ai.chat/tools/calculator/ph-scale-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🔢</div>
+        <h1>计算器</h1>
+        <p class="cat-intro">
+          各类在线计算器，覆盖贷款、利息、BMI、单位换算、百分比等日常与专业计算场景。
+        </p>
+        <p class="cat-meta">54 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="age-diff-calc.html">
+          <span class="cat-card-icon">👥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">年龄差计算器</span>
+            <span class="cat-card-desc">
+              年龄差计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="aspect-ratio-calculator.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宽高比计算器</span>
+            <span class="cat-card-desc">计算和转换宽高比，支持常见视频图片分辨率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="base-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">进制计算器</span>
+            <span class="cat-card-desc">多进制转换和位运算计算器，支持可视化位操作</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bitwise-calculator.html">
+          <span class="cat-card-icon">&amp;</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">位运算计算器</span>
+            <span class="cat-card-desc">
+              位运算计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="bmi-calculator.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">BMI 计算器</span>
+            <span class="cat-card-desc">计算身体质量指数，评估体重健康状况</span>
+          </span>
+        </a>
+        <a class="cat-card" href="electricity-calc.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电费计算器</span>
+            <span class="cat-card-desc">
+              电费计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="function-plotter.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">函数图像绘制器</span>
+            <span class="cat-card-desc">绘制数学函数图像</span>
+          </span>
+        </a>
+        <a class="cat-card" href="loan-calculator.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">贷款计算器</span>
+            <span class="cat-card-desc">计算贷款月供、总利息，支持两种还款方式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="math-evaluator.html">
+          <span class="cat-card-icon">∑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数学表达式计算器</span>
+            <span class="cat-card-desc">计算复杂数学表达式，支持函数和常量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="percentage.html">
+          <span class="cat-card-icon">%</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">百分比计算器</span>
+            <span class="cat-card-desc">多种百分比计算模式：求百分比、增减、占比等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="progress.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">进度计算器</span>
+            <span class="cat-card-desc">计算项目进度百分比和预计完成时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="salary-calc.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">税后工资计算器</span>
+            <span class="cat-card-desc">
+              税后工资计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="speed-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">网速计算器</span>
+            <span class="cat-card-desc">
+              网速计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="statistics-calc.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">统计计算器</span>
+            <span class="cat-card-desc">
+              统计计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="storage-converter.html">
+          <span class="cat-card-icon">💾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">存储单位换算</span>
+            <span class="cat-card-desc">B/KB/MB/GB/TB/PB 存储单位互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="time-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">时间加减计算器</span>
+            <span class="cat-card-desc">
+              时间加减计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tip-calculator.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">小费/AA计算器</span>
+            <span class="cat-card-desc">
+              小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="triangle-calc.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">三角函数计算器</span>
+            <span class="cat-card-desc">
+              三角函数计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="age-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">年龄计算器</span>
+            <span class="cat-card-desc">
+              年龄计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="compound-interest.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">复利计算器</span>
+            <span class="cat-card-desc">
+              复利计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="currency.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汇率转换器</span>
+            <span class="cat-card-desc">
+              汇率转换器，多格式互转，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="discount-calc.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">折扣计算器</span>
+            <span class="cat-card-desc">
+              折扣计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="equation.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">方程求解器</span>
+            <span class="cat-card-desc">方程求解器，在线使用，计算器，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fuel-calc.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">油耗计算器</span>
+            <span class="cat-card-desc">
+              油耗计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="matrix-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">矩阵计算器</span>
+            <span class="cat-card-desc">
+              矩阵计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="mortgage-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">房贷计算器</span>
+            <span class="cat-card-desc">
+              房贷计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="permutation.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">排列组合计算器</span>
+            <span class="cat-card-desc">
+              排列组合计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="probability.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">概率计算器</span>
+            <span class="cat-card-desc">
+              概率计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="programmer.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">程序员计算器</span>
+            <span class="cat-card-desc">
+              程序员计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="salary-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">工资计算器</span>
+            <span class="cat-card-desc">
+              工资计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="scientific.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">科学计算器</span>
+            <span class="cat-card-desc">
+              科学计算器，快速计算结果，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-converter.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">单位换算器</span>
+            <span class="cat-card-desc">单位换算器，在线使用，计算器，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="electricity-calculator.html">
+          <span class="cat-card-icon">💡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电费计算器(详细版)</span>
+            <span class="cat-card-desc">计算每月电费</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fuel-calculator.html">
+          <span class="cat-card-icon">⛽</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汽车油耗计算器</span>
+            <span class="cat-card-desc">计算汽车油耗</span>
+          </span>
+        </a>
+        <a class="cat-card" href="percentage-calculator.html">
+          <span class="cat-card-icon">%</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">百分比计算</span>
+            <span class="cat-card-desc">百分比计算器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="date-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Date Calculator</span>
+            <span class="cat-card-desc">
+              Date Calculator，在线使用，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="discount-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Discount Calculator</span>
+            <span class="cat-card-desc">
+              Discount Calculator，在线使用，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="percentage-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Percentage Calc</span>
+            <span class="cat-card-desc">
+              Percentage Calc，在线使用，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="subnet-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Subnet Calculator</span>
+            <span class="cat-card-desc">
+              Subnet Calculator，在线使用，计算器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="vat-gst-calculator.html">
+          <span class="cat-card-icon">%</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">增值税 / GST 计算器</span>
+            <span class="cat-card-desc">
+              支持含税价格还原不含税价、不含税价格加税，覆盖中国增值税（6%/9%/13%）和全球 GST/VAT
+              税率。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="import-duty-estimator.html">
+          <span class="cat-card-icon">🛃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">进口关税估算器</span>
+            <span class="cat-card-desc">
+              根据商品分类（HS
+              编码简化版）、货值和目的国，估算进口关税、增值税和综合税率，并给出常见税率参考表。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ohms-law-calculator.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">欧姆定律 / 电路计算器</span>
+            <span class="cat-card-desc">
+              基于欧姆定律（V=IR）计算电压、电流、电阻、功率，支持串并联电阻、分压器、LED
+              限流电阻等常用电路计算。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="dew-point-humidity-calculator.html">
+          <span class="cat-card-icon">💧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">湿度 / 露点计算器</span>
+            <span class="cat-card-desc">
+              根据气温和相对湿度计算露点温度、绝对湿度、湿球温度，以及室内是否有结露风险。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="normal-distribution-calculator.html">
+          <span class="cat-card-icon">𝒩</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正态分布计算器</span>
+            <span class="cat-card-desc">
+              输入均值和标准差，计算任意区间的概率密度（PDF）和累积概率（CDF），绘制钟形曲线并可查
+              Z-score 对应分位点。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="hypothesis-testing-calculator.html">
+          <span class="cat-card-icon">🔬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">假设检验计算器</span>
+            <span class="cat-card-desc">
+              支持单样本/双样本 t 检验、卡方检验（χ²），输入样本数据后计算 t/χ² 统计量、p
+              值和检验结论。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="print-size-dpi-calculator.html">
+          <span class="cat-card-icon">🖨️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">打印尺寸 / DPI 计算器</span>
+            <span class="cat-card-desc">
+              根据图片像素尺寸和打印
+              DPI，计算实际打印尺寸（cm/inch），或反向根据目标打印尺寸确定所需最低分辨率。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="inflation-calculator.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">通货膨胀计算器</span>
+            <span class="cat-card-desc">
+              根据历史 CPI 数据计算货币购买力变化，输入某年的金额换算为今日等值，支持主要经济体。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="resistor-color-code.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电阻色环计算器</span>
+            <span class="cat-card-desc">
+              4/5/6 色环电阻阻值读取与反查，支持 E12/E24/E96 标称系列，含误差与温度系数色带说明。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="capacitor-code-decoder.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电容代码解码器</span>
+            <span class="cat-card-desc">
+              输入贴片/直插电容上的 3 位数字代码（如 104、472），即时换算为 pF/nF/μF，反向亦可。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="voltage-divider-calculator.html">
+          <span class="cat-card-icon">&amp;#x26A1;</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">分压电路计算器</span>
+            <span class="cat-card-desc">
+              输入电源电压与两个分压电阻值，实时输出中间节点电压及电流，支持反向求解 R 值。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="wire-gauge-awg-calculator.html">
+          <span class="cat-card-icon">&amp;#x26A1;</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">导线规格 / AWG 载流计算器</span>
+            <span class="cat-card-desc">
+              查询 AWG/mm² 导线截面积、最大安全电流（安培容量）、直流电阻，适用于 DIY 电气布线选型。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="battery-runtime-calculator.html">
+          <span class="cat-card-icon">🔋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电池续航估算器</span>
+            <span class="cat-card-desc">
+              输入电池容量（mAh）和设备平均电流（mA），估算续航时间；支持效率系数与多节串并联。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="molar-mass-calculator.html">
+          <span class="cat-card-icon">⚗️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">摩尔质量计算器</span>
+            <span class="cat-card-desc">
+              输入化学式（如 H₂SO₄、C₆H₁₂O₆），即时解析并计算摩尔质量，显示各元素质量占比。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ph-scale-calculator.html">
+          <span class="cat-card-icon">⚗️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">pH 值计算器</span>
+            <span class="cat-card-desc">
+              由氢离子浓度（[H⁺]）或 pOH 互算 pH，含 pH 刻度可视化、酸碱判定与常见溶液参考表。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/chinese/index.html
+++ b/tools/chinese/index.html
@@ -1,0 +1,389 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>中文工具 - 在线工具合集（15个）| WebUtils</title>
+    <meta
+      name="description"
+      content="专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。"
+    />
+    <meta name="keywords" content="中文工具,在线工具,免费工具,中文工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/chinese/index.html" />
+    <meta property="og:title" content="中文工具 - 在线工具合集（15个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/chinese/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="中文工具 - 在线工具合集（15个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "中文工具",
+            "item": "https://tools.realtime-ai.chat/tools/chinese/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "中文工具 - 在线工具合集（15个）| WebUtils",
+        "description": "专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。",
+        "url": "https://tools.realtime-ai.chat/tools/chinese/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 15,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "身份证号码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/idcard-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "身份证号码验证器",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/idcard-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "统一社会信用代码验证器",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/uscc-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "车牌号归属地查询",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/license-plate.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "农历阳历转换",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/lunar-calendar.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "生肖查询工具",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/chinese-zodiac.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "银行卡BIN查询",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/bank-card-bin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "手机号归属地查询",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/phone-attribution.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "中文大写数字转换",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/chinese-number.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "成语词典",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/idiom-dictionary.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "古诗词查询",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/ancient-poetry.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "汉字笔画顺序",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/stroke-order.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "拼音声调标注",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/pinyin-tone.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "汉字偏旁部首查询",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/radicals.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "对联生成器",
+              "url": "https://tools.realtime-ai.chat/tools/chinese/couplet-generator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">中</div>
+        <h1>中文工具</h1>
+        <p class="cat-intro">
+          专为中文场景设计的在线工具，涵盖简繁转换、拼音、字数统计、汉字查询等。
+        </p>
+        <p class="cat-meta">15 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="idcard-generator.html">
+          <span class="cat-card-icon">🆔</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">身份证号码生成器</span>
+            <span class="cat-card-desc">生成测试用身份证号码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="idcard-validator.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">身份证号码验证器</span>
+            <span class="cat-card-desc">验证和解析身份证号码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="uscc-validator.html">
+          <span class="cat-card-icon">🏢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">统一社会信用代码验证器</span>
+            <span class="cat-card-desc">验证企业统一社会信用代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="license-plate.html">
+          <span class="cat-card-icon">🚗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">车牌号归属地查询</span>
+            <span class="cat-card-desc">查询车牌号归属地</span>
+          </span>
+        </a>
+        <a class="cat-card" href="lunar-calendar.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">农历阳历转换</span>
+            <span class="cat-card-desc">农历阳历日期互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chinese-zodiac.html">
+          <span class="cat-card-icon">🐲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">生肖查询工具</span>
+            <span class="cat-card-desc">根据年份查询生肖</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bank-card-bin.html">
+          <span class="cat-card-icon">💳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">银行卡BIN查询</span>
+            <span class="cat-card-desc">查询银行卡发卡行信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="phone-attribution.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">手机号归属地查询</span>
+            <span class="cat-card-desc">查询手机号归属地</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chinese-number.html">
+          <span class="cat-card-icon">壹</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">中文大写数字转换</span>
+            <span class="cat-card-desc">数字转中文大写金额</span>
+          </span>
+        </a>
+        <a class="cat-card" href="idiom-dictionary.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">成语词典</span>
+            <span class="cat-card-desc">查询成语释义和用法</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ancient-poetry.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">古诗词查询</span>
+            <span class="cat-card-desc">古典诗词查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="stroke-order.html">
+          <span class="cat-card-icon">✍️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汉字笔画顺序</span>
+            <span class="cat-card-desc">查询汉字笔画顺序</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pinyin-tone.html">
+          <span class="cat-card-icon">pīn</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">拼音声调标注</span>
+            <span class="cat-card-desc">为汉字添加拼音注音</span>
+          </span>
+        </a>
+        <a class="cat-card" href="radicals.html">
+          <span class="cat-card-icon">⺀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汉字偏旁部首查询</span>
+            <span class="cat-card-desc">查询汉字偏旁部首</span>
+          </span>
+        </a>
+        <a class="cat-card" href="couplet-generator.html">
+          <span class="cat-card-icon">🧧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">对联生成器</span>
+            <span class="cat-card-desc">生成传统对联</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/converter/index.html
+++ b/tools/converter/index.html
@@ -1,0 +1,729 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>转换器 - 在线工具合集（38个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。"
+    />
+    <meta name="keywords" content="转换器,在线工具,免费工具,转换器大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/converter/index.html" />
+    <meta property="og:title" content="转换器 - 在线工具合集（38个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/converter/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="转换器 - 在线工具合集（38个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "转换器",
+            "item": "https://tools.realtime-ai.chat/tools/converter/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "转换器 - 在线工具合集（38个）| WebUtils",
+        "description": "在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。",
+        "url": "https://tools.realtime-ai.chat/tools/converter/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 38,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "角度单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/angle-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "CSV ⇄ JSON 转换",
+              "url": "https://tools.realtime-ai.chat/tools/converter/csv-json.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "cURL to Code",
+              "url": "https://tools.realtime-ai.chat/tools/converter/curl-to-code.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "数据存储单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/data-size-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "数据大小转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/data-size.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Data URL 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/data-url-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "文件大小计算器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/file-size.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "HTML 转 Markdown",
+              "url": "https://tools.realtime-ai.chat/tools/converter/html-to-markdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "JSON ⇄ YAML 转换",
+              "url": "https://tools.realtime-ai.chat/tools/converter/json-yaml.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "数字转大写",
+              "url": "https://tools.realtime-ai.chat/tools/converter/number-words.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "压力单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/pressure-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/unit-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "面积单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/area.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "长度单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/length.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "任意进制转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/number-base.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "速度单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/speed.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "温度转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/temperature.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "时间单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/time.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "体积容量转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/volume.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "重量单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/weight.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "二进制翻译器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/binary-translator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "数字进制转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/number-base-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "颜色格式转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/color-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Unix 时间戳转换器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/unix-timestamp.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "温度转换",
+              "url": "https://tools.realtime-ai.chat/tools/converter/temperature-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "速度转换",
+              "url": "https://tools.realtime-ai.chat/tools/converter/speed-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "Area Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/area-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "Currency Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/currency-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Data Storage Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/data-storage-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "Energy Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/energy-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "Frequency Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/frequency-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "Length Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/length-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "Power Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/power-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "Time Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/time-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "Volume Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/volume-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "Weight Converter",
+              "url": "https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "国际电话号码格式化器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/phone-number-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "盲文翻译器",
+              "url": "https://tools.realtime-ai.chat/tools/converter/braille-translator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🔄</div>
+        <h1>转换器</h1>
+        <p class="cat-intro">
+          在线格式与单位转换工具，支持文档、数据、编码、度量单位之间的互转，快速搞定格式不兼容问题。
+        </p>
+        <p class="cat-meta">38 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="angle-converter.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">角度单位转换器</span>
+            <span class="cat-card-desc">度、弧度、梯度等角度单位互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="csv-json.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSV ⇄ JSON 转换</span>
+            <span class="cat-card-desc">CSV 和 JSON 双向转换，支持表格预览</span>
+          </span>
+        </a>
+        <a class="cat-card" href="curl-to-code.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">cURL to Code</span>
+            <span class="cat-card-desc">将 cURL 命令转换为多种编程语言代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-size-converter.html">
+          <span class="cat-card-icon">💾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据存储单位转换器</span>
+            <span class="cat-card-desc">Bit、Byte、KB、MB、GB 等单位互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-size.html">
+          <span class="cat-card-icon">💾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据大小转换器</span>
+            <span class="cat-card-desc">数据存储单位之间的转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-url-converter.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data URL 转换器</span>
+            <span class="cat-card-desc">文件与 Data URL/Base64 互转，支持多种输出格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="file-size.html">
+          <span class="cat-card-icon">📁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文件大小计算器</span>
+            <span class="cat-card-desc">文件大小单位转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-to-markdown.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 转 Markdown</span>
+            <span class="cat-card-desc">将 HTML 代码转换为 Markdown 格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-yaml.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON ⇄ YAML 转换</span>
+            <span class="cat-card-desc">JSON 和 YAML 双向转换，支持格式化和压缩</span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-words.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数字转大写</span>
+            <span class="cat-card-desc">数字转大写，在线使用，转换器，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pressure-converter.html">
+          <span class="cat-card-icon">🌡️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">压力单位转换器</span>
+            <span class="cat-card-desc">帕斯卡、巴、大气压、PSI 等压力单位互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-converter.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">单位转换器</span>
+            <span class="cat-card-desc">长度、重量、温度、面积等多种单位换算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="area.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">面积单位转换器</span>
+            <span class="cat-card-desc">
+              面积单位转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="length.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">长度单位转换器</span>
+            <span class="cat-card-desc">
+              长度单位转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-base.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">任意进制转换器</span>
+            <span class="cat-card-desc">
+              任意进制转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="speed.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">速度单位转换器</span>
+            <span class="cat-card-desc">
+              速度单位转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="temperature.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">温度转换器</span>
+            <span class="cat-card-desc">
+              温度转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="time.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">时间单位转换器</span>
+            <span class="cat-card-desc">
+              时间单位转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="volume.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">体积容量转换器</span>
+            <span class="cat-card-desc">
+              体积容量转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="weight.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">重量单位转换器</span>
+            <span class="cat-card-desc">
+              重量单位转换器，多格式互转，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="binary-translator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">二进制翻译器</span>
+            <span class="cat-card-desc">文本与二进制、十进制、十六进制、八进制互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-base-converter.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数字进制转换器</span>
+            <span class="cat-card-desc">数字进制转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-converter.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色格式转换器</span>
+            <span class="cat-card-desc">颜色格式转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unix-timestamp.html">
+          <span class="cat-card-icon">🕐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unix 时间戳转换器</span>
+            <span class="cat-card-desc">Unix时间戳转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="temperature-converter.html">
+          <span class="cat-card-icon">🌡️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">温度转换</span>
+            <span class="cat-card-desc">温度单位转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="speed-converter.html">
+          <span class="cat-card-icon">🏎️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">速度转换</span>
+            <span class="cat-card-desc">速度单位转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="area-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Area Converter</span>
+            <span class="cat-card-desc">
+              Area Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="currency-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Currency Converter</span>
+            <span class="cat-card-desc">
+              Currency Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-storage-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Storage Converter</span>
+            <span class="cat-card-desc">
+              Data Storage Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="energy-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Energy Converter</span>
+            <span class="cat-card-desc">
+              Energy Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="frequency-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Frequency Converter</span>
+            <span class="cat-card-desc">
+              Frequency Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="length-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Length Converter</span>
+            <span class="cat-card-desc">
+              Length Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="power-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Power Converter</span>
+            <span class="cat-card-desc">
+              Power Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="time-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Time Converter</span>
+            <span class="cat-card-desc">
+              Time Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="volume-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Volume Converter</span>
+            <span class="cat-card-desc">
+              Volume Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="weight-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Weight Converter</span>
+            <span class="cat-card-desc">
+              Weight Converter，在线使用，转换器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="phone-number-formatter.html">
+          <span class="cat-card-icon">📞</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">国际电话号码格式化器</span>
+            <span class="cat-card-desc">
+              输入任意格式的电话号码，自动识别国家并转换为 E.164、国际格式、本地格式，支持批量处理。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="braille-translator.html">
+          <span class="cat-card-icon">⠿</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">盲文翻译器</span>
+            <span class="cat-card-desc">
+              将英文文本转换为盲文点字符号（Unicode
+              Braille），或将盲文符号反向翻译为英文，支持一级和二级盲文。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/crypto/index.html
+++ b/tools/crypto/index.html
@@ -1,0 +1,389 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>加密货币 - 在线工具合集（15个）| WebUtils</title>
+    <meta
+      name="description"
+      content="加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。"
+    />
+    <meta name="keywords" content="加密货币,在线工具,免费工具,加密货币大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/crypto/index.html" />
+    <meta property="og:title" content="加密货币 - 在线工具合集（15个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/crypto/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="加密货币 - 在线工具合集（15个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "加密货币",
+            "item": "https://tools.realtime-ai.chat/tools/crypto/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "加密货币 - 在线工具合集（15个）| WebUtils",
+        "description": "加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。",
+        "url": "https://tools.realtime-ai.chat/tools/crypto/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 15,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "持仓盈亏计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/profit-loss.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "定投收益计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/dca.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "杠杆计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/leverage.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "爆仓价格计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/liquidation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "无常损失计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/impermanent-loss.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "APY/APR计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/apy-apr.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Gas费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/gas-fee.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "复利收益计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/compound.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "挖矿收益计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/mining.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "交易手续费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/trading-fee.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "仓位管理计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/position-size.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "网格交易计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/grid-trading.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "加密货币单位换算",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/unit-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "钱包地址校验",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/address-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "ICO/IDO收益计算器",
+              "url": "https://tools.realtime-ai.chat/tools/crypto/ico-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">₿</div>
+        <h1>加密货币</h1>
+        <p class="cat-intro">
+          加密货币相关的在线工具，包括价格换算、收益计算、地址校验、Gas 费参考等。
+        </p>
+        <p class="cat-meta">15 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="profit-loss.html">
+          <span class="cat-card-icon">💹</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">持仓盈亏计算器</span>
+            <span class="cat-card-desc">计算加密货币持仓盈亏</span>
+          </span>
+        </a>
+        <a class="cat-card" href="dca.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">定投收益计算器</span>
+            <span class="cat-card-desc">计算定投策略收益</span>
+          </span>
+        </a>
+        <a class="cat-card" href="leverage.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">杠杆计算器</span>
+            <span class="cat-card-desc">计算杠杆交易收益和风险</span>
+          </span>
+        </a>
+        <a class="cat-card" href="liquidation.html">
+          <span class="cat-card-icon">💥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">爆仓价格计算器</span>
+            <span class="cat-card-desc">计算合约爆仓价格</span>
+          </span>
+        </a>
+        <a class="cat-card" href="impermanent-loss.html">
+          <span class="cat-card-icon">📉</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">无常损失计算器</span>
+            <span class="cat-card-desc">计算流动性提供者的无常损失</span>
+          </span>
+        </a>
+        <a class="cat-card" href="apy-apr.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">APY/APR计算器</span>
+            <span class="cat-card-desc">计算和转换年化收益率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gas-fee.html">
+          <span class="cat-card-icon">⛽</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gas费计算器</span>
+            <span class="cat-card-desc">估算以太坊交易Gas费用</span>
+          </span>
+        </a>
+        <a class="cat-card" href="compound.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">复利收益计算器</span>
+            <span class="cat-card-desc">计算加密货币复利收益</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mining.html">
+          <span class="cat-card-icon">⛏️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">挖矿收益计算器</span>
+            <span class="cat-card-desc">计算加密货币挖矿收益</span>
+          </span>
+        </a>
+        <a class="cat-card" href="trading-fee.html">
+          <span class="cat-card-icon">💸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">交易手续费计算器</span>
+            <span class="cat-card-desc">计算交易手续费成本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="position-size.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">仓位管理计算器</span>
+            <span class="cat-card-desc">计算合理仓位大小</span>
+          </span>
+        </a>
+        <a class="cat-card" href="grid-trading.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">网格交易计算器</span>
+            <span class="cat-card-desc">设计网格交易参数</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-converter.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">加密货币单位换算</span>
+            <span class="cat-card-desc">加密货币单位互相转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="address-validator.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">钱包地址校验</span>
+            <span class="cat-card-desc">校验加密货币钱包地址格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ico-calculator.html">
+          <span class="cat-card-icon">🚀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ICO/IDO收益计算器</span>
+            <span class="cat-card-desc">计算ICO/IDO投资收益</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/data/index.html
+++ b/tools/data/index.html
@@ -1,0 +1,630 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>数据工具 - 在线工具合集（30个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。"
+    />
+    <meta name="keywords" content="数据工具,在线工具,免费工具,数据工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/data/index.html" />
+    <meta property="og:title" content="数据工具 - 在线工具合集（30个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="数据工具 - 在线工具合集（30个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "数据工具 - 在线工具合集（30个）| WebUtils",
+        "description": "在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。",
+        "url": "https://tools.realtime-ai.chat/tools/data/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 30,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Bar Chart",
+              "url": "https://tools.realtime-ai.chat/tools/data/bar-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Chart Maker",
+              "url": "https://tools.realtime-ai.chat/tools/data/chart-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Correlation Analyzer",
+              "url": "https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "Csv Viewer",
+              "url": "https://tools.realtime-ai.chat/tools/data/csv-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "Data Aggregator",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-aggregator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Data Cleaner",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-cleaner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Data Diff",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-diff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "Data Exporter",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-exporter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "数据筛选器",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-filter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "Data Importer",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-importer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "数据合并器",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-merger.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Data Normalizer",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-normalizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "数据采样器",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-sampler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Data Sorter",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-sorter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "数据转换器",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-transformer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "数据验证器",
+              "url": "https://tools.realtime-ai.chat/tools/data/data-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "Duplicate Remover",
+              "url": "https://tools.realtime-ai.chat/tools/data/duplicate-remover.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "Excel To Json",
+              "url": "https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Heatmap Generator",
+              "url": "https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "直方图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Json Flattener",
+              "url": "https://tools.realtime-ai.chat/tools/data/json-flattener.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "JSON 转 CSV",
+              "url": "https://tools.realtime-ai.chat/tools/data/json-to-csv.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "Json Unflatten",
+              "url": "https://tools.realtime-ai.chat/tools/data/json-unflatten.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Line Chart",
+              "url": "https://tools.realtime-ai.chat/tools/data/line-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "异常值检测器",
+              "url": "https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "Pie Chart",
+              "url": "https://tools.realtime-ai.chat/tools/data/pie-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "Pivot Table",
+              "url": "https://tools.realtime-ai.chat/tools/data/pivot-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "Scatter Plot",
+              "url": "https://tools.realtime-ai.chat/tools/data/scatter-plot.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Sql Query Builder",
+              "url": "https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "统计计算器(数据分析)",
+              "url": "https://tools.realtime-ai.chat/tools/data/statistics-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📊</div>
+        <h1>数据工具</h1>
+        <p class="cat-intro">
+          在线数据处理工具，支持表格、CSV/JSON 转换、清洗、统计、可视化等数据加工需求。
+        </p>
+        <p class="cat-meta">30 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="bar-chart.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Bar Chart</span>
+            <span class="cat-card-desc">Bar Chart，在线使用，数据工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chart-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Chart Maker</span>
+            <span class="cat-card-desc">
+              Chart Maker，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="correlation-analyzer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Correlation Analyzer</span>
+            <span class="cat-card-desc">
+              Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="csv-viewer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Csv Viewer</span>
+            <span class="cat-card-desc">
+              Csv Viewer，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-aggregator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Aggregator</span>
+            <span class="cat-card-desc">
+              Data Aggregator，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-cleaner.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Cleaner</span>
+            <span class="cat-card-desc">
+              Data Cleaner，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-diff.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Diff</span>
+            <span class="cat-card-desc">Data Diff，在线使用，数据工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-exporter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Exporter</span>
+            <span class="cat-card-desc">
+              Data Exporter，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-filter.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据筛选器</span>
+            <span class="cat-card-desc">
+              强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-importer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Importer</span>
+            <span class="cat-card-desc">
+              Data Importer，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-merger.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据合并器</span>
+            <span class="cat-card-desc">合并多个数据集，支持追加、交错、去重、CSV列合并模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-normalizer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Normalizer</span>
+            <span class="cat-card-desc">
+              Data Normalizer，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-sampler.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据采样器</span>
+            <span class="cat-card-desc">从数据集中采样，支持随机、前N条、后N条、每N条等模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-sorter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Data Sorter</span>
+            <span class="cat-card-desc">
+              Data Sorter，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-transformer.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据转换器</span>
+            <span class="cat-card-desc">
+              批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="data-validator.html">
+          <span class="cat-card-icon">✓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据验证器</span>
+            <span class="cat-card-desc">
+              验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="duplicate-remover.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Duplicate Remover</span>
+            <span class="cat-card-desc">
+              Duplicate Remover，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="excel-to-json.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Excel To Json</span>
+            <span class="cat-card-desc">
+              Excel To Json，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="heatmap-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Heatmap Generator</span>
+            <span class="cat-card-desc">
+              Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="histogram-generator.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">直方图生成器</span>
+            <span class="cat-card-desc">创建数据分布直方图，支持统计分析和PNG导出</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-flattener.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Json Flattener</span>
+            <span class="cat-card-desc">
+              Json Flattener，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-to-csv.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 转 CSV</span>
+            <span class="cat-card-desc">JSON 数组转 CSV 格式，支持嵌套展平、自定义分隔符</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-unflatten.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Json Unflatten</span>
+            <span class="cat-card-desc">
+              Json Unflatten，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="line-chart.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Line Chart</span>
+            <span class="cat-card-desc">
+              Line Chart，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="outlier-detector.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">异常值检测器</span>
+            <span class="cat-card-desc">
+              检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pie-chart.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Pie Chart</span>
+            <span class="cat-card-desc">Pie Chart，在线使用，数据工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pivot-table.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Pivot Table</span>
+            <span class="cat-card-desc">
+              Pivot Table，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="scatter-plot.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Scatter Plot</span>
+            <span class="cat-card-desc">
+              Scatter Plot，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-query-builder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Sql Query Builder</span>
+            <span class="cat-card-desc">
+              Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="statistics-calculator.html">
+          <span class="cat-card-icon">Σ</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">统计计算器(数据分析)</span>
+            <span class="cat-card-desc">
+              计算数据的统计指标：均值、中位数、众数、方差、标准差、百分位数等
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/design/index.html
+++ b/tools/design/index.html
@@ -1,0 +1,832 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>设计工具 - 在线工具合集（47个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。"
+    />
+    <meta name="keywords" content="设计工具,在线工具,免费工具,设计工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/design/index.html" />
+    <meta property="og:title" content="设计工具 - 在线工具合集（47个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/design/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="设计工具 - 在线工具合集（47个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "设计工具",
+            "item": "https://tools.realtime-ai.chat/tools/design/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "设计工具 - 在线工具合集（47个）| WebUtils",
+        "description": "面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。",
+        "url": "https://tools.realtime-ai.chat/tools/design/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 47,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "色轮配色",
+              "url": "https://tools.realtime-ai.chat/tools/art/color-wheel.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "颜色选择器(设计版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "渐变生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/gradient-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "阴影生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/box-shadow-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "调色板生成器(设计版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-palette.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "对比度检查器",
+              "url": "https://tools.realtime-ai.chat/tools/design/contrast-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "CSS Grid 生成器(布局版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-grid-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "Flexbox 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/flexbox-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "圆角生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/border-radius-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "CSS 滤镜生成器(设计版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-filter-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "CSS 动画生成器(简版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/animation-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "文字阴影生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/text-shadow-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "颜色格式转换",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "色盲模拟器(设计师版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-blindness-simulator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "字体配对工具",
+              "url": "https://tools.realtime-ai.chat/tools/design/font-pair-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "间距计算器",
+              "url": "https://tools.realtime-ai.chat/tools/design/spacing-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "毛玻璃生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/glassmorphism-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "新拟态生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/neumorphism-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "裁剪路径生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/clip-path-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "CSS 变换生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/transform-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "CSS 过渡生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/transition-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "光标样式生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/cursor-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "滚动条生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/scrollbar-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "CSS 三角形生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/triangle-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "Blob 形状生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/blob-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "波浪 SVG 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/wave-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "图案背景生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/pattern-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "加载动画生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/loader-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "按钮样式生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/button-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "卡片样式生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/card-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "文字渐变生成器",
+              "url": "https://tools.realtime-ai.chat/tools/design/text-gradient-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "Aspect Ratio Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/design/aspect-ratio-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "Color Contrast Checker",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-contrast-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "Css Animation Generator",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-animation-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "Css Button Generator",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-button-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "Css Clip Path Generator",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-clip-path-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "Css Transform Generator",
+              "url": "https://tools.realtime-ai.chat/tools/design/css-transform-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "Font Preview",
+              "url": "https://tools.realtime-ai.chat/tools/design/font-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "Palette Generator",
+              "url": "https://tools.realtime-ai.chat/tools/design/palette-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "Svg Path Editor",
+              "url": "https://tools.realtime-ai.chat/tools/design/svg-path-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "配色方案生成器(设计版)",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-palette-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "颜色混合器(美术调色)",
+              "url": "https://tools.realtime-ai.chat/tools/art/color-mixer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "颜色名称查询器",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-name-finder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "色温转换器",
+              "url": "https://tools.realtime-ai.chat/tools/design/color-temperature.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "OKLCH / Display P3 颜色编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/design/oklch-color-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "设备屏幕分辨率参考",
+              "url": "https://tools.realtime-ai.chat/tools/design/screen-resolution-reference.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "文字转 SVG 路径",
+              "url": "https://tools.realtime-ai.chat/tools/design/text-to-svg-path.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🎨</div>
+        <h1>设计工具</h1>
+        <p class="cat-intro">
+          面向设计师的在线工具，涵盖配色、渐变、阴影、字体、尺寸、图标等视觉设计需求。
+        </p>
+        <p class="cat-meta">47 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="../art/color-wheel.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">色轮配色</span>
+            <span class="cat-card-desc">交互式色轮和配色方案生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-picker.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色选择器(设计版)</span>
+            <span class="cat-card-desc">可视化颜色选择工具，支持 HEX、RGB、HSL 等格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gradient-generator.html">
+          <span class="cat-card-icon">🌈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">渐变生成器</span>
+            <span class="cat-card-desc">CSS 线性/径向渐变代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="box-shadow-generator.html">
+          <span class="cat-card-icon">🌑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阴影生成器</span>
+            <span class="cat-card-desc">CSS box-shadow 阴影效果可视化编辑器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-palette.html">
+          <span class="cat-card-icon">🎭</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">调色板生成器(设计版)</span>
+            <span class="cat-card-desc">生成和谐配色方案，支持多种色彩理论</span>
+          </span>
+        </a>
+        <a class="cat-card" href="contrast-checker.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">对比度检查器</span>
+            <span class="cat-card-desc">检查文本与背景颜色的 WCAG 对比度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-grid-generator.html">
+          <span class="cat-card-icon">⊞</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Grid 生成器(布局版)</span>
+            <span class="cat-card-desc">可视化 CSS Grid 布局代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="flexbox-generator.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Flexbox 生成器</span>
+            <span class="cat-card-desc">可视化 Flexbox 布局代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="border-radius-generator.html">
+          <span class="cat-card-icon">⬜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">圆角生成器</span>
+            <span class="cat-card-desc">CSS border-radius 圆角效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-filter-generator.html">
+          <span class="cat-card-icon">🔮</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 滤镜生成器(设计版)</span>
+            <span class="cat-card-desc">CSS filter 滤镜效果可视化编辑器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="animation-generator.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 动画生成器(简版)</span>
+            <span class="cat-card-desc">CSS @keyframes 动画代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-shadow-generator.html">
+          <span class="cat-card-icon">💬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字阴影生成器</span>
+            <span class="cat-card-desc">CSS text-shadow 文字阴影效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-converter.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色格式转换</span>
+            <span class="cat-card-desc">HEX、RGB、HSL、CMYK 颜色格式互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-blindness-simulator.html">
+          <span class="cat-card-icon">👁️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">色盲模拟器(设计师版)</span>
+            <span class="cat-card-desc">模拟不同类型色盲视觉效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="font-pair-generator.html">
+          <span class="cat-card-icon">🔤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字体配对工具</span>
+            <span class="cat-card-desc">推荐和谐的字体搭配组合</span>
+          </span>
+        </a>
+        <a class="cat-card" href="spacing-calculator.html">
+          <span class="cat-card-icon">📏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">间距计算器</span>
+            <span class="cat-card-desc">基于比例的间距系统计算器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="glassmorphism-generator.html">
+          <span class="cat-card-icon">🪟</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">毛玻璃生成器</span>
+            <span class="cat-card-desc">CSS 毛玻璃效果代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="neumorphism-generator.html">
+          <span class="cat-card-icon">🔘</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">新拟态生成器</span>
+            <span class="cat-card-desc">CSS 新拟态风格效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="clip-path-generator.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">裁剪路径生成器</span>
+            <span class="cat-card-desc">CSS clip-path 裁剪效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="transform-generator.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 变换生成器</span>
+            <span class="cat-card-desc">CSS transform 变换效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="transition-generator.html">
+          <span class="cat-card-icon">➡️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 过渡生成器</span>
+            <span class="cat-card-desc">CSS transition 过渡效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cursor-generator.html">
+          <span class="cat-card-icon">🖱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">光标样式生成器</span>
+            <span class="cat-card-desc">自定义鼠标光标样式生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="scrollbar-generator.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">滚动条生成器</span>
+            <span class="cat-card-desc">自定义滚动条样式代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="triangle-generator.html">
+          <span class="cat-card-icon">🔺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 三角形生成器</span>
+            <span class="cat-card-desc">纯 CSS 三角形代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="blob-generator.html">
+          <span class="cat-card-icon">🫧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Blob 形状生成器</span>
+            <span class="cat-card-desc">SVG/CSS 有机 blob 形状生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="wave-generator.html">
+          <span class="cat-card-icon">🌊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">波浪 SVG 生成器</span>
+            <span class="cat-card-desc">SVG 波浪背景图案生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pattern-generator.html">
+          <span class="cat-card-icon">🔲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图案背景生成器</span>
+            <span class="cat-card-desc">CSS/SVG 图案背景生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="loader-generator.html">
+          <span class="cat-card-icon">⏳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">加载动画生成器</span>
+            <span class="cat-card-desc">CSS 加载动画/Spinner 代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="button-generator.html">
+          <span class="cat-card-icon">🔵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">按钮样式生成器</span>
+            <span class="cat-card-desc">CSS 按钮样式代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="card-generator.html">
+          <span class="cat-card-icon">🃏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">卡片样式生成器</span>
+            <span class="cat-card-desc">CSS 卡片组件样式生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-gradient-generator.html">
+          <span class="cat-card-icon">🔠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字渐变生成器</span>
+            <span class="cat-card-desc">CSS 文字渐变效果生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="aspect-ratio-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Aspect Ratio Calculator</span>
+            <span class="cat-card-desc">
+              Aspect Ratio Calculator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-contrast-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Color Contrast Checker</span>
+            <span class="cat-card-desc">
+              Color Contrast Checker，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-animation-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Animation Generator</span>
+            <span class="cat-card-desc">
+              Css Animation Generator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-button-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Button Generator</span>
+            <span class="cat-card-desc">
+              Css Button Generator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-clip-path-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Clip Path Generator</span>
+            <span class="cat-card-desc">
+              Css Clip Path Generator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-transform-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Transform Generator</span>
+            <span class="cat-card-desc">
+              Css Transform Generator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="font-preview.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Font Preview</span>
+            <span class="cat-card-desc">
+              Font Preview，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="palette-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Palette Generator</span>
+            <span class="cat-card-desc">
+              Palette Generator，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-path-editor.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Svg Path Editor</span>
+            <span class="cat-card-desc">
+              Svg Path Editor，在线使用，设计工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-palette-generator.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">配色方案生成器(设计版)</span>
+            <span class="cat-card-desc">生成协调的配色方案，支持多种配色规则</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../art/color-mixer.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色混合器(美术调色)</span>
+            <span class="cat-card-desc">混合两种颜色，实时查看混合结果，支持RGB和HSL模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-name-finder.html">
+          <span class="cat-card-icon">🏷️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色名称查询器</span>
+            <span class="cat-card-desc">按颜色查名称、按名称查颜色，匹配最接近的 CSS 命名色</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-temperature.html">
+          <span class="cat-card-icon">🌡️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">色温转换器</span>
+            <span class="cat-card-desc">开尔文色温与 RGB 颜色互转，预览暖光冷光的真实色彩</span>
+          </span>
+        </a>
+        <a class="cat-card" href="oklch-color-editor.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">OKLCH / Display P3 颜色编辑器</span>
+            <span class="cat-card-desc">
+              以感知均匀的 OKLCH 颜色空间调色，实时预览 Display P3 宽色域色彩，并输出 CSS oklch()
+              函数代码。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="screen-resolution-reference.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">设备屏幕分辨率参考</span>
+            <span class="cat-card-desc">
+              按设备类型（手机/平板/桌面）浏览主流设备的物理分辨率、逻辑分辨率（CSS 像素）、DPR
+              和视口尺寸，支持搜索过滤。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-to-svg-path.html">
+          <span class="cat-card-icon">✍️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字转 SVG 路径</span>
+            <span class="cat-card-desc">
+              将文本渲染为矢量 SVG 路径（使用系统字体或上传 TTF），输出可直接用于 Illustrator /
+              Cricut 的纯路径 SVG。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/dev/index.html
+++ b/tools/dev/index.html
@@ -1,0 +1,3099 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>开发工具 - 在线工具合集（205个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向程序员的在线开发工具集合，涵盖 JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。"
+    />
+    <meta name="keywords" content="开发工具,在线工具,免费工具,开发工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/dev/index.html" />
+    <meta property="og:title" content="开发工具 - 在线工具合集（205个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向程序员的在线开发工具集合，涵盖 JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/dev/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="开发工具 - 在线工具合集（205个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向程序员的在线开发工具集合，涵盖 JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "开发工具 - 在线工具合集（205个）| WebUtils",
+        "description": "面向程序员的在线开发工具集合，涵盖 JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。",
+        "url": "https://tools.realtime-ai.chat/tools/dev/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 205,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "缓动函数可视化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/easing-visualizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "API 响应模拟器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/api-mock.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "箭头符号生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/arrow-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "ASCII 艺术",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ascii-art.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "ASCII 码表",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ascii-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Base64 编解码",
+              "url": "https://tools.realtime-ai.chat/tools/dev/base64.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Basic Auth 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/basic-auth-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "Box Shadow 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/box-shadow.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "浏览器存储查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/browser-storage-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "CHANGELOG 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/changelog-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "字符集转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/charset-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Chmod 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/chmod-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "剪贴板查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/clipboard-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "代码对比工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/code-diff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "代码统计器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/code-stats.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "色盲模拟器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-blindness.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "颜色转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "颜色混合器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-mixer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "颜色命名查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-names.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "调色板生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-palette-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "配色方案生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/color-palette.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "颜色对比度检查器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/contrast-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "Cron 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/cron-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Cron 表达式解析器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/cron-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "Crontab 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/crontab-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "CSS 动画生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-animation-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "Border Radius 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-border-radius.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "CSS 盒子阴影生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-box-shadow.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "CSS Clip-path 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-clip-path.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "CSS Filter 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-filter-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "CSS 滤镜生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-filter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "CSS 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "CSS Grid 生成器 | 在线工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-grid-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "CSS Grid 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-grid.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "CSS 压缩/美化工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-minifier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "CSS 选择器测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-selector-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "CSS雪碧图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-sprites.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "CSS Text Shadow 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-text-shadow.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "CSS Transform 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-transform.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "CSS 单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-unit-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "Cubic Bezier 编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/cubic-bezier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "cURL 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/curl-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "Git Diff 查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/diff-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "Docker Compose 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/docker-compose-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "Docker Compose 生成器 | 在线工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/docker-compose-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "Dockerfile 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/dockerfile-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "editorconfig 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/editorconfig-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "Emoji 选择器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/emoji-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": ".env 文件编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/env-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "Excel 预览器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/excel-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "Favicon 检测器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/favicon-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": "Flexbox 可视化编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/flexbox-playground.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "Git 命令速查",
+              "url": "https://tools.realtime-ai.chat/tools/dev/git-cheatsheet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "GitHub Actions 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/github-actions-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 55,
+              "name": ".gitignore 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/gitignore-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 56,
+              "name": "Glassmorphism 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/glassmorphism.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 57,
+              "name": "Glob 模式测试",
+              "url": "https://tools.realtime-ai.chat/tools/dev/glob-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 58,
+              "name": "GraphQL 查询构建器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/graphql-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 59,
+              "name": "GraphQL Playground",
+              "url": "https://tools.realtime-ai.chat/tools/dev/graphql-playground.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 60,
+              "name": "Hash 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 61,
+              "name": "Hex 查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/hex-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 62,
+              "name": "HMAC 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/hmac-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 63,
+              "name": "htaccess转Nginx",
+              "url": "https://tools.realtime-ai.chat/tools/dev/htaccess-nginx.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 64,
+              "name": "HTML 实体参考",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-entities.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 65,
+              "name": "HTML 实体编解码",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-entity.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 66,
+              "name": "HTML 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 67,
+              "name": "HTML 压缩",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-minify.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 68,
+              "name": "HTML 实时预览",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 69,
+              "name": "HTML 表格生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-table-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 70,
+              "name": "HTML 模板生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-template.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 71,
+              "name": "HTML 转 JSX/React 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-to-jsx.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 72,
+              "name": "HTTP 状态码参考",
+              "url": "https://tools.realtime-ai.chat/tools/dev/http-status.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 73,
+              "name": "i18n Key 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/i18n-key-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 74,
+              "name": "IP 地址转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ip-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 75,
+              "name": "JavaScript AST查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-ast-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 76,
+              "name": "JavaScript 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 77,
+              "name": "JavaScript 代码压缩器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-minifier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 78,
+              "name": "JavaScript 压缩",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-minify.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 79,
+              "name": "JS代码混淆",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-obfuscator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 80,
+              "name": "JavaScript 在线运行",
+              "url": "https://tools.realtime-ai.chat/tools/dev/js-playground.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 81,
+              "name": "JSON Diff 对比",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-diff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 82,
+              "name": "JSON 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 83,
+              "name": "JSON 压缩和美化器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-minifier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 84,
+              "name": "JSON 压缩",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-minify.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 85,
+              "name": "JSON 路径编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-path-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 86,
+              "name": "JSON Schema 验证器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-schema-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 87,
+              "name": "JSON 转 Go Struct",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-to-go.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 88,
+              "name": "JSON 转 SQL",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-to-sql.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 89,
+              "name": "JSON 转 TypeScript",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-to-typescript.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 90,
+              "name": "JSON 树形查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-tree.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 91,
+              "name": "JSON → TypeScript 类型生成",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-typescript.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 92,
+              "name": "JSON-YAML 转换",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-yaml.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 93,
+              "name": "JSONPath 查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/jsonpath-query.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 94,
+              "name": "JSONPath 测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/jsonpath-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 95,
+              "name": "JWT 解码器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 96,
+              "name": "键盘测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/keyboard-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 97,
+              "name": "Keycode 查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/keycode.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 98,
+              "name": "License 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/license-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 99,
+              "name": "Markdown 转 HTML 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/markdown-to-html.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 100,
+              "name": "数学符号大全",
+              "url": "https://tools.realtime-ai.chat/tools/dev/math-symbols.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 101,
+              "name": "Viewport Meta 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/meta-viewport.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 102,
+              "name": "MIME 类型查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/mime-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 103,
+              "name": "Neumorphism 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/neumorphism.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 104,
+              "name": "Nginx 配置生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/nginx-config.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 105,
+              "name": "Nginx 配置生成器 | 在线工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/nginx-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 106,
+              "name": "OpenAPI/Swagger查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/openapi-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 107,
+              "name": "OTP 验证码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/otp-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 108,
+              "name": "package.json编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/package-json-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 109,
+              "name": "package.json 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/package-json-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 110,
+              "name": "Protobuf 解码器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/protobuf-decoder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 111,
+              "name": "Punycode 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/punycode.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 112,
+              "name": "README 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/readme-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 113,
+              "name": "README.md 实时预览器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/readme-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 114,
+              "name": "正则表达式速查",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-cheatsheet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 115,
+              "name": "正则可视化解释器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-explainer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 116,
+              "name": "正则表达式生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 117,
+              "name": "正则测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 118,
+              "name": "正则表达式可视化器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-visualizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 119,
+              "name": "响应式预览",
+              "url": "https://tools.realtime-ai.chat/tools/dev/responsive-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 120,
+              "name": "RSA 密钥对生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/rsa-keygen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 121,
+              "name": "Semver 比较器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/semver-compare.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 122,
+              "name": "快捷键速查表",
+              "url": "https://tools.realtime-ai.chat/tools/dev/shortcuts-cheatsheet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 123,
+              "name": "Slug 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/slug-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 124,
+              "name": "SQL 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sql-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 125,
+              "name": "SQL 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sql-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 126,
+              "name": "SQL在线执行器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sql-playground.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 127,
+              "name": "SQL 转 MongoDB 查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sql-to-mongo.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 128,
+              "name": "SSE测试客户端",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sse-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 129,
+              "name": "字符串拼接器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/string-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 130,
+              "name": "SVG优化器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/svg-optimizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 131,
+              "name": "SVG 路径编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/svg-path-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 132,
+              "name": "特殊符号大全",
+              "url": "https://tools.realtime-ai.chat/tools/dev/symbols-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 133,
+              "name": "表格线生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/table-border.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 134,
+              "name": "Tailwind CSS 配置生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/tailwind-config-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 135,
+              "name": "Tailwind CSS 查询器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/tailwind-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 136,
+              "name": "TOML/YAML/JSON 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/toml-yaml-json.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 137,
+              "name": "tsconfig编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/tsconfig-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 138,
+              "name": "Unicode 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/unicode-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 139,
+              "name": "Unicode 查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/unicode-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 140,
+              "name": "URL 编解码",
+              "url": "https://tools.realtime-ai.chat/tools/dev/url-codec.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 141,
+              "name": "URL 解析器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/url-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 142,
+              "name": "Webhook测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/webhook-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 143,
+              "name": "WebSocket测试客户端",
+              "url": "https://tools.realtime-ai.chat/tools/dev/websocket-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 144,
+              "name": "XML 格式化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/xml-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 145,
+              "name": "XML ⇄ JSON 转换",
+              "url": "https://tools.realtime-ai.chat/tools/dev/xml-json.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 146,
+              "name": "XPath 测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/xpath-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 147,
+              "name": "代码截图美化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/code-screenshot.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 148,
+              "name": "数据图表生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/chart-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 149,
+              "name": "CSS 渐变生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/gradient-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 150,
+              "name": "HTTP 请求测试",
+              "url": "https://tools.realtime-ai.chat/tools/dev/http-client.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 151,
+              "name": "JSON Schema 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-schema-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 152,
+              "name": "进制转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/number-base.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 153,
+              "name": "文本差异比较",
+              "url": "https://tools.realtime-ai.chat/tools/dev/diff-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 154,
+              "name": "键盘码查询",
+              "url": "https://tools.realtime-ai.chat/tools/dev/keyboard-codes.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 155,
+              "name": "URL编码",
+              "url": "https://tools.realtime-ai.chat/tools/dev/url-encoder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 156,
+              "name": "Markdown预览",
+              "url": "https://tools.realtime-ai.chat/tools/dev/markdown-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 157,
+              "name": "表格生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/table-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 158,
+              "name": "Api Tester",
+              "url": "https://tools.realtime-ai.chat/tools/dev/api-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 159,
+              "name": "Css Animation",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-animation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 160,
+              "name": "Css Flexbox",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-flexbox.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 161,
+              "name": "Css Gradient Generator",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-gradient-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 162,
+              "name": "Curl Builder",
+              "url": "https://tools.realtime-ai.chat/tools/dev/curl-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 163,
+              "name": "Docker Command Builder",
+              "url": "https://tools.realtime-ai.chat/tools/dev/docker-command-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 164,
+              "name": "Env Generator",
+              "url": "https://tools.realtime-ai.chat/tools/dev/env-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 165,
+              "name": "Git Command Builder",
+              "url": "https://tools.realtime-ai.chat/tools/dev/git-command-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 166,
+              "name": "Git Command Helper",
+              "url": "https://tools.realtime-ai.chat/tools/dev/git-command-helper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 167,
+              "name": "Htaccess 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/htaccess-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 168,
+              "name": "Html Entity Encoder",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-entity-encoder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 169,
+              "name": "Html Minifier",
+              "url": "https://tools.realtime-ai.chat/tools/dev/html-minifier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 170,
+              "name": "Http Status Codes",
+              "url": "https://tools.realtime-ai.chat/tools/dev/http-status-codes.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 171,
+              "name": "Json Path Finder",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-path-finder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 172,
+              "name": "Json Path Tester",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-path-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 173,
+              "name": "Lorem Ipsum 占位文本生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/lorem-ipsum.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 174,
+              "name": "Nginx Config Generator",
+              "url": "https://tools.realtime-ai.chat/tools/dev/nginx-config-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 175,
+              "name": "Npm Command Helper",
+              "url": "https://tools.realtime-ai.chat/tools/dev/npm-command-helper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 176,
+              "name": "Sql Keywords",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sql-keywords.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 177,
+              "name": "String Escape",
+              "url": "https://tools.realtime-ai.chat/tools/dev/string-escape.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 178,
+              "name": "Yaml Formatter",
+              "url": "https://tools.realtime-ai.chat/tools/dev/yaml-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 179,
+              "name": "CSS 选择器权重计算器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-specificity-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 180,
+              "name": "流体排版 / CSS clamp 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/fluid-typography-clamp-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 181,
+              "name": "CSS 媒体查询生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/media-query-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 182,
+              "name": "px / rem / em 单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/px-rem-em-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 183,
+              "name": "字型比例计算器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/type-scale-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 184,
+              "name": "CSS 容器查询生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-container-query-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 185,
+              "name": "CSS z-index 层叠上下文可视化",
+              "url": "https://tools.realtime-ai.chat/tools/dev/css-z-index-stacking-visualizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 186,
+              "name": "SVG Sprite 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/svg-sprite-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 187,
+              "name": "SVG 转 Data URI 编码器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/svg-to-data-uri.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 188,
+              "name": "SRI 哈希生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/sri-hash-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 189,
+              "name": "Regex 查找替换测试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/regex-find-replace-tester.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 190,
+              "name": "HAR 文件查看器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/har-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 191,
+              "name": "JSON Merge Patch 工具",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-merge-patch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 192,
+              "name": "NDJSON / JSONL 格式化器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ndjson-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 193,
+              "name": "INI / 配置文件编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ini-file-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 194,
+              "name": "Java .properties 文件编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/java-properties-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 195,
+              "name": "Nginx / Apache 访问日志分析器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/access-log-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 196,
+              "name": "SSH 密钥对生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/ssh-keygen-helper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 197,
+              "name": "PO / Gettext 翻译文件编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/po-file-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 198,
+              "name": "邮箱地址格式验证器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/email-address-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 199,
+              "name": "GeoJSON 查看器 / 编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/geojson-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 200,
+              "name": "ISBN 验证与解析",
+              "url": "https://tools.realtime-ai.chat/tools/dev/isbn-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 201,
+              "name": "CRC32 / Adler-32 校验计算器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/crc32-checksum-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 202,
+              "name": "Favicon 多尺寸 ICO 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/favicon-ico-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 203,
+              "name": "Markdown 语法检查器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/markdown-linter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 204,
+              "name": "JSON Schema → HTML 表单生成器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/json-schema-to-form.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 205,
+              "name": "CORS 请求调试器",
+              "url": "https://tools.realtime-ai.chat/tools/dev/cors-preflight-debugger.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">⚡</div>
+        <h1>开发工具</h1>
+        <p class="cat-intro">
+          面向程序员的在线开发工具集合，涵盖
+          JSON、Base64、正则、JWT、哈希、编码转换等高频需求。所有处理在浏览器本地完成，无需安装、不上传数据。
+        </p>
+        <p class="cat-meta">205 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="easing-visualizer.html">
+          <span class="cat-card-icon">〰️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">缓动函数可视化</span>
+            <span class="cat-card-desc">
+              35+ 缓动函数可视化预览，支持 CSS/JS/Anime.js/GSAP 多格式导出
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="api-mock.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">API 响应模拟器</span>
+            <span class="cat-card-desc">
+              API 响应模拟器，在线模拟，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="arrow-generator.html">
+          <span class="cat-card-icon">➡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">箭头符号生成器</span>
+            <span class="cat-card-desc">
+              箭头符号生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ascii-art.html">
+          <span class="cat-card-icon">▓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ASCII 艺术</span>
+            <span class="cat-card-desc">将文字转换为 ASCII 艺术字体</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ascii-table.html">
+          <span class="cat-card-icon">A</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ASCII 码表</span>
+            <span class="cat-card-desc">ASCII 码表速查</span>
+          </span>
+        </a>
+        <a class="cat-card" href="base64.html">
+          <span class="cat-card-icon">b64</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Base64 编解码</span>
+            <span class="cat-card-desc">Base64 编码与解码，支持文本和文件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="basic-auth-generator.html">
+          <span class="cat-card-icon">🔑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Basic Auth 生成器</span>
+            <span class="cat-card-desc">生成 HTTP Basic Authentication 头部</span>
+          </span>
+        </a>
+        <a class="cat-card" href="box-shadow.html">
+          <span class="cat-card-icon">◰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Box Shadow 生成器</span>
+            <span class="cat-card-desc">可视化创建 CSS box-shadow，支持多层阴影和预设样式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="browser-storage-viewer.html">
+          <span class="cat-card-icon">🗄️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">浏览器存储查看器</span>
+            <span class="cat-card-desc">
+              查看和管理浏览器 LocalStorage、SessionStorage 和 Cookies
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="changelog-gen.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CHANGELOG 生成器</span>
+            <span class="cat-card-desc">
+              CHANGELOG 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="charset-converter.html">
+          <span class="cat-card-icon">🔤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字符集转换器</span>
+            <span class="cat-card-desc">文本编码转换，支持 UTF-8/16、Hex、URL 编码等格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chmod-calculator.html">
+          <span class="cat-card-icon">🔓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Chmod 计算器</span>
+            <span class="cat-card-desc">Linux 文件权限计算，支持数字和符号模式互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="clipboard-viewer.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">剪贴板查看器</span>
+            <span class="cat-card-desc">查看剪贴板中的各种格式数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="code-diff.html">
+          <span class="cat-card-icon">⇔</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">代码对比工具</span>
+            <span class="cat-card-desc">并排对比两段代码的差异，高亮显示变更</span>
+          </span>
+        </a>
+        <a class="cat-card" href="code-stats.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">代码统计器</span>
+            <span class="cat-card-desc">
+              代码统计器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-blindness.html">
+          <span class="cat-card-icon">👁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">色盲模拟器</span>
+            <span class="cat-card-desc">模拟不同类型色盲用户看到的颜色效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-converter.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色转换器</span>
+            <span class="cat-card-desc">HEX、RGB、HSL 颜色格式互转，可视化调色</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-mixer.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色混合器</span>
+            <span class="cat-card-desc">两种颜色混合工具，支持多种混合模式和比例调节</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-names.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色命名查询</span>
+            <span class="cat-card-desc">
+              颜色命名查询，便捷查询，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-palette-generator.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">调色板生成器</span>
+            <span class="cat-card-desc">基于色彩理论生成和谐配色方案</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-palette.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">配色方案生成器</span>
+            <span class="cat-card-desc">生成配色方案和调色板</span>
+          </span>
+        </a>
+        <a class="cat-card" href="contrast-checker.html">
+          <span class="cat-card-icon">◐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色对比度检查器</span>
+            <span class="cat-card-desc">检查颜色对比度是否符合 WCAG 2.1 无障碍标准</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cron-generator.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cron 生成器</span>
+            <span class="cat-card-desc">可视化生成 Cron 表达式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cron-parser.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cron 表达式解析器</span>
+            <span class="cat-card-desc">
+              Cron 表达式解析器，在线分析，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="crontab-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Crontab 生成器</span>
+            <span class="cat-card-desc">
+              Crontab 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-animation-generator.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 动画生成器</span>
+            <span class="cat-card-desc">可视化生成 CSS 动画和关键帧代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-border-radius.html">
+          <span class="cat-card-icon">◜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Border Radius 生成器</span>
+            <span class="cat-card-desc">CSS 圆角可视化生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-box-shadow.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 盒子阴影生成器</span>
+            <span class="cat-card-desc">可视化生成 CSS box-shadow 阴影效果，支持多层阴影</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-clip-path.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Clip-path 生成器</span>
+            <span class="cat-card-desc">
+              CSS Clip-path 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-filter-generator.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Filter 生成器</span>
+            <span class="cat-card-desc">可视化调整 CSS filter 属性，支持预设效果和对比预览</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-filter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 滤镜生成器</span>
+            <span class="cat-card-desc">
+              CSS 滤镜生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-formatter.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 格式化</span>
+            <span class="cat-card-desc">CSS 代码格式化和压缩</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-grid-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Grid 生成器 | 在线工具</span>
+            <span class="cat-card-desc">
+              CSS Grid 生成器 | 在线工具，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-grid.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Grid 生成器</span>
+            <span class="cat-card-desc">
+              CSS Grid 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-minifier.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 压缩/美化工具</span>
+            <span class="cat-card-desc">
+              CSS 压缩/美化工具，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-selector-test.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 选择器测试器</span>
+            <span class="cat-card-desc">
+              CSS 选择器测试器，在线验证，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-sprites.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS雪碧图生成器</span>
+            <span class="cat-card-desc">合并图片生成雪碧图</span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-text-shadow.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Text Shadow 生成器</span>
+            <span class="cat-card-desc">
+              CSS Text Shadow 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-transform.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS Transform 生成器</span>
+            <span class="cat-card-desc">
+              CSS Transform 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-unit-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 单位转换器</span>
+            <span class="cat-card-desc">
+              CSS 单位转换器，多格式互转，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cubic-bezier.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cubic Bezier 编辑器</span>
+            <span class="cat-card-desc">
+              Cubic Bezier 编辑器，在线编辑，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="curl-converter.html">
+          <span class="cat-card-icon">↔️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">cURL 转换器</span>
+            <span class="cat-card-desc">将 cURL 命令转换为各种编程语言代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="diff-viewer.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Git Diff 查看器</span>
+            <span class="cat-card-desc">解析并美化显示 Git diff 输出，支持文件统计</span>
+          </span>
+        </a>
+        <a class="cat-card" href="docker-compose-gen.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Docker Compose 生成器</span>
+            <span class="cat-card-desc">
+              Docker Compose 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="docker-compose-generator.html">
+          <span class="cat-card-icon">🐳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Docker Compose 生成器 | 在线工具</span>
+            <span class="cat-card-desc">
+              Docker Compose 生成器 | 在线工具，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="dockerfile-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Dockerfile 生成器</span>
+            <span class="cat-card-desc">
+              Dockerfile 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="editorconfig-gen.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">editorconfig 生成器</span>
+            <span class="cat-card-desc">
+              editorconfig 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="emoji-picker.html">
+          <span class="cat-card-icon">😀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Emoji 选择器</span>
+            <span class="cat-card-desc">浏览和复制各种 Emoji 表情符号</span>
+          </span>
+        </a>
+        <a class="cat-card" href="env-editor.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">.env 文件编辑器</span>
+            <span class="cat-card-desc">
+              .env 文件编辑器，在线编辑，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="excel-viewer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Excel 预览器</span>
+            <span class="cat-card-desc">
+              Excel 预览器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="favicon-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Favicon 检测器</span>
+            <span class="cat-card-desc">
+              Favicon 检测器，在线分析，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="flexbox-playground.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Flexbox 可视化编辑器</span>
+            <span class="cat-card-desc">可视化调整 Flexbox 布局属性，实时预览效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="git-cheatsheet.html">
+          <span class="cat-card-icon">📚</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Git 命令速查</span>
+            <span class="cat-card-desc">常用 Git 命令速查表</span>
+          </span>
+        </a>
+        <a class="cat-card" href="github-actions-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GitHub Actions 生成器</span>
+            <span class="cat-card-desc">
+              GitHub Actions 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gitignore-generator.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">.gitignore 生成器</span>
+            <span class="cat-card-desc">选择编程语言和框架，快速生成 .gitignore 文件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="glassmorphism.html">
+          <span class="cat-card-icon">🪟</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Glassmorphism 生成器</span>
+            <span class="cat-card-desc">Glassmorphism 毛玻璃效果 CSS 代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="glob-tester.html">
+          <span class="cat-card-icon">*</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Glob 模式测试</span>
+            <span class="cat-card-desc">Glob 模式匹配测试</span>
+          </span>
+        </a>
+        <a class="cat-card" href="graphql-builder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GraphQL 查询构建器</span>
+            <span class="cat-card-desc">
+              GraphQL 查询构建器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="graphql-playground.html">
+          <span class="cat-card-icon">⬡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GraphQL Playground</span>
+            <span class="cat-card-desc">GraphQL查询测试工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="hash-generator.html">
+          <span class="cat-card-icon">#</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Hash 生成器</span>
+            <span class="cat-card-desc">计算文本或文件的 MD5、SHA-1、SHA-256、SHA-512 哈希值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="hex-viewer.html">
+          <span class="cat-card-icon">0x</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Hex 查看器</span>
+            <span class="cat-card-desc">以十六进制查看文件或文本内容</span>
+          </span>
+        </a>
+        <a class="cat-card" href="hmac-generator.html">
+          <span class="cat-card-icon">🔏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HMAC 生成器</span>
+            <span class="cat-card-desc">生成 HMAC 消息认证码，支持多种哈希算法</span>
+          </span>
+        </a>
+        <a class="cat-card" href="htaccess-nginx.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">htaccess转Nginx</span>
+            <span class="cat-card-desc">Apache htaccess转Nginx配置</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-entities.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 实体参考</span>
+            <span class="cat-card-desc">HTML 实体字符参考表，支持搜索和复制</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-entity.html">
+          <span class="cat-card-icon">&amp;amp;</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 实体编解码</span>
+            <span class="cat-card-desc">HTML 实体编码与解码，常用实体参考</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-formatter.html">
+          <span class="cat-card-icon">&lt;/&gt;</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 格式化</span>
+            <span class="cat-card-desc">HTML 代码格式化、压缩和美化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-minify.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 压缩</span>
+            <span class="cat-card-desc">压缩 HTML 代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-preview.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 实时预览</span>
+            <span class="cat-card-desc">
+              HTML 实时预览，即时预览，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-table-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 表格生成器</span>
+            <span class="cat-card-desc">
+              HTML 表格生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-template.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 模板生成器</span>
+            <span class="cat-card-desc">生成 HTML5 页面模板，支持多种布局和 CSS 框架</span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-to-jsx.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML 转 JSX/React 转换器</span>
+            <span class="cat-card-desc">
+              HTML 转 JSX/React 转换器，多格式互转，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="http-status.html">
+          <span class="cat-card-icon">200</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTTP 状态码参考</span>
+            <span class="cat-card-desc">HTTP 状态码速查，包含描述和使用场景</span>
+          </span>
+        </a>
+        <a class="cat-card" href="i18n-key-generator.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">i18n Key 生成器</span>
+            <span class="cat-card-desc">根据文本智能生成国际化 key</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ip-converter.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">IP 地址转换器</span>
+            <span class="cat-card-desc">IP 地址格式转换，支持点分十进制、整数、二进制等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-ast-viewer.html">
+          <span class="cat-card-icon">🌳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JavaScript AST查看器</span>
+            <span class="cat-card-desc">解析JavaScript代码的抽象语法树</span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-formatter.html">
+          <span class="cat-card-icon">JS</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JavaScript 格式化</span>
+            <span class="cat-card-desc">JavaScript 代码格式化、压缩和美化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-minifier.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JavaScript 代码压缩器</span>
+            <span class="cat-card-desc">
+              JavaScript 代码压缩器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-minify.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JavaScript 压缩</span>
+            <span class="cat-card-desc">压缩 JavaScript 代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-obfuscator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JS代码混淆</span>
+            <span class="cat-card-desc">混淆JavaScript代码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="js-playground.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JavaScript 在线运行</span>
+            <span class="cat-card-desc">
+              JavaScript 在线运行，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-diff.html">
+          <span class="cat-card-icon">≠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Diff 对比</span>
+            <span class="cat-card-desc">智能对比两个 JSON 的结构和值差异</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-formatter.html">
+          <span class="cat-card-icon">{}</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 格式化</span>
+            <span class="cat-card-desc">JSON 格式化、压缩、校验，支持错误定位和语法高亮</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-minifier.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 压缩和美化器</span>
+            <span class="cat-card-desc">
+              JSON 压缩和美化器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-minify.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 压缩</span>
+            <span class="cat-card-desc">压缩 JSON 去除空格和换行</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-path-editor.html">
+          <span class="cat-card-icon">📍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 路径编辑器</span>
+            <span class="cat-card-desc">通过路径查询、编辑和导航 JSON 数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-schema-validator.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Schema 验证器</span>
+            <span class="cat-card-desc">
+              JSON Schema 验证器，在线验证，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-to-go.html">
+          <span class="cat-card-icon">🐹</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 转 Go Struct</span>
+            <span class="cat-card-desc">
+              JSON 转 Go Struct，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-to-sql.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 转 SQL</span>
+            <span class="cat-card-desc">
+              JSON 转 SQL，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-to-typescript.html">
+          <span class="cat-card-icon">🔷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 转 TypeScript</span>
+            <span class="cat-card-desc">将 JSON 数据转换为 TypeScript 接口定义</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-tree.html">
+          <span class="cat-card-icon">🌳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON 树形查看器</span>
+            <span class="cat-card-desc">JSON 可视化树形结构查看器，支持折叠展开和路径显示</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-typescript.html">
+          <span class="cat-card-icon">TS</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON → TypeScript 类型生成</span>
+            <span class="cat-card-desc">JSON 转 TypeScript 类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-yaml.html">
+          <span class="cat-card-icon">⇄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON-YAML 转换</span>
+            <span class="cat-card-desc">JSON 与 YAML 格式互转，支持格式化输出</span>
+          </span>
+        </a>
+        <a class="cat-card" href="jsonpath-query.html">
+          <span class="cat-card-icon">$.</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSONPath 查询</span>
+            <span class="cat-card-desc">使用 JSONPath 表达式查询 JSON 数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="jsonpath-tester.html">
+          <span class="cat-card-icon">🔎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSONPath 测试器</span>
+            <span class="cat-card-desc">在线测试 JSONPath 表达式，提取 JSON 数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="jwt-decoder.html">
+          <span class="cat-card-icon">🔓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JWT 解码器</span>
+            <span class="cat-card-desc">解码 JWT Token，查看 Header、Payload 和签名信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="keyboard-tester.html">
+          <span class="cat-card-icon">⌨️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">键盘测试器</span>
+            <span class="cat-card-desc">测试键盘按键，显示按键事件详细信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="keycode.html">
+          <span class="cat-card-icon">⌨️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Keycode 查看器</span>
+            <span class="cat-card-desc">获取键盘按键的 KeyCode 值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="license-generator.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">License 生成器</span>
+            <span class="cat-card-desc">生成开源许可证文件，支持 MIT、Apache、GPL 等协议</span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-to-html.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 转 HTML 转换器</span>
+            <span class="cat-card-desc">
+              Markdown 转 HTML 转换器，多格式互转，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="math-symbols.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数学符号大全</span>
+            <span class="cat-card-desc">
+              数学符号大全，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meta-viewport.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Viewport Meta 生成器</span>
+            <span class="cat-card-desc">生成移动端 Viewport meta 标签</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mime-lookup.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">MIME 类型查询</span>
+            <span class="cat-card-desc">查询文件扩展名对应的 MIME 类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="neumorphism.html">
+          <span class="cat-card-icon">◐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Neumorphism 生成器</span>
+            <span class="cat-card-desc">Neumorphism 软 UI 风格 CSS 代码生成器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nginx-config.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Nginx 配置生成器</span>
+            <span class="cat-card-desc">
+              Nginx 配置生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="nginx-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Nginx 配置生成器 | 在线工具</span>
+            <span class="cat-card-desc">
+              Nginx 配置生成器 | 在线工具，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="openapi-viewer.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">OpenAPI/Swagger查看器</span>
+            <span class="cat-card-desc">解析展示OpenAPI文档</span>
+          </span>
+        </a>
+        <a class="cat-card" href="otp-generator.html">
+          <span class="cat-card-icon">🔑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">OTP 验证码生成器</span>
+            <span class="cat-card-desc">生成一次性密码 (OTP/TOTP)</span>
+          </span>
+        </a>
+        <a class="cat-card" href="package-json-editor.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">package.json编辑器</span>
+            <span class="cat-card-desc">可视化编辑package.json</span>
+          </span>
+        </a>
+        <a class="cat-card" href="package-json-gen.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">package.json 生成器</span>
+            <span class="cat-card-desc">
+              package.json 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="protobuf-decoder.html">
+          <span class="cat-card-icon">◈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Protobuf 解码器</span>
+            <span class="cat-card-desc">解码 Protobuf 二进制数据，无需 schema 定义</span>
+          </span>
+        </a>
+        <a class="cat-card" href="punycode.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Punycode 转换器</span>
+            <span class="cat-card-desc">国际化域名 (IDN) 与 Punycode 编码互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="readme-generator.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">README 生成器</span>
+            <span class="cat-card-desc">快速生成项目 README.md，支持徽章、特性、安装说明等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="readme-preview.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">README.md 实时预览器</span>
+            <span class="cat-card-desc">
+              README.md 实时预览器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-cheatsheet.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则表达式速查</span>
+            <span class="cat-card-desc">正则表达式语法速查表</span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-explainer.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则可视化解释器</span>
+            <span class="cat-card-desc">可视化解析正则表达式，逐步解释每个部分的含义</span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则表达式生成器</span>
+            <span class="cat-card-desc">
+              正则表达式生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-tester.html">
+          <span class="cat-card-icon">.*</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则测试器</span>
+            <span class="cat-card-desc">正则表达式测试，匹配高亮，捕获组展示</span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-visualizer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则表达式可视化器</span>
+            <span class="cat-card-desc">
+              正则表达式可视化器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="responsive-preview.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">响应式预览</span>
+            <span class="cat-card-desc">
+              响应式预览，即时预览，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="rsa-keygen.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">RSA 密钥对生成器</span>
+            <span class="cat-card-desc">生成 RSA 公私钥对</span>
+          </span>
+        </a>
+        <a class="cat-card" href="semver-compare.html">
+          <span class="cat-card-icon">🏷️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Semver 比较器</span>
+            <span class="cat-card-desc">语义化版本号比较和验证</span>
+          </span>
+        </a>
+        <a class="cat-card" href="shortcuts-cheatsheet.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">快捷键速查表</span>
+            <span class="cat-card-desc">
+              快捷键速查表，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="slug-generator.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Slug 生成器</span>
+            <span class="cat-card-desc">生成 URL 友好的 slug 字符串</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-converter.html">
+          <span class="cat-card-icon">🔀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SQL 转换器</span>
+            <span class="cat-card-desc">
+              SQL 转换器，多格式互转，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-formatter.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SQL 格式化</span>
+            <span class="cat-card-desc">SQL 语句格式化和美化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-playground.html">
+          <span class="cat-card-icon">🗄️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SQL在线执行器</span>
+            <span class="cat-card-desc">在浏览器中执行SQL查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-to-mongo.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SQL 转 MongoDB 查询</span>
+            <span class="cat-card-desc">
+              SQL 转 MongoDB 查询，便捷查询，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sse-test.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SSE测试客户端</span>
+            <span class="cat-card-desc">
+              SSE测试客户端，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="string-builder.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字符串拼接器</span>
+            <span class="cat-card-desc">可视化字符串拼接工具，支持拖拽排序和分隔符设置</span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-optimizer.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG优化器</span>
+            <span class="cat-card-desc">优化压缩SVG文件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-path-editor.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 路径编辑器</span>
+            <span class="cat-card-desc">
+              SVG 路径编辑器，在线编辑，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="symbols-table.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">特殊符号大全</span>
+            <span class="cat-card-desc">
+              特殊符号大全，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="table-border.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">表格线生成器</span>
+            <span class="cat-card-desc">
+              表格线生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tailwind-config-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Tailwind CSS 配置生成器</span>
+            <span class="cat-card-desc">
+              Tailwind CSS 配置生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tailwind-lookup.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Tailwind CSS 查询器</span>
+            <span class="cat-card-desc">
+              Tailwind CSS 查询器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="toml-yaml-json.html">
+          <span class="cat-card-icon">⇆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">TOML/YAML/JSON 转换器</span>
+            <span class="cat-card-desc">TOML、YAML、JSON 配置格式互相转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="tsconfig-editor.html">
+          <span class="cat-card-icon">🔷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">tsconfig编辑器</span>
+            <span class="cat-card-desc">可视化编辑tsconfig.json</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unicode-converter.html">
+          <span class="cat-card-icon">U+</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unicode 转换器</span>
+            <span class="cat-card-desc">Unicode 编解码，支持 \uXXXX、HTML 实体等格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unicode-lookup.html">
+          <span class="cat-card-icon">🔤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unicode 查询</span>
+            <span class="cat-card-desc">Unicode 字符查询和信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="url-codec.html">
+          <span class="cat-card-icon">%</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">URL 编解码</span>
+            <span class="cat-card-desc">URL 编码与解码，支持完整 URL 或组件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="url-parser.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">URL 解析器</span>
+            <span class="cat-card-desc">解析 URL 各组成部分，提取查询参数</span>
+          </span>
+        </a>
+        <a class="cat-card" href="webhook-tester.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Webhook测试器</span>
+            <span class="cat-card-desc">发送HTTP请求测试Webhook</span>
+          </span>
+        </a>
+        <a class="cat-card" href="websocket-test.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">WebSocket测试客户端</span>
+            <span class="cat-card-desc">
+              WebSocket测试客户端，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="xml-formatter.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">XML 格式化</span>
+            <span class="cat-card-desc">XML 格式化和验证</span>
+          </span>
+        </a>
+        <a class="cat-card" href="xml-json.html">
+          <span class="cat-card-icon">⇆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">XML ⇄ JSON 转换</span>
+            <span class="cat-card-desc">XML 与 JSON 格式互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="xpath-tester.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">XPath 测试器</span>
+            <span class="cat-card-desc">
+              XPath 测试器，在线验证，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="code-screenshot.html">
+          <span class="cat-card-icon">📸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">代码截图美化</span>
+            <span class="cat-card-desc">将代码转换为精美的截图，支持50+编程语言和多种主题</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chart-generator.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数据图表生成器</span>
+            <span class="cat-card-desc">
+              数据图表生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gradient-generator.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 渐变生成器</span>
+            <span class="cat-card-desc">
+              CSS 渐变生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="http-client.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTTP 请求测试</span>
+            <span class="cat-card-desc">
+              HTTP 请求测试，在线验证，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-schema-generator.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Schema 生成器</span>
+            <span class="cat-card-desc">
+              JSON Schema 生成器，一键在线生成，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-base.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">进制转换器</span>
+            <span class="cat-card-desc">
+              进制转换器，多格式互转，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="diff-checker.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本差异比较</span>
+            <span class="cat-card-desc">比较两段文本的差异，高亮显示修改内容</span>
+          </span>
+        </a>
+        <a class="cat-card" href="keyboard-codes.html">
+          <span class="cat-card-icon">⌨️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">键盘码查询</span>
+            <span class="cat-card-desc">键盘按键码查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="url-encoder.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">URL编码</span>
+            <span class="cat-card-desc">URL编码解码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-preview.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown预览</span>
+            <span class="cat-card-desc">实时预览Markdown</span>
+          </span>
+        </a>
+        <a class="cat-card" href="table-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">表格生成器</span>
+            <span class="cat-card-desc">生成Markdown/HTML/CSV表格</span>
+          </span>
+        </a>
+        <a class="cat-card" href="api-tester.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Api Tester</span>
+            <span class="cat-card-desc">
+              Api Tester，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-animation.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Animation</span>
+            <span class="cat-card-desc">
+              Css Animation，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-flexbox.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Flexbox</span>
+            <span class="cat-card-desc">
+              Css Flexbox，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-gradient-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Css Gradient Generator</span>
+            <span class="cat-card-desc">
+              Css Gradient Generator，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="curl-builder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Curl Builder</span>
+            <span class="cat-card-desc">
+              Curl Builder，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="docker-command-builder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Docker Command Builder</span>
+            <span class="cat-card-desc">
+              Docker Command Builder，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="env-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Env Generator</span>
+            <span class="cat-card-desc">
+              Env Generator，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="git-command-builder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Git Command Builder</span>
+            <span class="cat-card-desc">
+              Git Command Builder，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="git-command-helper.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Git Command Helper</span>
+            <span class="cat-card-desc">
+              Git Command Helper，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="htaccess-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Htaccess 生成器</span>
+            <span class="cat-card-desc">
+              Htaccess 生成器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-entity-encoder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Html Entity Encoder</span>
+            <span class="cat-card-desc">
+              Html Entity Encoder，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-minifier.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Html Minifier</span>
+            <span class="cat-card-desc">
+              Html Minifier，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="http-status-codes.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Http Status Codes</span>
+            <span class="cat-card-desc">
+              Http Status Codes，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-path-finder.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Json Path Finder</span>
+            <span class="cat-card-desc">
+              Json Path Finder，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-path-tester.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Json Path Tester</span>
+            <span class="cat-card-desc">
+              Json Path Tester，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="lorem-ipsum.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Lorem Ipsum 占位文本生成器</span>
+            <span class="cat-card-desc">
+              Lorem Ipsum 占位文本生成器，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="nginx-config-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Nginx Config Generator</span>
+            <span class="cat-card-desc">
+              Nginx Config Generator，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="npm-command-helper.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Npm Command Helper</span>
+            <span class="cat-card-desc">
+              Npm Command Helper，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sql-keywords.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Sql Keywords</span>
+            <span class="cat-card-desc">
+              Sql Keywords，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="string-escape.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">String Escape</span>
+            <span class="cat-card-desc">
+              String Escape，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="yaml-formatter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Yaml Formatter</span>
+            <span class="cat-card-desc">
+              Yaml Formatter，在线使用，开发工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-specificity-calculator.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 选择器权重计算器</span>
+            <span class="cat-card-desc">
+              输入任意 CSS 选择器，实时计算其优先级权重（a-b-c
+              三元组），并可视化比较多个选择器的层叠顺序。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="fluid-typography-clamp-generator.html">
+          <span class="cat-card-icon">Aa</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">流体排版 / CSS clamp 生成器</span>
+            <span class="cat-card-desc">
+              根据最小/最大视口宽度和字号，自动生成 CSS clamp()
+              函数，实现响应式流体字体大小，无需媒体查询。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="media-query-builder.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 媒体查询生成器</span>
+            <span class="cat-card-desc">
+              可视化配置断点条件（宽度、高度、方向、分辨率），一键生成标准 CSS @media 查询代码。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="px-rem-em-converter.html">
+          <span class="cat-card-icon">px</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">px / rem / em 单位转换器</span>
+            <span class="cat-card-desc">
+              基于根字号（root font-size）在 px、rem、em、pt 之间互相换算，快速查出任意 CSS
+              尺寸的等效值。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="type-scale-calculator.html">
+          <span class="cat-card-icon">Aa</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字型比例计算器</span>
+            <span class="cat-card-desc">
+              输入基准字号和比例（Major Third、Perfect Fourth
+              等），生成完整的字型比例阶梯，并预览各级 heading 效果。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-container-query-builder.html">
+          <span class="cat-card-icon">📦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS 容器查询生成器</span>
+            <span class="cat-card-desc">
+              可视化构建 CSS @container 查询规则，设置容器名称和尺寸条件，生成即用代码片段。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="css-z-index-stacking-visualizer.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSS z-index 层叠上下文可视化</span>
+            <span class="cat-card-desc">
+              交互式演示 CSS 层叠上下文规则：添加元素、设置 z-index
+              和触发层叠的属性，实时看到层叠顺序。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-sprite-generator.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG Sprite 生成器</span>
+            <span class="cat-card-desc">
+              上传多个 SVG 图标，合并生成 &lt;svg&gt; symbol sprite 文件，并输出每个图标的
+              &lt;use&gt; 引用代码。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-to-data-uri.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 转 Data URI 编码器</span>
+            <span class="cat-card-desc">
+              将 SVG 代码转换为适合 CSS background-image 使用的 data URI 格式，支持 URL 编码和
+              Base64 两种方式。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sri-hash-generator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SRI 哈希生成器</span>
+            <span class="cat-card-desc">
+              为 CDN 脚本或样式表生成 Subresource Integrity（SRI）integrity 属性值，支持
+              SHA-256/384/512。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-find-replace-tester.html">
+          <span class="cat-card-icon">.*</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Regex 查找替换测试器</span>
+            <span class="cat-card-desc">
+              输入正则表达式和替换模式，实时预览在输入文本上的替换结果，支持捕获组引用（$1, \1）。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="har-viewer.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HAR 文件查看器</span>
+            <span class="cat-card-desc">
+              拖入 .har 文件，可视化展示所有 HTTP 请求的时序瀑布图、请求头、响应体和耗时统计。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-merge-patch.html">
+          <span class="cat-card-icon">⇄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Merge Patch 工具</span>
+            <span class="cat-card-desc">
+              按 RFC 7396 规范对两个 JSON 文档执行 merge patch 操作，实时预览合并结果。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ndjson-formatter.html">
+          <span class="cat-card-icon">{L}</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">NDJSON / JSONL 格式化器</span>
+            <span class="cat-card-desc">
+              格式化和验证换行分隔 JSON（NDJSON/JSONL）文件，逐行解析并高亮错误行，支持行数统计。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ini-file-editor.html">
+          <span class="cat-card-icon">⚙️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">INI / 配置文件编辑器</span>
+            <span class="cat-card-desc">
+              在线解析和编辑 .ini/.cfg
+              配置文件，支持分节（section）、键值对增删改，导出格式化后的文件。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="java-properties-editor.html">
+          <span class="cat-card-icon">⚙️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Java .properties 文件编辑器</span>
+            <span class="cat-card-desc">
+              在线编辑 Java .properties 文件，支持 Unicode
+              转义（\uXXXX）自动处理、注释保留和键值对搜索。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="access-log-analyzer.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Nginx / Apache 访问日志分析器</span>
+            <span class="cat-card-desc">
+              粘贴 Nginx 或 Apache 访问日志，自动解析并统计 Top
+              IP、路径、状态码、带宽，可视化展示流量模式。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ssh-keygen-helper.html">
+          <span class="cat-card-icon">🔑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SSH 密钥对生成器</span>
+            <span class="cat-card-desc">
+              纯浏览器端生成 RSA / Ed25519 SSH 密钥对，无需安装 ssh-keygen，输出公钥、私钥和
+              authorized_keys 格式。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="po-file-editor.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PO / Gettext 翻译文件编辑器</span>
+            <span class="cat-card-desc">
+              上传 .po 或 .pot 文件，以表格形式编辑 msgid 和
+              msgstr，支持过滤未翻译条目，下载修改后的文件。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="email-address-validator.html">
+          <span class="cat-card-icon">@</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">邮箱地址格式验证器</span>
+            <span class="cat-card-desc">
+              验证邮箱地址语法是否符合 RFC 5321/5322 规范，检查域名部分格式，并批量处理多行输入。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="geojson-viewer.html">
+          <span class="cat-card-icon">🗺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GeoJSON 查看器 / 编辑器</span>
+            <span class="cat-card-desc">
+              在地图上渲染 GeoJSON 文件（使用 Leaflet），支持点击查看属性、高亮选中要素，并可编辑
+              JSON 实时刷新。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="isbn-validator.html">
+          <span class="cat-card-icon">📚</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ISBN 验证与解析</span>
+            <span class="cat-card-desc">
+              验证 ISBN-10 / ISBN-13 校验位，解析出版商和出版社前缀含义，并在 ISBN-10 和 ISBN-13
+              之间互转。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="crc32-checksum-calculator.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CRC32 / Adler-32 校验计算器</span>
+            <span class="cat-card-desc">
+              计算文本或文件的 CRC-32、Adler-32、FNV-1a 校验值，补充现有 MD5/SHA
+              系哈希工具未覆盖的非密码学校验。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="favicon-ico-generator.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Favicon 多尺寸 ICO 生成器</span>
+            <span class="cat-card-desc">
+              上传 PNG/SVG 图片，一键生成包含 16×16、32×32、48×48 的 .ico 文件，以及
+              apple-touch-icon 和 PWA manifest 所需的各尺寸 PNG。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-linter.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 语法检查器</span>
+            <span class="cat-card-desc">
+              检查 Markdown
+              文档中的常见问题：标题层级跳跃、重复标题、代码块未指定语言、链接格式错误等，输出带行号的报告。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-schema-to-form.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Schema → HTML 表单生成器</span>
+            <span class="cat-card-desc">
+              粘贴 JSON Schema，自动生成对应的 HTML
+              表单（支持字符串、数字、枚举、对象、数组类型），并实时验证输入值。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cors-preflight-debugger.html">
+          <span class="cat-card-icon">🔀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CORS 请求调试器</span>
+            <span class="cat-card-desc">
+              模拟 preflight 请求，解析 CORS 响应头，定位跨域报错根因，显示各字段含义。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/education/index.html
+++ b/tools/education/index.html
@@ -1,0 +1,459 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>教育学习 - 在线工具合集（20个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。"
+    />
+    <meta name="keywords" content="教育学习,在线工具,免费工具,教育学习大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/education/index.html" />
+    <meta property="og:title" content="教育学习 - 在线工具合集（20个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/education/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="教育学习 - 在线工具合集（20个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "教育学习",
+            "item": "https://tools.realtime-ai.chat/tools/education/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "教育学习 - 在线工具合集（20个）| WebUtils",
+        "description": "面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。",
+        "url": "https://tools.realtime-ai.chat/tools/education/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 20,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "GPA计算器",
+              "url": "https://tools.realtime-ai.chat/tools/education/gpa-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "成绩计算器",
+              "url": "https://tools.realtime-ai.chat/tools/education/grade-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "学习计时器",
+              "url": "https://tools.realtime-ai.chat/tools/education/study-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "单词卡片工具",
+              "url": "https://tools.realtime-ai.chat/tools/education/flashcard.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "论文引用格式生成器",
+              "url": "https://tools.realtime-ai.chat/tools/education/citation-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "阅读速度测试",
+              "url": "https://tools.realtime-ai.chat/tools/education/reading-speed.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "数学方程求解器",
+              "url": "https://tools.realtime-ai.chat/tools/education/math-solver.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "三角函数单位圆",
+              "url": "https://tools.realtime-ai.chat/tools/education/unit-circle.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "元素周期表",
+              "url": "https://tools.realtime-ai.chat/tools/education/periodic-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "物理公式速查",
+              "url": "https://tools.realtime-ai.chat/tools/education/physics-formulas.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "化学方程式配平",
+              "url": "https://tools.realtime-ai.chat/tools/education/chemical-equation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "统计学计算器",
+              "url": "https://tools.realtime-ai.chat/tools/education/statistics.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "二叉树可视化",
+              "url": "https://tools.realtime-ai.chat/tools/education/binary-tree.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "词汇量测试",
+              "url": "https://tools.realtime-ai.chat/tools/language/vocabulary-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "拼音转换",
+              "url": "https://tools.realtime-ai.chat/tools/language/pinyin-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "阅读进度追踪",
+              "url": "https://tools.realtime-ai.chat/tools/education/reading-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "乘法口诀表",
+              "url": "https://tools.realtime-ai.chat/tools/education/multiplication-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "单词本",
+              "url": "https://tools.realtime-ai.chat/tools/language/vocabulary-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "行星 / 太阳系信息查询",
+              "url": "https://tools.realtime-ai.chat/tools/education/solar-system-explorer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "世界国家地理测验",
+              "url": "https://tools.realtime-ai.chat/tools/education/geography-country-quiz.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📚</div>
+        <h1>教育学习</h1>
+        <p class="cat-intro">
+          面向学习与教学的在线工具，涵盖单位换算、公式计算、记忆训练、成绩统计等。
+        </p>
+        <p class="cat-meta">20 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="gpa-calculator.html">
+          <span class="cat-card-icon">🎓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GPA计算器</span>
+            <span class="cat-card-desc">计算GPA绩点（中/美/英制）</span>
+          </span>
+        </a>
+        <a class="cat-card" href="grade-calculator.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">成绩计算器</span>
+            <span class="cat-card-desc">加权平均成绩计算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="study-timer.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">学习计时器</span>
+            <span class="cat-card-desc">番茄钟学习计时器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="flashcard.html">
+          <span class="cat-card-icon">🃏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">单词卡片工具</span>
+            <span class="cat-card-desc">单词记忆卡片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="citation-generator.html">
+          <span class="cat-card-icon">📚</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">论文引用格式生成器</span>
+            <span class="cat-card-desc">生成APA/MLA/Chicago格式引用</span>
+          </span>
+        </a>
+        <a class="cat-card" href="reading-speed.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阅读速度测试</span>
+            <span class="cat-card-desc">测试阅读速度和理解能力</span>
+          </span>
+        </a>
+        <a class="cat-card" href="math-solver.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数学方程求解器</span>
+            <span class="cat-card-desc">求解各类数学方程</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-circle.html">
+          <span class="cat-card-icon">⭕</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">三角函数单位圆</span>
+            <span class="cat-card-desc">三角函数单位圆可视化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="periodic-table.html">
+          <span class="cat-card-icon">⚗️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">元素周期表</span>
+            <span class="cat-card-desc">交互式元素周期表</span>
+          </span>
+        </a>
+        <a class="cat-card" href="physics-formulas.html">
+          <span class="cat-card-icon">🔬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">物理公式速查</span>
+            <span class="cat-card-desc">常用物理公式速查</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chemical-equation.html">
+          <span class="cat-card-icon">⚗️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">化学方程式配平</span>
+            <span class="cat-card-desc">化学方程式配平工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="statistics.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">统计学计算器</span>
+            <span class="cat-card-desc">统计学基础计算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="binary-tree.html">
+          <span class="cat-card-icon">🌳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">二叉树可视化</span>
+            <span class="cat-card-desc">二叉树操作可视化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../language/vocabulary-test.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">词汇量测试</span>
+            <span class="cat-card-desc">测试英语词汇量水平</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../language/pinyin-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">拼音转换</span>
+            <span class="cat-card-desc">汉字转拼音工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="reading-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阅读进度追踪</span>
+            <span class="cat-card-desc">管理书单和阅读进度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="multiplication-table.html">
+          <span class="cat-card-icon">✖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">乘法口诀表</span>
+            <span class="cat-card-desc">交互式乘法口诀表，支持练习模式和测验模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../language/vocabulary-builder.html">
+          <span class="cat-card-icon">📚</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">单词本</span>
+            <span class="cat-card-desc">记录生词，复习背诵，提升词汇量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="solar-system-explorer.html">
+          <span class="cat-card-icon">🪐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">行星 / 太阳系信息查询</span>
+            <span class="cat-card-desc">
+              交互式浏览太阳系各行星的物理参数（质量、半径、公转周期、卫星数等），支持单位换算和星球对比。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="geography-country-quiz.html">
+          <span class="cat-card-icon">🌍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">世界国家地理测验</span>
+            <span class="cat-card-desc">
+              随机显示国旗或地图轮廓，测试国家名称、首都、所在洲的记忆，支持错题重练，内嵌 195
+              个国家数据。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/extractor/index.html
+++ b/tools/extractor/index.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>提取器 - 在线工具合集（5个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。"
+    />
+    <meta name="keywords" content="提取器,在线工具,免费工具,提取器大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/extractor/index.html" />
+    <meta property="og:title" content="提取器 - 在线工具合集（5个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/extractor/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="提取器 - 在线工具合集（5个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "提取器",
+            "item": "https://tools.realtime-ai.chat/tools/extractor/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "提取器 - 在线工具合集（5个）| WebUtils",
+        "description": "在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。",
+        "url": "https://tools.realtime-ai.chat/tools/extractor/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 5,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "网站图标提取器",
+              "url": "https://tools.realtime-ai.chat/tools/extractor/favicon-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "链接提取器",
+              "url": "https://tools.realtime-ai.chat/tools/extractor/link-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "正则提取器",
+              "url": "https://tools.realtime-ai.chat/tools/extractor/regex-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "文本信息提取器",
+              "url": "https://tools.realtime-ai.chat/tools/extractor/text-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "JSON Path 提取器",
+              "url": "https://tools.realtime-ai.chat/tools/extractor/json-path-extractor.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📤</div>
+        <h1>提取器</h1>
+        <p class="cat-intro">
+          在线信息提取工具，从文本、网页、文件中抽取链接、邮箱、关键词等结构化数据。
+        </p>
+        <p class="cat-meta">5 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="favicon-extractor.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">网站图标提取器</span>
+            <span class="cat-card-desc">提取网站的 Favicon 图标，支持多种尺寸下载</span>
+          </span>
+        </a>
+        <a class="cat-card" href="link-extractor.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">链接提取器</span>
+            <span class="cat-card-desc">从文本提取链接</span>
+          </span>
+        </a>
+        <a class="cat-card" href="regex-extractor.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">正则提取器</span>
+            <span class="cat-card-desc">使用正则表达式批量提取文本内容，支持导出 CSV</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-extractor.html">
+          <span class="cat-card-icon">📤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本信息提取器</span>
+            <span class="cat-card-desc">提取文本中的特定内容</span>
+          </span>
+        </a>
+        <a class="cat-card" href="json-path-extractor.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">JSON Path 提取器</span>
+            <span class="cat-card-desc">使用 JSONPath 表达式从 JSON 数据中提取特定字段</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/finance/index.html
+++ b/tools/finance/index.html
@@ -1,0 +1,484 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>财务工具 - 在线工具合集（21个）| WebUtils</title>
+    <meta
+      name="description"
+      content="个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。"
+    />
+    <meta name="keywords" content="财务工具,在线工具,免费工具,财务工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/finance/index.html" />
+    <meta property="og:title" content="财务工具 - 在线工具合集（21个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/finance/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="财务工具 - 在线工具合集（21个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "财务工具",
+            "item": "https://tools.realtime-ai.chat/tools/finance/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "财务工具 - 在线工具合集（21个）| WebUtils",
+        "description": "个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。",
+        "url": "https://tools.realtime-ai.chat/tools/finance/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 21,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "股票收益计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/stock-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "汇率换算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/currency-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "个人所得税计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/tax-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "家庭预算规划器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/budget-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "投资回报率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/investment-return.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "债务还款计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/debt-payoff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "退休计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/retirement-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "利润率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/profit-margin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "小费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/tip-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "AA记账分摊器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/exchange-split.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "储蓄目标计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/savings-goal.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "资产折旧计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/depreciation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "提前还贷计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/loan-early-repay.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "复利投资计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/compound-interest.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "预算追踪器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/budget-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "SWIFT / BIC 银行代码查询",
+              "url": "https://tools.realtime-ai.chat/tools/finance/swift-bic-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "股息率 / 市盈率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/dividend-pe-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "贷款摊销明细表",
+              "url": "https://tools.realtime-ai.chat/tools/finance/amortization-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "CAGR 复合年增长率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/cagr-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "50/30/20 预算规划器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/budget-50-30-20-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "投资回收期计算器",
+              "url": "https://tools.realtime-ai.chat/tools/finance/payback-period-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">💰</div>
+        <h1>财务工具</h1>
+        <p class="cat-intro">
+          个人与企业财务相关的在线工具，包括贷款、税务、投资、汇率、预算计算，辅助理财决策。
+        </p>
+        <p class="cat-meta">21 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="stock-calculator.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">股票收益计算器</span>
+            <span class="cat-card-desc">计算股票投资盈亏、成本均价和收益率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="currency-converter.html">
+          <span class="cat-card-icon">💱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汇率换算器</span>
+            <span class="cat-card-desc">多种货币实时汇率换算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="tax-calculator.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">个人所得税计算器</span>
+            <span class="cat-card-desc">计算中国个人所得税</span>
+          </span>
+        </a>
+        <a class="cat-card" href="budget-planner.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">家庭预算规划器</span>
+            <span class="cat-card-desc">合理规划收支，实现财务自由</span>
+          </span>
+        </a>
+        <a class="cat-card" href="investment-return.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">投资回报率计算器</span>
+            <span class="cat-card-desc">计算ROI、年化收益率等投资指标</span>
+          </span>
+        </a>
+        <a class="cat-card" href="debt-payoff.html">
+          <span class="cat-card-icon">💳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">债务还款计算器</span>
+            <span class="cat-card-desc">制定债务还款计划，比较还款策略</span>
+          </span>
+        </a>
+        <a class="cat-card" href="retirement-calculator.html">
+          <span class="cat-card-icon">🏖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">退休计算器</span>
+            <span class="cat-card-desc">计算退休所需资金和储蓄计划</span>
+          </span>
+        </a>
+        <a class="cat-card" href="profit-margin.html">
+          <span class="cat-card-icon">💵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">利润率计算器</span>
+            <span class="cat-card-desc">计算毛利率、净利率、盈亏平衡点</span>
+          </span>
+        </a>
+        <a class="cat-card" href="tip-calculator.html">
+          <span class="cat-card-icon">🍽️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">小费计算器</span>
+            <span class="cat-card-desc">快速计算餐厅小费和AA账单</span>
+          </span>
+        </a>
+        <a class="cat-card" href="exchange-split.html">
+          <span class="cat-card-icon">🧾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AA记账分摊器</span>
+            <span class="cat-card-desc">聚餐、旅行费用分摊计算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="savings-goal.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">储蓄目标计算器</span>
+            <span class="cat-card-desc">设定目标，计算每月储蓄金额</span>
+          </span>
+        </a>
+        <a class="cat-card" href="depreciation.html">
+          <span class="cat-card-icon">📉</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">资产折旧计算器</span>
+            <span class="cat-card-desc">计算固定资产折旧</span>
+          </span>
+        </a>
+        <a class="cat-card" href="loan-early-repay.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">提前还贷计算器</span>
+            <span class="cat-card-desc">计算提前还贷节省的利息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="compound-interest.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">复利投资计算器</span>
+            <span class="cat-card-desc">计算复利投资收益，模拟长期理财规划</span>
+          </span>
+        </a>
+        <a class="cat-card" href="budget-tracker.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">预算追踪器</span>
+            <span class="cat-card-desc">记录收支，管理预算，可视化财务状况</span>
+          </span>
+        </a>
+        <a class="cat-card" href="swift-bic-lookup.html">
+          <span class="cat-card-icon">🏦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SWIFT / BIC 银行代码查询</span>
+            <span class="cat-card-desc">
+              查询 SWIFT/BIC
+              银行识别代码的结构（8位或11位）含义，解析银行名称、国家、城市和分行代码。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="dividend-pe-calculator.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">股息率 / 市盈率计算器</span>
+            <span class="cat-card-desc">
+              根据股价、每股收益、每股股息，计算市盈率（P/E）、股息率（Dividend
+              Yield）、股息支付率等核心估值指标。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="amortization-table.html">
+          <span class="cat-card-icon">🏦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">贷款摊销明细表</span>
+            <span class="cat-card-desc">
+              输入贷款金额、年利率、期数，生成完整的逐期还款明细（本金/利息/余额），支持导出 CSV
+              和额外还款模拟。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cagr-calculator.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CAGR 复合年增长率计算器</span>
+            <span class="cat-card-desc">
+              输入初始值、终值和年数，计算
+              CAGR；或由目标增长率反推所需终值，广泛用于投资和业务分析。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="budget-50-30-20-planner.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">50/30/20 预算规划器</span>
+            <span class="cat-card-desc">
+              按 50% 必要支出、30% 想要支出、20%
+              储蓄/还债的经典法则，输入税后收入即可自动分配并可视化。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="payback-period-calculator.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">投资回收期计算器</span>
+            <span class="cat-card-desc">
+              输入初始投资和年度净现金流（可逐年不同），计算静态和动态回收期，含图表展示累计现金流。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/food/index.html
+++ b/tools/food/index.html
@@ -1,0 +1,428 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>餐饮食品 - 在线工具合集（18个）| WebUtils</title>
+    <meta
+      name="description"
+      content="与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。"
+    />
+    <meta name="keywords" content="餐饮食品,在线工具,免费工具,餐饮食品大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/food/index.html" />
+    <meta property="og:title" content="餐饮食品 - 在线工具合集（18个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/food/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="餐饮食品 - 在线工具合集（18个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "餐饮食品",
+            "item": "https://tools.realtime-ai.chat/tools/food/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "餐饮食品 - 在线工具合集（18个）| WebUtils",
+        "description": "与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。",
+        "url": "https://tools.realtime-ai.chat/tools/food/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 18,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "泡茶计时器",
+              "url": "https://tools.realtime-ai.chat/tools/food/tea-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "食物卡路里查询",
+              "url": "https://tools.realtime-ai.chat/tools/food/calorie-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "烹饪单位转换器",
+              "url": "https://tools.realtime-ai.chat/tools/food/cooking-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "配方缩放工具",
+              "url": "https://tools.realtime-ai.chat/tools/food/recipe-scaler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "营养成分计算器",
+              "url": "https://tools.realtime-ai.chat/tools/food/nutrition-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "烘焙比例计算器",
+              "url": "https://tools.realtime-ai.chat/tools/food/baking-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "咖啡冲泡比例",
+              "url": "https://tools.realtime-ai.chat/tools/food/coffee-ratio.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "葡萄酒配餐指南",
+              "url": "https://tools.realtime-ai.chat/tools/food/wine-pairing.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "肉类温度参考",
+              "url": "https://tools.realtime-ai.chat/tools/food/meat-temperature.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "菜品成本计算器",
+              "url": "https://tools.realtime-ai.chat/tools/food/food-cost.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "购物清单生成器",
+              "url": "https://tools.realtime-ai.chat/tools/food/shopping-list.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "周餐计划器",
+              "url": "https://tools.realtime-ai.chat/tools/food/meal-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "发酵计时器",
+              "url": "https://tools.realtime-ai.chat/tools/food/fermentation-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "食物份量计算器",
+              "url": "https://tools.realtime-ai.chat/tools/food/serving-size.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "食材保存时间查询",
+              "url": "https://tools.realtime-ai.chat/tools/food/food-storage.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "鸡尾酒配方工具",
+              "url": "https://tools.realtime-ai.chat/tools/food/drink-mixer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "食谱份量转换器",
+              "url": "https://tools.realtime-ai.chat/tools/food/recipe-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "烹饪计时器",
+              "url": "https://tools.realtime-ai.chat/tools/food/recipe-timer.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🍳</div>
+        <h1>餐饮食品</h1>
+        <p class="cat-intro">
+          与饮食相关的在线工具，包括食谱换算、热量计算、烹饪计时、营养参考等。
+        </p>
+        <p class="cat-meta">18 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="tea-timer.html">
+          <span class="cat-card-icon">🍵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">泡茶计时器</span>
+            <span class="cat-card-desc">不同茶类推荐温度和冲泡时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="calorie-counter.html">
+          <span class="cat-card-icon">🔥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">食物卡路里查询</span>
+            <span class="cat-card-desc">查询常见食物热量和营养成分</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cooking-converter.html">
+          <span class="cat-card-icon">🥄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">烹饪单位转换器</span>
+            <span class="cat-card-desc">烹饪单位互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="recipe-scaler.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">配方缩放工具</span>
+            <span class="cat-card-desc">按份量调整食材用量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nutrition-calculator.html">
+          <span class="cat-card-icon">🥗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">营养成分计算器</span>
+            <span class="cat-card-desc">计算食谱营养成分</span>
+          </span>
+        </a>
+        <a class="cat-card" href="baking-calculator.html">
+          <span class="cat-card-icon">🍞</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">烘焙比例计算器</span>
+            <span class="cat-card-desc">烘焙配方比例计算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="coffee-ratio.html">
+          <span class="cat-card-icon">☕</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">咖啡冲泡比例</span>
+            <span class="cat-card-desc">咖啡冲泡比例计算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="wine-pairing.html">
+          <span class="cat-card-icon">🍷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">葡萄酒配餐指南</span>
+            <span class="cat-card-desc">葡萄酒与食物搭配建议</span>
+          </span>
+        </a>
+        <a class="cat-card" href="meat-temperature.html">
+          <span class="cat-card-icon">🥩</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">肉类温度参考</span>
+            <span class="cat-card-desc">肉类最佳烹饪温度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="food-cost.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">菜品成本计算器</span>
+            <span class="cat-card-desc">计算菜品成本和利润</span>
+          </span>
+        </a>
+        <a class="cat-card" href="shopping-list.html">
+          <span class="cat-card-icon">🛒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">购物清单生成器</span>
+            <span class="cat-card-desc">生成购物清单</span>
+          </span>
+        </a>
+        <a class="cat-card" href="meal-planner.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">周餐计划器</span>
+            <span class="cat-card-desc">规划一周餐食</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fermentation-timer.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">发酵计时器</span>
+            <span class="cat-card-desc">面团发酵计时</span>
+          </span>
+        </a>
+        <a class="cat-card" href="serving-size.html">
+          <span class="cat-card-icon">🍽️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">食物份量计算器</span>
+            <span class="cat-card-desc">计算食物份量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="food-storage.html">
+          <span class="cat-card-icon">❄️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">食材保存时间查询</span>
+            <span class="cat-card-desc">查询食材保存时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="drink-mixer.html">
+          <span class="cat-card-icon">🍸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">鸡尾酒配方工具</span>
+            <span class="cat-card-desc">鸡尾酒配方查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="recipe-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">食谱份量转换器</span>
+            <span class="cat-card-desc">调整食谱食材份量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="recipe-timer.html">
+          <span class="cat-card-icon">⏲️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">烹饪计时器</span>
+            <span class="cat-card-desc">多个烹饪计时器同时运行，厨房好帮手</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/fun/index.html
+++ b/tools/fun/index.html
@@ -1,0 +1,486 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>趣味工具 - 在线工具合集（22个）| WebUtils</title>
+    <meta
+      name="description"
+      content="轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。"
+    />
+    <meta name="keywords" content="趣味工具,在线工具,免费工具,趣味工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/fun/index.html" />
+    <meta property="og:title" content="趣味工具 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/fun/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="趣味工具 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "趣味工具",
+            "item": "https://tools.realtime-ai.chat/tools/fun/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "趣味工具 - 在线工具合集（22个）| WebUtils",
+        "description": "轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。",
+        "url": "https://tools.realtime-ai.chat/tools/fun/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 22,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "瞄准训练",
+              "url": "https://tools.realtime-ai.chat/tools/fun/aim-trainer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "抛硬币",
+              "url": "https://tools.realtime-ai.chat/tools/fun/coin-flip.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "骰子模拟器",
+              "url": "https://tools.realtime-ai.chat/tools/fun/dice-roller.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "数字记忆测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/number-memory.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "反应时间测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/reaction-time.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "序列记忆测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/sequence-memory.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "今天吃什么",
+              "url": "https://tools.realtime-ai.chat/tools/fun/what-to-eat.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "转盘抽奖",
+              "url": "https://tools.realtime-ai.chat/tools/fun/wheel-spinner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "是或否决策器",
+              "url": "https://tools.realtime-ai.chat/tools/fun/yes-or-no.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "今日运势",
+              "url": "https://tools.realtime-ai.chat/tools/fun/fortune-teller.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "倒计时器(趣味)",
+              "url": "https://tools.realtime-ai.chat/tools/fun/countdown-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "秒表计时器(简版)",
+              "url": "https://tools.realtime-ai.chat/tools/fun/stopwatch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "记忆翻牌",
+              "url": "https://tools.realtime-ai.chat/tools/fun/memory-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "点击计数器",
+              "url": "https://tools.realtime-ai.chat/tools/fun/click-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "抛硬币(简版)",
+              "url": "https://tools.realtime-ai.chat/tools/fun/flip-coin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "打字测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/typing-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "反应测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/reaction-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "色盲测试",
+              "url": "https://tools.realtime-ai.chat/tools/fun/color-blind-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "猜数字",
+              "url": "https://tools.realtime-ai.chat/tools/fun/number-guessing.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "Name Generator",
+              "url": "https://tools.realtime-ai.chat/tools/fun/name-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Quiz Maker",
+              "url": "https://tools.realtime-ai.chat/tools/fun/quiz-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "Wheel Of Fortune",
+              "url": "https://tools.realtime-ai.chat/tools/fun/wheel-of-fortune.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🎯</div>
+        <h1>趣味工具</h1>
+        <p class="cat-intro">
+          轻松有趣的在线小工具，用于消遣、抽签、测试、随机决策，给日常添点乐趣。
+        </p>
+        <p class="cat-meta">22 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="aim-trainer.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">瞄准训练</span>
+            <span class="cat-card-desc">训练瞄准速度和精准度，提升手眼协调</span>
+          </span>
+        </a>
+        <a class="cat-card" href="coin-flip.html">
+          <span class="cat-card-icon">🪙</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">抛硬币</span>
+            <span class="cat-card-desc">3D 抛硬币动画，支持统计和历史记录</span>
+          </span>
+        </a>
+        <a class="cat-card" href="dice-roller.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">骰子模拟器</span>
+            <span class="cat-card-desc">多种骰子类型模拟器，支持多骰子投掷和统计</span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-memory.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数字记忆测试</span>
+            <span class="cat-card-desc">记住显示的数字，测试你的数字记忆能力</span>
+          </span>
+        </a>
+        <a class="cat-card" href="reaction-time.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">反应时间测试</span>
+            <span class="cat-card-desc">测试你的反应速度，记录最佳成绩</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sequence-memory.html">
+          <span class="cat-card-icon">🧠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">序列记忆测试</span>
+            <span class="cat-card-desc">记住闪烁的顺序，测试你的记忆力</span>
+          </span>
+        </a>
+        <a class="cat-card" href="what-to-eat.html">
+          <span class="cat-card-icon">🍜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">今天吃什么</span>
+            <span class="cat-card-desc">随机选择今天吃什么，支持自定义食物列表</span>
+          </span>
+        </a>
+        <a class="cat-card" href="wheel-spinner.html">
+          <span class="cat-card-icon">🎡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">转盘抽奖</span>
+            <span class="cat-card-desc">自定义转盘抽奖，支持自定义选项、颜色和历史记录</span>
+          </span>
+        </a>
+        <a class="cat-card" href="yes-or-no.html">
+          <span class="cat-card-icon">🔮</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">是或否决策器</span>
+            <span class="cat-card-desc">神秘决策球，帮你做出是或否的选择</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fortune-teller.html">
+          <span class="cat-card-icon">🔮</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">今日运势</span>
+            <span class="cat-card-desc">每日运势签文，获取今日的好运指引</span>
+          </span>
+        </a>
+        <a class="cat-card" href="countdown-timer.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">倒计时器(趣味)</span>
+            <span class="cat-card-desc">自定义倒计时工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="stopwatch.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">秒表计时器(简版)</span>
+            <span class="cat-card-desc">精确秒表计时器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="memory-game.html">
+          <span class="cat-card-icon">🧠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">记忆翻牌</span>
+            <span class="cat-card-desc">翻牌记忆游戏</span>
+          </span>
+        </a>
+        <a class="cat-card" href="click-counter.html">
+          <span class="cat-card-icon">👆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">点击计数器</span>
+            <span class="cat-card-desc">测试点击速度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="flip-coin.html">
+          <span class="cat-card-icon">🪙</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">抛硬币(简版)</span>
+            <span class="cat-card-desc">随机抛硬币</span>
+          </span>
+        </a>
+        <a class="cat-card" href="typing-test.html">
+          <span class="cat-card-icon">⌨️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">打字测试</span>
+            <span class="cat-card-desc">测试打字速度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="reaction-test.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">反应测试</span>
+            <span class="cat-card-desc">测试反应速度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-blind-test.html">
+          <span class="cat-card-icon">👁️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">色盲测试</span>
+            <span class="cat-card-desc">简单色盲检测</span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-guessing.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">猜数字</span>
+            <span class="cat-card-desc">猜数字游戏</span>
+          </span>
+        </a>
+        <a class="cat-card" href="name-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Name Generator</span>
+            <span class="cat-card-desc">
+              Name Generator，在线使用，趣味工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="quiz-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Quiz Maker</span>
+            <span class="cat-card-desc">
+              Quiz Maker，在线使用，趣味工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="wheel-of-fortune.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Wheel Of Fortune</span>
+            <span class="cat-card-desc">
+              Wheel Of Fortune，在线使用，趣味工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/game/index.html
+++ b/tools/game/index.html
@@ -1,0 +1,492 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>小游戏 - 在线工具合集（22个）| WebUtils</title>
+    <meta
+      name="description"
+      content="浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。"
+    />
+    <meta name="keywords" content="小游戏,在线工具,免费工具,小游戏大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/game/index.html" />
+    <meta property="og:title" content="小游戏 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/game/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="小游戏 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "小游戏",
+            "item": "https://tools.realtime-ai.chat/tools/game/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "小游戏 - 在线工具合集（22个）| WebUtils",
+        "description": "浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。",
+        "url": "https://tools.realtime-ai.chat/tools/game/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 22,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "2048 游戏",
+              "url": "https://tools.realtime-ai.chat/tools/game/game-2048.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "扫雷",
+              "url": "https://tools.realtime-ai.chat/tools/game/game-minesweeper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "贪吃蛇",
+              "url": "https://tools.realtime-ai.chat/tools/game/game-snake.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "数独",
+              "url": "https://tools.realtime-ai.chat/tools/game/game-sudoku.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "俄罗斯方块",
+              "url": "https://tools.realtime-ai.chat/tools/game/game-tetris.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "记忆配对游戏",
+              "url": "https://tools.realtime-ai.chat/tools/game/memory-match.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "贪吃蛇游戏",
+              "url": "https://tools.realtime-ai.chat/tools/game/snake-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "五子棋",
+              "url": "https://tools.realtime-ai.chat/tools/game/gomoku.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "记忆翻牌游戏",
+              "url": "https://tools.realtime-ai.chat/tools/game/memory-cards.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "骰子模拟器(桌游)",
+              "url": "https://tools.realtime-ai.chat/tools/game/dice-roller.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "Breakout Game",
+              "url": "https://tools.realtime-ai.chat/tools/game/breakout-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Color Match",
+              "url": "https://tools.realtime-ai.chat/tools/game/color-match.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "Flappy Bird",
+              "url": "https://tools.realtime-ai.chat/tools/game/flappy-bird.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Guess Number",
+              "url": "https://tools.realtime-ai.chat/tools/game/guess-number.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "Math Challenge",
+              "url": "https://tools.realtime-ai.chat/tools/game/math-challenge.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "Pinball Game",
+              "url": "https://tools.realtime-ai.chat/tools/game/pinball-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "Reaction Game",
+              "url": "https://tools.realtime-ai.chat/tools/game/reaction-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "Shooter Game",
+              "url": "https://tools.realtime-ai.chat/tools/game/shooter-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Tic Tac Toe",
+              "url": "https://tools.realtime-ai.chat/tools/game/tic-tac-toe.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "Typing Game",
+              "url": "https://tools.realtime-ai.chat/tools/game/typing-game.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Word Chain",
+              "url": "https://tools.realtime-ai.chat/tools/game/word-chain.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "Word Scramble",
+              "url": "https://tools.realtime-ai.chat/tools/game/word-scramble.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🎮</div>
+        <h1>小游戏</h1>
+        <p class="cat-intro">浏览器即开即玩的在线小游戏，无需下载安装，利用碎片时间放松一下。</p>
+        <p class="cat-meta">22 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="game-2048.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">2048 游戏</span>
+            <span class="cat-card-desc">经典 2048 数字合并游戏，支持撤销和最高分记录</span>
+          </span>
+        </a>
+        <a class="cat-card" href="game-minesweeper.html">
+          <span class="cat-card-icon">💣</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">扫雷</span>
+            <span class="cat-card-desc">经典扫雷游戏，支持简单/中等/困难三种难度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="game-snake.html">
+          <span class="cat-card-icon">🐍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">贪吃蛇</span>
+            <span class="cat-card-desc">经典贪吃蛇游戏，支持多种速度和穿墙模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="game-sudoku.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数独</span>
+            <span class="cat-card-desc">经典数独游戏，支持三种难度和笔记功能</span>
+          </span>
+        </a>
+        <a class="cat-card" href="game-tetris.html">
+          <span class="cat-card-icon">🧱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">俄罗斯方块</span>
+            <span class="cat-card-desc">经典俄罗斯方块游戏，支持键盘和触屏操作</span>
+          </span>
+        </a>
+        <a class="cat-card" href="memory-match.html">
+          <span class="cat-card-icon">🃏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">记忆配对游戏</span>
+            <span class="cat-card-desc">经典记忆配对卡牌游戏，锻炼大脑记忆力</span>
+          </span>
+        </a>
+        <a class="cat-card" href="snake-game.html">
+          <span class="cat-card-icon">🐍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">贪吃蛇游戏</span>
+            <span class="cat-card-desc">经典贪吃蛇游戏，支持键盘和触屏操控</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gomoku.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">五子棋</span>
+            <span class="cat-card-desc">单人对战AI的五子棋游戏</span>
+          </span>
+        </a>
+        <a class="cat-card" href="memory-cards.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">记忆翻牌游戏</span>
+            <span class="cat-card-desc">考验记忆力的翻牌配对游戏</span>
+          </span>
+        </a>
+        <a class="cat-card" href="dice-roller.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">骰子模拟器(桌游)</span>
+            <span class="cat-card-desc">在线骰子模拟器，支持多种骰子类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="breakout-game.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Breakout Game</span>
+            <span class="cat-card-desc">
+              Breakout Game，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-match.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Color Match</span>
+            <span class="cat-card-desc">Color Match，在线使用，小游戏，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="flappy-bird.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Flappy Bird</span>
+            <span class="cat-card-desc">Flappy Bird，在线使用，小游戏，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="guess-number.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Guess Number</span>
+            <span class="cat-card-desc">
+              Guess Number，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="math-challenge.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Math Challenge</span>
+            <span class="cat-card-desc">
+              Math Challenge，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pinball-game.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Pinball Game</span>
+            <span class="cat-card-desc">
+              Pinball Game，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="reaction-game.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Reaction Game</span>
+            <span class="cat-card-desc">
+              Reaction Game，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="shooter-game.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Shooter Game</span>
+            <span class="cat-card-desc">
+              Shooter Game，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tic-tac-toe.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Tic Tac Toe</span>
+            <span class="cat-card-desc">Tic Tac Toe，在线使用，小游戏，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="typing-game.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Typing Game</span>
+            <span class="cat-card-desc">Typing Game，在线使用，小游戏，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="word-chain.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Word Chain</span>
+            <span class="cat-card-desc">Word Chain，在线使用，小游戏，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="word-scramble.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Word Scramble</span>
+            <span class="cat-card-desc">
+              Word Scramble，在线使用，小游戏，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -1,0 +1,1033 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>生成器 - 在线工具合集（59个）| WebUtils</title>
+    <meta
+      name="description"
+      content="各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。"
+    />
+    <meta name="keywords" content="生成器,在线工具,免费工具,生成器大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/generator/index.html" />
+    <meta property="og:title" content="生成器 - 在线工具合集（59个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/generator/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="生成器 - 在线工具合集（59个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "生成器 - 在线工具合集（59个）| WebUtils",
+        "description": "各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。",
+        "url": "https://tools.realtime-ai.chat/tools/generator/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 59,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "头像生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/avatar-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "条形码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/barcode.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "名片生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/business-card.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "证书生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/certificate-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "代码卡片生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/code-card.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "邮件签名生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/email-signature.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "假数据生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/fake-data.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "GitHub 贡献图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/github-contrib.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "渐变色卡生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/gradient-card.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "发票/收据生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/invoice-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "Logo 文字生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/logo-text.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "表情包生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/meme-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "Mesh渐变背景生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/mesh-gradient.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Mock 数据生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/mock-data.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "NanoID 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/nanoid-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "噪点纹理生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/noise-texture.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "密码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/password-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "像素画编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/pixel-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "占位图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/placeholder-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "进度条生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/progress-bar-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "批量二维码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/qrcode-batch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "二维码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "二维码扫描器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/qrcode-scanner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "简历生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/resume-builder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "签名生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/signature-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "URL Slug 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/slug-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "社交媒体图片生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/social-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "印章生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/stamp-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "SVG Blob形状生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/svg-blob.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "文字卡片生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/text-to-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "UUID/ULID 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "二维码名片生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/vcard-qr.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "波浪背景生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/wave-bg.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "白噪音生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/white-noise.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "WiFi 二维码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/wifi-qr.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "在线图表生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/chart-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "推特截图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/tweet-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "社交媒体尺寸指南",
+              "url": "https://tools.realtime-ai.chat/tools/generator/social-size-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "Instagram 帖子生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/instagram-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "UTM 链接生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/utm-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "WhatsApp 链接生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/whatsapp-link.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "YouTube 时间戳链接",
+              "url": "https://tools.realtime-ai.chat/tools/generator/youtube-timestamp.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "调色板提取器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/color-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "渐变背景生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/gradient-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "几何图案生成器",
+              "url": "https://tools.realtime-ai.chat/tools/generator/pattern-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "开源协议生成",
+              "url": "https://tools.realtime-ai.chat/tools/generator/license-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "Gitignore生成",
+              "url": "https://tools.realtime-ai.chat/tools/generator/gitignore-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "Barcode Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/barcode-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": "Credit Card Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/credit-card-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "Fake Data Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/fake-data-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "Favicon Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/favicon-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": ".htaccess Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/htaccess-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "Iban Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/iban-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "Lorem Ipsum 文本生成",
+              "url": "https://tools.realtime-ai.chat/tools/generator/lorem-ipsum.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 55,
+              "name": "Markdown Table",
+              "url": "https://tools.realtime-ai.chat/tools/generator/markdown-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 56,
+              "name": "Meta Tag Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/meta-tag-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 57,
+              "name": "Random Name Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/random-name-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 58,
+              "name": "Robots Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/robots-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 59,
+              "name": "Robots Txt Generator",
+              "url": "https://tools.realtime-ai.chat/tools/generator/robots-txt-generator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🎲</div>
+        <h1>生成器</h1>
+        <p class="cat-intro">
+          各类在线生成器，一键生成 UUID、密码、二维码、随机数、占位文本等，省去手动制作的麻烦。
+        </p>
+        <p class="cat-meta">59 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="avatar-generator.html">
+          <span class="cat-card-icon">👤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">头像生成器</span>
+            <span class="cat-card-desc">根据名字首字母生成头像</span>
+          </span>
+        </a>
+        <a class="cat-card" href="barcode.html">
+          <span class="cat-card-icon">|||</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">条形码生成器</span>
+            <span class="cat-card-desc">生成多种格式条形码：Code128、EAN、UPC 等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="business-card.html">
+          <span class="cat-card-icon">💼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">名片生成器</span>
+            <span class="cat-card-desc">
+              名片生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="certificate-gen.html">
+          <span class="cat-card-icon">🏆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">证书生成器</span>
+            <span class="cat-card-desc">
+              证书生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="code-card.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">代码卡片生成器</span>
+            <span class="cat-card-desc">
+              代码卡片生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="email-signature.html">
+          <span class="cat-card-icon">✉️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">邮件签名生成器</span>
+            <span class="cat-card-desc">生成专业的 HTML 邮件签名</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fake-data.html">
+          <span class="cat-card-icon">🎭</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">假数据生成器</span>
+            <span class="cat-card-desc">生成测试用的假数据：姓名、邮箱、地址、电话等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="github-contrib.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GitHub 贡献图生成器</span>
+            <span class="cat-card-desc">
+              GitHub 贡献图生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gradient-card.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">渐变色卡生成器</span>
+            <span class="cat-card-desc">
+              渐变色卡生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="invoice-gen.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">发票/收据生成器</span>
+            <span class="cat-card-desc">
+              发票/收据生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="logo-text.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Logo 文字生成器</span>
+            <span class="cat-card-desc">
+              Logo 文字生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meme-maker.html">
+          <span class="cat-card-icon">😂</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">表情包生成器</span>
+            <span class="cat-card-desc">
+              表情包生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="mesh-gradient.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Mesh渐变背景生成器</span>
+            <span class="cat-card-desc">
+              Mesh渐变背景生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="mock-data.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Mock 数据生成器</span>
+            <span class="cat-card-desc">生成模拟测试数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nanoid-generator.html">
+          <span class="cat-card-icon">🆔</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">NanoID 生成器</span>
+            <span class="cat-card-desc">生成紧凑的 URL 安全短 ID，可自定义长度和字符集</span>
+          </span>
+        </a>
+        <a class="cat-card" href="noise-texture.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">噪点纹理生成器</span>
+            <span class="cat-card-desc">
+              噪点纹理生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="password-generator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">密码生成器</span>
+            <span class="cat-card-desc">生成安全随机密码，支持自定义长度和字符类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pixel-editor.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">像素画编辑器</span>
+            <span class="cat-card-desc">
+              像素画编辑器，在线编辑，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="placeholder-image.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">占位图生成器</span>
+            <span class="cat-card-desc">生成自定义尺寸、颜色、文字的占位图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="progress-bar-generator.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">进度条生成器</span>
+            <span class="cat-card-desc">自定义样式生成 CSS 进度条，支持动画效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="qrcode-batch.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">批量二维码生成器</span>
+            <span class="cat-card-desc">
+              批量二维码生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="qrcode-generator.html">
+          <span class="cat-card-icon">▣</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">二维码生成器</span>
+            <span class="cat-card-desc">生成自定义颜色和大小的二维码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="qrcode-scanner.html">
+          <span class="cat-card-icon">📷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">二维码扫描器</span>
+            <span class="cat-card-desc">在线二维码扫描器，支持摄像头扫描和图片上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="resume-builder.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">简历生成器</span>
+            <span class="cat-card-desc">
+              简历生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="signature-gen.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">签名生成器</span>
+            <span class="cat-card-desc">
+              签名生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="slug-generator.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">URL Slug 生成器</span>
+            <span class="cat-card-desc">将文本转换为 URL 友好的 slug</span>
+          </span>
+        </a>
+        <a class="cat-card" href="social-image.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交媒体图片生成器</span>
+            <span class="cat-card-desc">
+              社交媒体图片生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="stamp-maker.html">
+          <span class="cat-card-icon">🔴</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">印章生成器</span>
+            <span class="cat-card-desc">
+              印章生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-blob.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG Blob形状生成器</span>
+            <span class="cat-card-desc">
+              SVG Blob形状生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-to-image.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字卡片生成器</span>
+            <span class="cat-card-desc">
+              文字卡片生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="uuid-generator.html">
+          <span class="cat-card-icon">#</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">UUID/ULID 生成器</span>
+            <span class="cat-card-desc">生成 UUID v4/v7 和 ULID，支持批量生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="vcard-qr.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">二维码名片生成器</span>
+            <span class="cat-card-desc">
+              二维码名片生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="wave-bg.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">波浪背景生成器</span>
+            <span class="cat-card-desc">
+              波浪背景生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="white-noise.html">
+          <span class="cat-card-icon">🎧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">白噪音生成器</span>
+            <span class="cat-card-desc">
+              白噪音生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="wifi-qr.html">
+          <span class="cat-card-icon">📶</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">WiFi 二维码生成器</span>
+            <span class="cat-card-desc">生成 WiFi 连接二维码，扫码即可连接网络</span>
+          </span>
+        </a>
+        <a class="cat-card" href="chart-generator.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">在线图表生成器</span>
+            <span class="cat-card-desc">在线生成柱状图、折线图、饼图等多种图表，支持CSV导入</span>
+          </span>
+        </a>
+        <a class="cat-card" href="tweet-generator.html">
+          <span class="cat-card-icon">🐦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">推特截图生成器</span>
+            <span class="cat-card-desc">在线生成仿真推特/X截图，自定义头像、用户名、内容</span>
+          </span>
+        </a>
+        <a class="cat-card" href="social-size-guide.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交媒体尺寸指南</span>
+            <span class="cat-card-desc">2024年最新社交平台图片尺寸参考，一键复制</span>
+          </span>
+        </a>
+        <a class="cat-card" href="instagram-generator.html">
+          <span class="cat-card-icon">📸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Instagram 帖子生成器</span>
+            <span class="cat-card-desc">在线生成 Instagram 风格帖子截图</span>
+          </span>
+        </a>
+        <a class="cat-card" href="utm-generator.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">UTM 链接生成器</span>
+            <span class="cat-card-desc">快速生成带 UTM 参数的营销追踪链接</span>
+          </span>
+        </a>
+        <a class="cat-card" href="whatsapp-link.html">
+          <span class="cat-card-icon">💬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">WhatsApp 链接生成器</span>
+            <span class="cat-card-desc">生成 WhatsApp 聊天链接，可预设消息内容</span>
+          </span>
+        </a>
+        <a class="cat-card" href="youtube-timestamp.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">YouTube 时间戳链接</span>
+            <span class="cat-card-desc">生成带时间戳的 YouTube 视频分享链接</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-extractor.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">调色板提取器</span>
+            <span class="cat-card-desc">
+              调色板提取器，一键提取，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gradient-generator.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">渐变背景生成器</span>
+            <span class="cat-card-desc">
+              渐变背景生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pattern-generator.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">几何图案生成器</span>
+            <span class="cat-card-desc">
+              几何图案生成器，一键在线生成，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="license-generator.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">开源协议生成</span>
+            <span class="cat-card-desc">生成开源协议文件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gitignore-generator.html">
+          <span class="cat-card-icon">🙈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gitignore生成</span>
+            <span class="cat-card-desc">生成.gitignore文件</span>
+          </span>
+        </a>
+        <a class="cat-card" href="barcode-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Barcode Generator</span>
+            <span class="cat-card-desc">
+              Barcode Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="credit-card-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Credit Card Generator</span>
+            <span class="cat-card-desc">
+              Credit Card Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="fake-data-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Fake Data Generator</span>
+            <span class="cat-card-desc">
+              Fake Data Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="favicon-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Favicon Generator</span>
+            <span class="cat-card-desc">
+              Favicon Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="htaccess-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">.htaccess Generator</span>
+            <span class="cat-card-desc">
+              .htaccess Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="iban-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Iban Generator</span>
+            <span class="cat-card-desc">
+              Iban Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="lorem-ipsum.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Lorem Ipsum 文本生成</span>
+            <span class="cat-card-desc">
+              Lorem Ipsum 文本生成，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-table.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown Table</span>
+            <span class="cat-card-desc">
+              Markdown Table，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meta-tag-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Meta Tag Generator</span>
+            <span class="cat-card-desc">
+              Meta Tag Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-name-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Random Name Generator</span>
+            <span class="cat-card-desc">
+              Random Name Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="robots-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Robots Generator</span>
+            <span class="cat-card-desc">
+              Robots Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="robots-txt-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Robots Txt Generator</span>
+            <span class="cat-card-desc">
+              Robots Txt Generator，在线使用，生成器，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/health/index.html
+++ b/tools/health/index.html
@@ -1,0 +1,602 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>医疗健康 - 在线工具合集（30个）| WebUtils</title>
+    <meta
+      name="description"
+      content="健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。"
+    />
+    <meta name="keywords" content="医疗健康,在线工具,免费工具,医疗健康大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/health/index.html" />
+    <meta property="og:title" content="医疗健康 - 在线工具合集（30个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/health/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="医疗健康 - 在线工具合集（30个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "医疗健康",
+            "item": "https://tools.realtime-ai.chat/tools/health/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "医疗健康 - 在线工具合集（30个）| WebUtils",
+        "description": "健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。",
+        "url": "https://tools.realtime-ai.chat/tools/health/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 30,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "月经周期追踪器",
+              "url": "https://tools.realtime-ai.chat/tools/health/menstrual-cycle.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "体脂率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/body-fat.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "每日饮水量计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/water-intake.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "卡路里需求计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/calorie-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "心率区间计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "血压分析工具",
+              "url": "https://tools.realtime-ai.chat/tools/health/blood-pressure.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "睡眠时间计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/sleep-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "理想体重计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/ideal-weight.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "酒精代谢计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/alcohol-metabolism.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "服药提醒器",
+              "url": "https://tools.realtime-ai.chat/tools/health/medication-reminder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "视力测试工具",
+              "url": "https://tools.realtime-ai.chat/tools/health/vision-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "听力测试工具",
+              "url": "https://tools.realtime-ai.chat/tools/health/hearing-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "血液酒精浓度计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/bac-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "跑步配速计算",
+              "url": "https://tools.realtime-ai.chat/tools/sports/running-pace.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "运动卡路里计算",
+              "url": "https://tools.realtime-ai.chat/tools/sports/calories-burned.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "症状自查",
+              "url": "https://tools.realtime-ai.chat/tools/health/symptom-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "运动间歇计时器",
+              "url": "https://tools.realtime-ai.chat/tools/fitness/workout-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "喝水提醒",
+              "url": "https://tools.realtime-ai.chat/tools/health/water-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "运动消耗卡路里计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/calorie-burn-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "健身记录",
+              "url": "https://tools.realtime-ai.chat/tools/fitness/workout-logger.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "比分记录器",
+              "url": "https://tools.realtime-ai.chat/tools/sports/score-keeper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "呼吸练习",
+              "url": "https://tools.realtime-ai.chat/tools/health/breathing-exercise.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "咖啡因代谢计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/caffeine-half-life-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "TDEE / 热量缺口计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/tdee-calorie-deficit-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "最大重复次数 / 1RM 计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/one-rep-max-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "血压记录日志",
+              "url": "https://tools.realtime-ai.chat/tools/health/blood-pressure-log.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "血糖记录追踪器",
+              "url": "https://tools.realtime-ai.chat/tools/health/blood-glucose-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "胆固醇比率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/cholesterol-ratio-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "宏量营养素计算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/macro-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "VO₂max 估算器",
+              "url": "https://tools.realtime-ai.chat/tools/health/vo2max-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">⚕️</div>
+        <h1>医疗健康</h1>
+        <p class="cat-intro">
+          健康管理类在线工具，涵盖 BMI、热量、心率、用药、体征计算等，帮助关注身体状况。
+        </p>
+        <p class="cat-meta">30 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="menstrual-cycle.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">月经周期追踪器</span>
+            <span class="cat-card-desc">追踪月经周期，预测排卵期</span>
+          </span>
+        </a>
+        <a class="cat-card" href="body-fat.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">体脂率计算器</span>
+            <span class="cat-card-desc">多种方法计算体脂率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="water-intake.html">
+          <span class="cat-card-icon">💧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">每日饮水量计算器</span>
+            <span class="cat-card-desc">计算每日推荐饮水量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="calorie-calculator.html">
+          <span class="cat-card-icon">🍎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">卡路里需求计算器</span>
+            <span class="cat-card-desc">计算每日热量需求和宏量营养素</span>
+          </span>
+        </a>
+        <a class="cat-card" href="heart-rate-zone.html">
+          <span class="cat-card-icon">❤️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">心率区间计算器</span>
+            <span class="cat-card-desc">计算运动心率区间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="blood-pressure.html">
+          <span class="cat-card-icon">🩺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">血压分析工具</span>
+            <span class="cat-card-desc">血压分类评估和健康建议</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sleep-calculator.html">
+          <span class="cat-card-icon">😴</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">睡眠时间计算器</span>
+            <span class="cat-card-desc">基于睡眠周期计算最佳时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ideal-weight.html">
+          <span class="cat-card-icon">🏃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">理想体重计算器</span>
+            <span class="cat-card-desc">多公式计算理想体重</span>
+          </span>
+        </a>
+        <a class="cat-card" href="alcohol-metabolism.html">
+          <span class="cat-card-icon">🍺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">酒精代谢计算器</span>
+            <span class="cat-card-desc">估算酒精代谢时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="medication-reminder.html">
+          <span class="cat-card-icon">💊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">服药提醒器</span>
+            <span class="cat-card-desc">药物管理和服药提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="vision-test.html">
+          <span class="cat-card-icon">👁️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">视力测试工具</span>
+            <span class="cat-card-desc">在线视力测试</span>
+          </span>
+        </a>
+        <a class="cat-card" href="hearing-test.html">
+          <span class="cat-card-icon">👂</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">听力测试工具</span>
+            <span class="cat-card-desc">在线听力测试</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bac-calculator.html">
+          <span class="cat-card-icon">🚗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">血液酒精浓度计算器</span>
+            <span class="cat-card-desc">计算血液酒精浓度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../sports/running-pace.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">跑步配速计算</span>
+            <span class="cat-card-desc">计算跑步配速和完赛时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../sports/calories-burned.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">运动卡路里计算</span>
+            <span class="cat-card-desc">计算各类运动消耗的卡路里</span>
+          </span>
+        </a>
+        <a class="cat-card" href="symptom-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">症状自查</span>
+            <span class="cat-card-desc">根据症状初步判断可能疾病</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../fitness/workout-timer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">运动间歇计时器</span>
+            <span class="cat-card-desc">HIIT间歇训练专用计时器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="water-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">喝水提醒</span>
+            <span class="cat-card-desc">记录每日饮水量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="calorie-burn-calculator.html">
+          <span class="cat-card-icon">🔥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">运动消耗卡路里计算器</span>
+            <span class="cat-card-desc">计算不同运动消耗的卡路里，帮助制定健身计划</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../fitness/workout-logger.html">
+          <span class="cat-card-icon">💪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">健身记录</span>
+            <span class="cat-card-desc">记录每日健身运动，追踪卡路里消耗</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../sports/score-keeper.html">
+          <span class="cat-card-icon">🏆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">比分记录器</span>
+            <span class="cat-card-desc">实时记录体育比赛比分，支持多种运动项目</span>
+          </span>
+        </a>
+        <a class="cat-card" href="breathing-exercise.html">
+          <span class="cat-card-icon">🧘</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">呼吸练习</span>
+            <span class="cat-card-desc">4-7-8呼吸法放松练习，减压助眠</span>
+          </span>
+        </a>
+        <a class="cat-card" href="caffeine-half-life-calculator.html">
+          <span class="cat-card-icon">☕</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">咖啡因代谢计算器</span>
+            <span class="cat-card-desc">
+              输入咖啡摄入时间和剂量，基于 5.7
+              小时半衰期计算体内咖啡因随时间的衰减曲线，估算最佳停止摄入时间。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tdee-calorie-deficit-calculator.html">
+          <span class="cat-card-icon">🔥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">TDEE / 热量缺口计算器</span>
+            <span class="cat-card-desc">
+              根据年龄、体重、身高和活动量计算每日总能量消耗（TDEE），并给出增重/减脂所需热量缺口建议。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="one-rep-max-calculator.html">
+          <span class="cat-card-icon">🏋️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">最大重复次数 / 1RM 计算器</span>
+            <span class="cat-card-desc">
+              输入已完成的重量和次数，用 Epley / Brzycki / Lombardi 等公式估算训练最大力量（1RM）。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="blood-pressure-log.html">
+          <span class="cat-card-icon">🩺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">血压记录日志</span>
+            <span class="cat-card-desc">
+              按日期记录收缩压/舒张压/心率，绘制折线趋势图，标记高血压区间，支持导出 CSV。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="blood-glucose-tracker.html">
+          <span class="cat-card-icon">🩸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">血糖记录追踪器</span>
+            <span class="cat-card-desc">
+              按餐前/餐后记录血糖值，绘制折线趋势图，标注正常/偏高/偏低区间，支持导出 CSV。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cholesterol-ratio-calculator.html">
+          <span class="cat-card-icon">🫀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">胆固醇比率计算器</span>
+            <span class="cat-card-desc">
+              输入总胆固醇、LDL、HDL、甘油三酯，计算 LDL/HDL 比值和非 HDL
+              胆固醇，给出心血管风险评估。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="macro-calculator.html">
+          <span class="cat-card-icon">🥗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宏量营养素计算器</span>
+            <span class="cat-card-desc">
+              根据 TDEE 和目标（减脂/增肌/维持），按比例分配每日蛋白质、脂肪、碳水化合物克数。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="vo2max-calculator.html">
+          <span class="cat-card-icon">🫁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">VO₂max 估算器</span>
+            <span class="cat-card-desc">
+              通过 Cooper 12 分钟跑或静息心率公式估算最大摄氧量（VO₂max），评估心肺适能等级。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/legal/index.html
+++ b/tools/legal/index.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>法律合规 - 在线工具合集（13个）| WebUtils</title>
+    <meta
+      name="description"
+      content="法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。"
+    />
+    <meta name="keywords" content="法律合规,在线工具,免费工具,法律合规大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/legal/index.html" />
+    <meta property="og:title" content="法律合规 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/legal/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="法律合规 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "法律合规",
+            "item": "https://tools.realtime-ai.chat/tools/legal/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "法律合规 - 在线工具合集（13个）| WebUtils",
+        "description": "法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。",
+        "url": "https://tools.realtime-ai.chat/tools/legal/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 13,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "隐私政策生成器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/privacy-policy.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "服务条款生成器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/terms-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "保密协议生成器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/nda-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "免责声明生成器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/disclaimer-gen.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "Cookie政策生成器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/cookie-policy.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "GDPR合规检查清单",
+              "url": "https://tools.realtime-ai.chat/tools/legal/gdpr-checklist.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "合同条款检查器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/contract-review.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "法律时限计算器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/legal-deadline.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "律师费用计算器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/lawyer-fee.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "法律术语词典",
+              "url": "https://tools.realtime-ai.chat/tools/legal/legal-glossary.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "协议对比工具",
+              "url": "https://tools.realtime-ai.chat/tools/legal/agreement-compare.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "签署日期格式化器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/signature-date.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "诉讼费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/legal/lawsuit-fee.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">⚖️</div>
+        <h1>法律合规</h1>
+        <p class="cat-intro">
+          法律与合规相关的在线工具，涵盖合同要素、隐私政策、赔偿计算、条款参考等常见场景。
+        </p>
+        <p class="cat-meta">13 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="privacy-policy.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">隐私政策生成器</span>
+            <span class="cat-card-desc">快速生成符合法规要求的隐私政策文档</span>
+          </span>
+        </a>
+        <a class="cat-card" href="terms-generator.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">服务条款生成器</span>
+            <span class="cat-card-desc">快速生成网站或应用的服务条款文档</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nda-generator.html">
+          <span class="cat-card-icon">🤐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">保密协议生成器</span>
+            <span class="cat-card-desc">生成保密协议/NDA文档</span>
+          </span>
+        </a>
+        <a class="cat-card" href="disclaimer-gen.html">
+          <span class="cat-card-icon">⚠️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">免责声明生成器</span>
+            <span class="cat-card-desc">生成各类免责声明文档</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cookie-policy.html">
+          <span class="cat-card-icon">🍪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cookie政策生成器</span>
+            <span class="cat-card-desc">生成符合法规的Cookie政策</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gdpr-checklist.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GDPR合规检查清单</span>
+            <span class="cat-card-desc">检查GDPR合规性的清单工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="contract-review.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">合同条款检查器</span>
+            <span class="cat-card-desc">检查合同中的常见风险条款</span>
+          </span>
+        </a>
+        <a class="cat-card" href="legal-deadline.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">法律时限计算器</span>
+            <span class="cat-card-desc">计算各类法律时限和期限</span>
+          </span>
+        </a>
+        <a class="cat-card" href="lawyer-fee.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">律师费用计算器</span>
+            <span class="cat-card-desc">估算律师费用和诉讼成本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="legal-glossary.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">法律术语词典</span>
+            <span class="cat-card-desc">查询常用法律术语的含义</span>
+          </span>
+        </a>
+        <a class="cat-card" href="agreement-compare.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">协议对比工具</span>
+            <span class="cat-card-desc">对比两份协议或合同的差异</span>
+          </span>
+        </a>
+        <a class="cat-card" href="signature-date.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">签署日期格式化器</span>
+            <span class="cat-card-desc">将日期转换为法律文书常用格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="lawsuit-fee.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">诉讼费计算器</span>
+            <span class="cat-card-desc">计算民事诉讼受理费用</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/life/index.html
+++ b/tools/life/index.html
@@ -1,0 +1,1096 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>生活工具 - 在线工具合集（67个）| WebUtils</title>
+    <meta
+      name="description"
+      content="贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。"
+    />
+    <meta name="keywords" content="生活工具,在线工具,免费工具,生活工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/life/index.html" />
+    <meta property="og:title" content="生活工具 - 在线工具合集（67个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/life/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="生活工具 - 在线工具合集（67个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生活工具",
+            "item": "https://tools.realtime-ai.chat/tools/life/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "生活工具 - 在线工具合集（67个）| WebUtils",
+        "description": "贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。",
+        "url": "https://tools.realtime-ai.chat/tools/life/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 67,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "年假计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/annual-leave.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "银行卡号校验",
+              "url": "https://tools.realtime-ai.chat/tools/life/bank-card-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "课堂弹幕",
+              "url": "https://tools.realtime-ai.chat/tools/life/classroom-danmaku.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "颜色选择器",
+              "url": "https://tools.realtime-ai.chat/tools/life/color-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "日期差计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/date-diff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "阶梯电费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/electricity-bill.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "体测成绩计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/fitness-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "身份证号校验",
+              "url": "https://tools.realtime-ai.chat/tools/life/id-card-validator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "个税计算器 2025",
+              "url": "https://tools.realtime-ai.chat/tools/life/income-tax-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "车牌归属地查询",
+              "url": "https://tools.realtime-ai.chat/tools/life/license-plate-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "金额大写转换",
+              "url": "https://tools.realtime-ai.chat/tools/life/money-uppercase.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "房贷计算器 2025",
+              "url": "https://tools.realtime-ai.chat/tools/life/mortgage-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "随机密码生成器",
+              "url": "https://tools.realtime-ai.chat/tools/life/password-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "随机数生成器",
+              "url": "https://tools.realtime-ai.chat/tools/life/random-number.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "随机点名器",
+              "url": "https://tools.realtime-ai.chat/tools/life/random-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "亲戚称呼计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/relative-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "退休年龄计算器 2025",
+              "url": "https://tools.realtime-ai.chat/tools/life/retirement-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "学生分组工具",
+              "url": "https://tools.realtime-ai.chat/tools/life/student-grouping.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "字数统计工具",
+              "url": "https://tools.realtime-ai.chat/tools/life/word-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "剪贴板历史",
+              "url": "https://tools.realtime-ai.chat/tools/life/clipboard-history.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "文件合并器",
+              "url": "https://tools.realtime-ai.chat/tools/life/file-merger.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "多功能计数器",
+              "url": "https://tools.realtime-ai.chat/tools/life/multi-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "快捷便签",
+              "url": "https://tools.realtime-ai.chat/tools/life/quick-notes.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "基础代谢率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/bmr-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "预产期计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/due-date.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "待办事项",
+              "url": "https://tools.realtime-ai.chat/tools/life/todo-list.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "便签笔记",
+              "url": "https://tools.realtime-ai.chat/tools/life/notes.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "书签管理器",
+              "url": "https://tools.realtime-ai.chat/tools/life/bookmark-manager.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "记账本",
+              "url": "https://tools.realtime-ai.chat/tools/life/expense-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "番茄钟",
+              "url": "https://tools.realtime-ai.chat/tools/life/pomodoro.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "节拍器",
+              "url": "https://tools.realtime-ai.chat/tools/music/metronome.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "单价对比",
+              "url": "https://tools.realtime-ai.chat/tools/shopping/unit-price.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "AA制分账",
+              "url": "https://tools.realtime-ai.chat/tools/social/split-bill.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "活动倒计时",
+              "url": "https://tools.realtime-ai.chat/tools/social/event-countdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "婴儿辅食指南",
+              "url": "https://tools.realtime-ai.chat/tools/parenting/baby-food.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "油漆用量计算",
+              "url": "https://tools.realtime-ai.chat/tools/diy/paint-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "编织行数计数",
+              "url": "https://tools.realtime-ai.chat/tools/diy/knitting-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "体感温度计算",
+              "url": "https://tools.realtime-ai.chat/tools/weather/feels-like-temp.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "紫外线指数查询",
+              "url": "https://tools.realtime-ai.chat/tools/weather/uv-index.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "月相查询",
+              "url": "https://tools.realtime-ai.chat/tools/astronomy/moon-phase.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "植物浇水提醒",
+              "url": "https://tools.realtime-ai.chat/tools/gardening/plant-watering.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "折扣价格计算器",
+              "url": "https://tools.realtime-ai.chat/tools/shopping/discount-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "习惯打卡追踪器",
+              "url": "https://tools.realtime-ai.chat/tools/life/habit-tracker-checkin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "商品价格对比器",
+              "url": "https://tools.realtime-ai.chat/tools/shopping/price-comparison.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "Countdown Timer",
+              "url": "https://tools.realtime-ai.chat/tools/life/countdown-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "Decision Maker",
+              "url": "https://tools.realtime-ai.chat/tools/life/decision-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "Habit Tracker",
+              "url": "https://tools.realtime-ai.chat/tools/life/habit-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "Pomodoro Timer",
+              "url": "https://tools.realtime-ai.chat/tools/life/pomodoro-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": "Stopwatch",
+              "url": "https://tools.realtime-ai.chat/tools/life/stopwatch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "Unit Converter",
+              "url": "https://tools.realtime-ai.chat/tools/life/unit-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "World Clock 世界时钟",
+              "url": "https://tools.realtime-ai.chat/tools/life/world-clock.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": "生日提醒器",
+              "url": "https://tools.realtime-ai.chat/tools/lifestyle/birthday-reminder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "每日正能量",
+              "url": "https://tools.realtime-ai.chat/tools/lifestyle/daily-affirmation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "喝水打卡",
+              "url": "https://tools.realtime-ai.chat/tools/lifestyle/water-intake-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 55,
+              "name": "礼物灵感记录",
+              "url": "https://tools.realtime-ai.chat/tools/social/gift-idea-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 56,
+              "name": "儿童生长曲线",
+              "url": "https://tools.realtime-ai.chat/tools/parenting/growth-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 57,
+              "name": "紫外线指数指南",
+              "url": "https://tools.realtime-ai.chat/tools/weather/uv-index-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 58,
+              "name": "浇水日程",
+              "url": "https://tools.realtime-ai.chat/tools/gardening/watering-schedule.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 59,
+              "name": "宝宝睡眠记录",
+              "url": "https://tools.realtime-ai.chat/tools/parenting/baby-sleep-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 60,
+              "name": "事件倒计时",
+              "url": "https://tools.realtime-ai.chat/tools/life/event-countdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 61,
+              "name": "材料用量计算",
+              "url": "https://tools.realtime-ai.chat/tools/diy/material-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 62,
+              "name": "和弦查询",
+              "url": "https://tools.realtime-ai.chat/tools/music/chord-finder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 63,
+              "name": "植物养护指南",
+              "url": "https://tools.realtime-ai.chat/tools/gardening/plant-care-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 64,
+              "name": "今夜观星",
+              "url": "https://tools.realtime-ai.chat/tools/astronomy/stargazing-tonight.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 65,
+              "name": "音阶查找器",
+              "url": "https://tools.realtime-ai.chat/tools/life/music-scale-finder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 66,
+              "name": "和弦进行生成器",
+              "url": "https://tools.realtime-ai.chat/tools/life/chord-progression-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 67,
+              "name": "个人碳排放计算器",
+              "url": "https://tools.realtime-ai.chat/tools/life/carbon-footprint-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🏠</div>
+        <h1>生活工具</h1>
+        <p class="cat-intro">
+          贴近日常的在线生活工具，覆盖记账、提醒、换算、查询等场景，让生活琐事更省心。
+        </p>
+        <p class="cat-meta">67 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="annual-leave.html">
+          <span class="cat-card-icon">🏖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">年假计算器</span>
+            <span class="cat-card-desc">根据工龄计算年假天数，支持新入职/离职折算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bank-card-validator.html">
+          <span class="cat-card-icon">💳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">银行卡号校验</span>
+            <span class="cat-card-desc">银行卡号 Luhn 算法校验，识别发卡行和卡类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="classroom-danmaku.html">
+          <span class="cat-card-icon">💬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">课堂弹幕</span>
+            <span class="cat-card-desc">纯前端课堂弹幕系统，支持多标签页同步，适合教学互动</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-picker.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色选择器</span>
+            <span class="cat-card-desc">颜色选择和转换工具，支持 RGB/HSL/HEX 格式，对比度预览</span>
+          </span>
+        </a>
+        <a class="cat-card" href="date-diff.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">日期差计算器</span>
+            <span class="cat-card-desc">计算两个日期之间的天数差，支持工作日统计和日期推算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="electricity-bill.html">
+          <span class="cat-card-icon">⚡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阶梯电费计算器</span>
+            <span class="cat-card-desc">根据各地阶梯电价政策计算居民用电费用</span>
+          </span>
+        </a>
+        <a class="cat-card" href="fitness-test.html">
+          <span class="cat-card-icon">🏃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">体测成绩计算器</span>
+            <span class="cat-card-desc">依据国家学生体质健康标准计算体测成绩</span>
+          </span>
+        </a>
+        <a class="cat-card" href="id-card-validator.html">
+          <span class="cat-card-icon">🪪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">身份证号校验</span>
+            <span class="cat-card-desc">身份证号码校验，解析籍贯、生日、性别等信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="income-tax-calculator.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">个税计算器 2025</span>
+            <span class="cat-card-desc">2025 个人所得税计算器，支持专项附加扣除</span>
+          </span>
+        </a>
+        <a class="cat-card" href="license-plate-lookup.html">
+          <span class="cat-card-icon">🚗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">车牌归属地查询</span>
+            <span class="cat-card-desc">查询车牌号码归属地，支持全国省市</span>
+          </span>
+        </a>
+        <a class="cat-card" href="money-uppercase.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">金额大写转换</span>
+            <span class="cat-card-desc">人民币金额小写转大写，支持财务场景</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mortgage-calculator.html">
+          <span class="cat-card-icon">🏠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">房贷计算器 2025</span>
+            <span class="cat-card-desc">2025 房贷计算器，支持商贷/公积金/组合贷，最新利率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="password-generator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机密码生成器</span>
+            <span class="cat-card-desc">
+              生成安全随机密码，支持自定义长度和字符类型，密码强度检测
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-number.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机数生成器</span>
+            <span class="cat-card-desc">生成随机数，模拟掷骰子和彩票号码</span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-picker.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机点名器</span>
+            <span class="cat-card-desc">随机点名工具，支持滚动动画、不重复抽取、历史记录</span>
+          </span>
+        </a>
+        <a class="cat-card" href="relative-calculator.html">
+          <span class="cat-card-icon">👨‍👩‍👧‍👦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">亲戚称呼计算器</span>
+            <span class="cat-card-desc">计算复杂亲戚关系的正确称呼</span>
+          </span>
+        </a>
+        <a class="cat-card" href="retirement-calculator.html">
+          <span class="cat-card-icon">👴</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">退休年龄计算器 2025</span>
+            <span class="cat-card-desc">2025 延迟退休政策计算器，计算法定退休年龄</span>
+          </span>
+        </a>
+        <a class="cat-card" href="student-grouping.html">
+          <span class="cat-card-icon">👥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">学生分组工具</span>
+            <span class="cat-card-desc">学生分组工具，支持随机/性别均衡/成绩均衡分组</span>
+          </span>
+        </a>
+        <a class="cat-card" href="word-counter.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字数统计工具</span>
+            <span class="cat-card-desc">统计文本字数、字符数、行数，分析字符频率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="clipboard-history.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">剪贴板历史</span>
+            <span class="cat-card-desc">
+              剪贴板历史，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="file-merger.html">
+          <span class="cat-card-icon">📎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文件合并器</span>
+            <span class="cat-card-desc">
+              文件合并器，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="multi-counter.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">多功能计数器</span>
+            <span class="cat-card-desc">
+              多功能计数器，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="quick-notes.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">快捷便签</span>
+            <span class="cat-card-desc">快捷便签，在线使用，生活工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bmr-calculator.html">
+          <span class="cat-card-icon">🏠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">基础代谢率计算器</span>
+            <span class="cat-card-desc">
+              基础代谢率计算器，快速计算结果，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="due-date.html">
+          <span class="cat-card-icon">🏠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">预产期计算器</span>
+            <span class="cat-card-desc">
+              预产期计算器，快速计算结果，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="todo-list.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">待办事项</span>
+            <span class="cat-card-desc">简单的待办事项管理</span>
+          </span>
+        </a>
+        <a class="cat-card" href="notes.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">便签笔记</span>
+            <span class="cat-card-desc">彩色便签笔记工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bookmark-manager.html">
+          <span class="cat-card-icon">🔖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">书签管理器</span>
+            <span class="cat-card-desc">网址书签管理工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="expense-tracker.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">记账本</span>
+            <span class="cat-card-desc">简单记账工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pomodoro.html">
+          <span class="cat-card-icon">🍅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">番茄钟</span>
+            <span class="cat-card-desc">番茄工作法计时器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../music/metronome.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">节拍器</span>
+            <span class="cat-card-desc">可调节的数字节拍器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../shopping/unit-price.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">单价对比</span>
+            <span class="cat-card-desc">比较不同规格商品的单价</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../social/split-bill.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AA制分账</span>
+            <span class="cat-card-desc">多人聚餐分账计算器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../social/event-countdown.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">活动倒计时</span>
+            <span class="cat-card-desc">重要活动倒计时提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../parenting/baby-food.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">婴儿辅食指南</span>
+            <span class="cat-card-desc">按月龄的辅食添加指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../diy/paint-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">油漆用量计算</span>
+            <span class="cat-card-desc">根据面积计算油漆用量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../diy/knitting-counter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">编织行数计数</span>
+            <span class="cat-card-desc">编织项目的行数和针数计数器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../weather/feels-like-temp.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">体感温度计算</span>
+            <span class="cat-card-desc">考虑风寒和湿度的体感温度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../weather/uv-index.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">紫外线指数查询</span>
+            <span class="cat-card-desc">紫外线强度和防护建议</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../astronomy/moon-phase.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">月相查询</span>
+            <span class="cat-card-desc">查看任意日期的月相</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../gardening/plant-watering.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">植物浇水提醒</span>
+            <span class="cat-card-desc">管理植物浇水时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../shopping/discount-calculator.html">
+          <span class="cat-card-icon">🏷️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">折扣价格计算器</span>
+            <span class="cat-card-desc">计算商品折扣价、优惠金额和最终价格</span>
+          </span>
+        </a>
+        <a class="cat-card" href="habit-tracker-checkin.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">习惯打卡追踪器</span>
+            <span class="cat-card-desc">追踪每日习惯，建立良好生活方式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../shopping/price-comparison.html">
+          <span class="cat-card-icon">🛒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">商品价格对比器</span>
+            <span class="cat-card-desc">对比不同商品价格、折扣和性价比</span>
+          </span>
+        </a>
+        <a class="cat-card" href="countdown-timer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Countdown Timer</span>
+            <span class="cat-card-desc">
+              Countdown Timer，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="decision-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Decision Maker</span>
+            <span class="cat-card-desc">
+              Decision Maker，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="habit-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Habit Tracker</span>
+            <span class="cat-card-desc">
+              Habit Tracker，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pomodoro-timer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Pomodoro Timer</span>
+            <span class="cat-card-desc">
+              Pomodoro Timer，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="stopwatch.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Stopwatch</span>
+            <span class="cat-card-desc">Stopwatch，在线使用，生活工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unit Converter</span>
+            <span class="cat-card-desc">
+              Unit Converter，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="world-clock.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">World Clock 世界时钟</span>
+            <span class="cat-card-desc">
+              World Clock 世界时钟，在线使用，生活工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="../lifestyle/birthday-reminder.html">
+          <span class="cat-card-icon">🎂</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">生日提醒器</span>
+            <span class="cat-card-desc">记录亲友生日，提前提醒，不再错过重要日子</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../lifestyle/daily-affirmation.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">每日正能量</span>
+            <span class="cat-card-desc">每日正能量语录，积极心理暗示，提升心理健康</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../lifestyle/water-intake-tracker.html">
+          <span class="cat-card-icon">💧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">喝水打卡</span>
+            <span class="cat-card-desc">记录每日饮水量，养成健康喝水习惯</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../social/gift-idea-tracker.html">
+          <span class="cat-card-icon">🎁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">礼物灵感记录</span>
+            <span class="cat-card-desc">记录亲友喜好和礼物灵感，节日送礼不再烦恼</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../parenting/growth-tracker.html">
+          <span class="cat-card-icon">👶</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">儿童生长曲线</span>
+            <span class="cat-card-desc">记录孩子身高体重，对照WHO生长曲线，监测生长发育</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../weather/uv-index-guide.html">
+          <span class="cat-card-icon">☀️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">紫外线指数指南</span>
+            <span class="cat-card-desc">了解UV指数等级，获取防晒建议，保护皮肤健康</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../gardening/watering-schedule.html">
+          <span class="cat-card-icon">🌱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">浇水日程</span>
+            <span class="cat-card-desc">植物浇水提醒，根据植物类型设置浇水频率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../parenting/baby-sleep-tracker.html">
+          <span class="cat-card-icon">👶</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宝宝睡眠记录</span>
+            <span class="cat-card-desc">记录宝宝睡眠时间，分析睡眠规律</span>
+          </span>
+        </a>
+        <a class="cat-card" href="event-countdown.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">事件倒计时</span>
+            <span class="cat-card-desc">重要日期倒计时，纪念日提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../diy/material-calculator.html">
+          <span class="cat-card-icon">🔨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">材料用量计算</span>
+            <span class="cat-card-desc">计算装修、DIY所需材料数量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../music/chord-finder.html">
+          <span class="cat-card-icon">🎸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">和弦查询</span>
+            <span class="cat-card-desc">吉他和弦指法查询，常用和弦指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../gardening/plant-care-guide.html">
+          <span class="cat-card-icon">🌿</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">植物养护指南</span>
+            <span class="cat-card-desc">常见植物养护建议和注意事项</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../astronomy/stargazing-tonight.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">今夜观星</span>
+            <span class="cat-card-desc">今夜可见星座和天体指南</span>
+          </span>
+        </a>
+        <a class="cat-card" href="music-scale-finder.html">
+          <span class="cat-card-icon">🎵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">音阶查找器</span>
+            <span class="cat-card-desc">
+              选择根音和调式（大调、小调、多利亚等），显示该音阶的全部音符、指板图（吉他/钢琴键盘），并标注和弦级数。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="chord-progression-generator.html">
+          <span class="cat-card-icon">🎵</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">和弦进行生成器</span>
+            <span class="cat-card-desc">
+              在选定调性中生成常用和弦进行（I-IV-V-I、ii-V-I
+              等），显示每个和弦的音符，并可切换不同调。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="carbon-footprint-calculator.html">
+          <span class="cat-card-icon">🌍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">个人碳排放计算器</span>
+            <span class="cat-card-desc">
+              填写交通、家庭用电、饮食习惯等信息，估算个人年度碳排放量（CO₂e），对比全国/世界人均并给出减排建议。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/math/index.html
+++ b/tools/math/index.html
@@ -1,0 +1,481 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>数学工具 - 在线工具合集（19个）| WebUtils</title>
+    <meta
+      name="description"
+      content="数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。"
+    />
+    <meta name="keywords" content="数学工具,在线工具,免费工具,数学工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/math/index.html" />
+    <meta property="og:title" content="数学工具 - 在线工具合集（19个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/math/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="数学工具 - 在线工具合集（19个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数学工具",
+            "item": "https://tools.realtime-ai.chat/tools/math/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "数学工具 - 在线工具合集（19个）| WebUtils",
+        "description": "数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。",
+        "url": "https://tools.realtime-ai.chat/tools/math/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 19,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Binary Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/binary-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Equation Solver",
+              "url": "https://tools.realtime-ai.chat/tools/math/equation-solver.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Factorial Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/factorial-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "Fraction Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/fraction-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "Gcd Lcm Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/gcd-lcm-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Logarithm Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/logarithm-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Matrix Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/matrix-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "Number Base Converter",
+              "url": "https://tools.realtime-ai.chat/tools/math/number-base-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "Percentage Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/percentage-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "Permutation Combination",
+              "url": "https://tools.realtime-ai.chat/tools/math/permutation-combination.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "Prime Checker",
+              "url": "https://tools.realtime-ai.chat/tools/math/prime-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Quadratic Equation",
+              "url": "https://tools.realtime-ai.chat/tools/math/quadratic-equation.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "Statistics Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/statistics-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Trigonometry Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/math/trigonometry-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "Unit Circle",
+              "url": "https://tools.realtime-ai.chat/tools/math/unit-circle.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "圆周率 π 数字查询器",
+              "url": "https://tools.realtime-ai.chat/tools/math/pi-digits-explorer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "斐波那契数列生成器",
+              "url": "https://tools.realtime-ai.chat/tools/math/fibonacci-sequence-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "质因数分解器",
+              "url": "https://tools.realtime-ai.chat/tools/math/prime-factorization.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "矩阵行列式 / 逆矩阵计算器",
+              "url": "https://tools.realtime-ai.chat/tools/math/matrix-determinant-inverse.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🔢</div>
+        <h1>数学工具</h1>
+        <p class="cat-intro">
+          数学相关的在线工具，涵盖方程、几何、统计、进制、概率等计算与求解需求。
+        </p>
+        <p class="cat-meta">19 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="binary-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Binary Calculator</span>
+            <span class="cat-card-desc">
+              Binary Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="equation-solver.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Equation Solver</span>
+            <span class="cat-card-desc">
+              Equation Solver，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="factorial-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Factorial Calculator</span>
+            <span class="cat-card-desc">
+              Factorial Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="fraction-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Fraction Calculator</span>
+            <span class="cat-card-desc">
+              Fraction Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gcd-lcm-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gcd Lcm Calculator</span>
+            <span class="cat-card-desc">
+              Gcd Lcm Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="logarithm-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Logarithm Calculator</span>
+            <span class="cat-card-desc">
+              Logarithm Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="matrix-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Matrix Calculator</span>
+            <span class="cat-card-desc">
+              Matrix Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-base-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Number Base Converter</span>
+            <span class="cat-card-desc">
+              Number Base Converter，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="percentage-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Percentage Calculator</span>
+            <span class="cat-card-desc">
+              Percentage Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="permutation-combination.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Permutation Combination</span>
+            <span class="cat-card-desc">
+              Permutation Combination，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="prime-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Prime Checker</span>
+            <span class="cat-card-desc">
+              Prime Checker，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="quadratic-equation.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Quadratic Equation</span>
+            <span class="cat-card-desc">
+              Quadratic Equation，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="statistics-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Statistics Calculator</span>
+            <span class="cat-card-desc">
+              Statistics Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="trigonometry-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Trigonometry Calculator</span>
+            <span class="cat-card-desc">
+              Trigonometry Calculator，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="unit-circle.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unit Circle</span>
+            <span class="cat-card-desc">
+              Unit Circle，在线使用，数学工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pi-digits-explorer.html">
+          <span class="cat-card-icon">π</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">圆周率 π 数字查询器</span>
+            <span class="cat-card-desc">
+              显示圆周率前 N
+              万位数字，支持搜索特定数字串出现的位置，以及基础统计（各数字频次分布）。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="fibonacci-sequence-generator.html">
+          <span class="cat-card-icon">🌀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">斐波那契数列生成器</span>
+            <span class="cat-card-desc">
+              生成斐波那契数列的前 N
+              项（支持高精度大整数），计算相邻项之比趋近黄金比例的过程，并可视化螺旋图案。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="prime-factorization.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">质因数分解器</span>
+            <span class="cat-card-desc">
+              将任意整数分解为质因数乘积（支持大数），以因数树或指数形式显示，并列出所有因数。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="matrix-determinant-inverse.html">
+          <span class="cat-card-icon">∑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">矩阵行列式 / 逆矩阵计算器</span>
+            <span class="cat-card-desc">
+              计算矩阵的行列式、逆矩阵、转置、特征值（2×2~4×4），显示逐步运算过程。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/media/index.html
+++ b/tools/media/index.html
@@ -1,0 +1,968 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>媒体工具 - 在线工具合集（57个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64 编码等，无需上传即可在浏览器内完成。"
+    />
+    <meta name="keywords" content="媒体工具,在线工具,免费工具,媒体工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/media/index.html" />
+    <meta property="og:title" content="媒体工具 - 在线工具合集（57个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64 编码等，无需上传即可在浏览器内完成。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/media/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="媒体工具 - 在线工具合集（57个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64 编码等，无需上传即可在浏览器内完成。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "媒体工具",
+            "item": "https://tools.realtime-ai.chat/tools/media/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "媒体工具 - 在线工具合集（57个）| WebUtils",
+        "description": "在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64 编码等，无需上传即可在浏览器内完成。",
+        "url": "https://tools.realtime-ai.chat/tools/media/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 57,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Favicon 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/media/favicon-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "GIF制作",
+              "url": "https://tools.realtime-ai.chat/tools/media/gif-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "GIF分割",
+              "url": "https://tools.realtime-ai.chat/tools/media/gif-splitter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "证件照裁剪",
+              "url": "https://tools.realtime-ai.chat/tools/media/id-photo.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "图片模糊",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-blur.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "图片加边框",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-border.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "图片拼接",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-collage.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "图片压缩器",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-compressor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "图片裁剪工具",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-cropper.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "图片滤镜",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-filter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "图片翻转",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-flip.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "图片马赛克",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-mosaic.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "图片尺寸调整",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-resizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "图片旋转",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-rotate.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "图片圆角",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-round-corner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "图片转素描",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-sketch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "图片分割",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-split.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "图片加文字",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-text.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "图片 Base64 转换",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-to-base64.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "音频剪辑器",
+              "url": "https://tools.realtime-ai.chat/tools/media/audio-cutter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "音频可视化器",
+              "url": "https://tools.realtime-ai.chat/tools/media/audio-visualizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "Base64 图片转换",
+              "url": "https://tools.realtime-ai.chat/tools/media/base64-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "图片批量调整尺寸",
+              "url": "https://tools.realtime-ai.chat/tools/media/batch-resize.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "摄像头拍照",
+              "url": "https://tools.realtime-ai.chat/tools/media/camera-demo.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "图片颜色提取器",
+              "url": "https://tools.realtime-ai.chat/tools/media/color-extractor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "EXIF 信息查看",
+              "url": "https://tools.realtime-ai.chat/tools/media/exif-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "ICO 图标查看器",
+              "url": "https://tools.realtime-ai.chat/tools/media/ico-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "图片 Base64 转换器",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-base64.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "图片颜色提取",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-color-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "图片对比滑块",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-compare.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "图片裁剪",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-crop.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "图片格式批量转换",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-format-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "图片像素化/马赛克",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-pixelate.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "图片压缩对比",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-resize.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "图片转 ASCII 艺术",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-to-ascii.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "图片水印",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-watermark.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "屏幕录制器",
+              "url": "https://tools.realtime-ai.chat/tools/media/screen-recorder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "截图美化工具",
+              "url": "https://tools.realtime-ai.chat/tools/media/screenshot-beautifier.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "语音转文字",
+              "url": "https://tools.realtime-ai.chat/tools/media/speech-to-text.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "SVG 编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/media/svg-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "SVG 占位图生成器 | HTML Tools",
+              "url": "https://tools.realtime-ai.chat/tools/media/svg-placeholder.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "SVG 渲染器",
+              "url": "https://tools.realtime-ai.chat/tools/media/svg-render.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "SVG 转 PNG",
+              "url": "https://tools.realtime-ai.chat/tools/media/svg-to-png.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "文字转图片",
+              "url": "https://tools.realtime-ai.chat/tools/media/text-to-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "文字转语音",
+              "url": "https://tools.realtime-ai.chat/tools/media/text-to-speech.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "视频缩略图提取器",
+              "url": "https://tools.realtime-ai.chat/tools/media/video-thumbnail.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "PDF合并工具",
+              "url": "https://tools.realtime-ai.chat/tools/media/pdf-merge.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "PDF拆分工具",
+              "url": "https://tools.realtime-ai.chat/tools/media/pdf-split.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": "PDF 压缩工具",
+              "url": "https://tools.realtime-ai.chat/tools/media/pdf-compress.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "图片取色器",
+              "url": "https://tools.realtime-ai.chat/tools/media/color-picker-image.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "图片滤镜编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-filters.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": "图片拼接器",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-stitcher.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "颜色选择器(媒体)",
+              "url": "https://tools.realtime-ai.chat/tools/media/color-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "曝光计算器",
+              "url": "https://tools.realtime-ai.chat/tools/photography/exposure-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 55,
+              "name": "黄金时刻计算器",
+              "url": "https://tools.realtime-ai.chat/tools/photography/golden-hour.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 56,
+              "name": "图片转 PDF",
+              "url": "https://tools.realtime-ai.chat/tools/media/image-to-pdf.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 57,
+              "name": "PDF 转图片",
+              "url": "https://tools.realtime-ai.chat/tools/media/pdf-to-image.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🖼️</div>
+        <h1>媒体工具</h1>
+        <p class="cat-intro">
+          在线图片与媒体处理工具，支持压缩、格式转换、取色、裁剪、Base64
+          编码等，无需上传即可在浏览器内完成。
+        </p>
+        <p class="cat-meta">57 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="favicon-generator.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Favicon 生成器</span>
+            <span class="cat-card-desc">
+              Favicon 生成器，一键在线生成，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gif-maker.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GIF制作</span>
+            <span class="cat-card-desc">将多张图片合成GIF</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gif-splitter.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GIF分割</span>
+            <span class="cat-card-desc">将GIF分割为单帧图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="id-photo.html">
+          <span class="cat-card-icon">🪪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">证件照裁剪</span>
+            <span class="cat-card-desc">裁剪标准尺寸证件照</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-blur.html">
+          <span class="cat-card-icon">🌫️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片模糊</span>
+            <span class="cat-card-desc">给图片添加模糊效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-border.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片加边框</span>
+            <span class="cat-card-desc">给图片添加各种边框</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-collage.html">
+          <span class="cat-card-icon">🧩</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片拼接</span>
+            <span class="cat-card-desc">将多张图片拼接在一起</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-compressor.html">
+          <span class="cat-card-icon">🗜️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片压缩器</span>
+            <span class="cat-card-desc">在浏览器中压缩图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-cropper.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片裁剪工具</span>
+            <span class="cat-card-desc">自由裁剪或按比例裁剪图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-filter.html">
+          <span class="cat-card-icon">✨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片滤镜</span>
+            <span class="cat-card-desc">给图片添加各种滤镜效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-flip.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片翻转</span>
+            <span class="cat-card-desc">水平或垂直翻转图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-mosaic.html">
+          <span class="cat-card-icon">🟦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片马赛克</span>
+            <span class="cat-card-desc">给图片局部添加马赛克</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-resizer.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片尺寸调整</span>
+            <span class="cat-card-desc">调整图片的宽高尺寸</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-rotate.html">
+          <span class="cat-card-icon">🔃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片旋转</span>
+            <span class="cat-card-desc">旋转图片任意角度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-round-corner.html">
+          <span class="cat-card-icon">⬜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片圆角</span>
+            <span class="cat-card-desc">给图片添加圆角</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-sketch.html">
+          <span class="cat-card-icon">✏️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片转素描</span>
+            <span class="cat-card-desc">将图片转换为素描风格</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-split.html">
+          <span class="cat-card-icon">🔲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片分割</span>
+            <span class="cat-card-desc">将图片分割为多块</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-text.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片加文字</span>
+            <span class="cat-card-desc">在图片上添加文字</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-to-base64.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片 Base64 转换</span>
+            <span class="cat-card-desc">图片与 Base64 编码互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="audio-cutter.html">
+          <span class="cat-card-icon">✂</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">音频剪辑器</span>
+            <span class="cat-card-desc">
+              音频剪辑器，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="audio-visualizer.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">音频可视化器</span>
+            <span class="cat-card-desc">音频频谱可视化，支持波形、柱状等多种显示模式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="base64-image.html">
+          <span class="cat-card-icon">64</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Base64 图片转换</span>
+            <span class="cat-card-desc">图片与 Base64 编码互转，支持多种格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="batch-resize.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片批量调整尺寸</span>
+            <span class="cat-card-desc">
+              图片批量调整尺寸，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="camera-demo.html">
+          <span class="cat-card-icon">📷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">摄像头拍照</span>
+            <span class="cat-card-desc">调用摄像头拍照并保存到本地</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-extractor.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片颜色提取器</span>
+            <span class="cat-card-desc">
+              图片颜色提取器，一键提取，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="exif-viewer.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">EXIF 信息查看</span>
+            <span class="cat-card-desc">查看图片的 EXIF 元数据和拍摄信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ico-viewer.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ICO 图标查看器</span>
+            <span class="cat-card-desc">查看和提取 ICO 文件中的所有图标尺寸</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-base64.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片 Base64 转换器</span>
+            <span class="cat-card-desc">
+              图片 Base64 转换器，多格式互转，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-color-picker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片颜色提取</span>
+            <span class="cat-card-desc">
+              图片颜色提取，一键提取，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-compare.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片对比滑块</span>
+            <span class="cat-card-desc">
+              图片对比滑块，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-crop.html">
+          <span class="cat-card-icon">✂</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片裁剪</span>
+            <span class="cat-card-desc">在线裁剪图片，支持自由裁剪和预设比例</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-format-converter.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片格式批量转换</span>
+            <span class="cat-card-desc">批量转换图片格式，支持 PNG/JPG/WebP/AVIF</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-pixelate.html">
+          <span class="cat-card-icon">▦</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片像素化/马赛克</span>
+            <span class="cat-card-desc">为图片添加像素化或马赛克效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-resize.html">
+          <span class="cat-card-icon">⚖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片压缩对比</span>
+            <span class="cat-card-desc">比较不同质量设置下的图片压缩效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-to-ascii.html">
+          <span class="cat-card-icon">A</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片转 ASCII 艺术</span>
+            <span class="cat-card-desc">图片转 ASCII 字符画</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-watermark.html">
+          <span class="cat-card-icon">💧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片水印</span>
+            <span class="cat-card-desc">为图片添加文字或图片水印，支持平铺</span>
+          </span>
+        </a>
+        <a class="cat-card" href="screen-recorder.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">屏幕录制器</span>
+            <span class="cat-card-desc">
+              屏幕录制器，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="screenshot-beautifier.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">截图美化工具</span>
+            <span class="cat-card-desc">给截图添加精美背景、阴影和圆角，一键生成分享图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="speech-to-text.html">
+          <span class="cat-card-icon">🎤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">语音转文字</span>
+            <span class="cat-card-desc">使用 Web Speech API 实时识别语音</span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-editor.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 编辑器</span>
+            <span class="cat-card-desc">
+              SVG 编辑器，在线编辑，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-placeholder.html">
+          <span class="cat-card-icon">▢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 占位图生成器 | HTML Tools</span>
+            <span class="cat-card-desc">SVG 占位图生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-render.html">
+          <span class="cat-card-icon">◇</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 渲染器</span>
+            <span class="cat-card-desc">将 SVG 代码渲染为 PNG/JPEG 图片</span>
+          </span>
+        </a>
+        <a class="cat-card" href="svg-to-png.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SVG 转 PNG</span>
+            <span class="cat-card-desc">将 SVG 矢量图转换为 PNG 位图格式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-to-image.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字转图片</span>
+            <span class="cat-card-desc">
+              文字转图片，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-to-speech.html">
+          <span class="cat-card-icon">🔊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文字转语音</span>
+            <span class="cat-card-desc">使用 Web Speech API 将文字转为语音朗读</span>
+          </span>
+        </a>
+        <a class="cat-card" href="video-thumbnail.html">
+          <span class="cat-card-icon">🎬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">视频缩略图提取器</span>
+            <span class="cat-card-desc">
+              视频缩略图提取器，一键提取，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pdf-merge.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PDF合并工具</span>
+            <span class="cat-card-desc">在线合并多个PDF文件，支持拖拽排序，完全本地处理</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pdf-split.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PDF拆分工具</span>
+            <span class="cat-card-desc">按页码范围或每N页拆分PDF，页面预览，本地处理</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pdf-compress.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PDF 压缩工具</span>
+            <span class="cat-card-desc">在线 PDF 压缩工具，纯前端处理，文件不上传服务器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-picker-image.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片取色器</span>
+            <span class="cat-card-desc">
+              图片取色器，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-filters.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片滤镜编辑器</span>
+            <span class="cat-card-desc">
+              图片滤镜编辑器，在线编辑，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-stitcher.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片拼接器</span>
+            <span class="cat-card-desc">
+              图片拼接器，在线使用，媒体工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="color-picker.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">颜色选择器(媒体)</span>
+            <span class="cat-card-desc">选择和转换颜色</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../photography/exposure-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">曝光计算器</span>
+            <span class="cat-card-desc">计算相机曝光参数组合</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../photography/golden-hour.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">黄金时刻计算器</span>
+            <span class="cat-card-desc">计算摄影黄金时刻和蓝调时刻</span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-to-pdf.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片转 PDF</span>
+            <span class="cat-card-desc">
+              多张图片合并为一个 PDF，可排序、设页面尺寸与方向，纯本地处理
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pdf-to-image.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PDF 转图片</span>
+            <span class="cat-card-desc">
+              将 PDF 每一页导出为 PNG 或 JPG 图片，可调清晰度，纯本地处理
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/network/index.html
+++ b/tools/network/index.html
@@ -1,0 +1,498 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>网络工具 - 在线工具合集（22个）| WebUtils</title>
+    <meta
+      name="description"
+      content="网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL 解析、端口参考等，便于排查与配置网络。"
+    />
+    <meta name="keywords" content="网络工具,在线工具,免费工具,网络工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/network/index.html" />
+    <meta property="og:title" content="网络工具 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL 解析、端口参考等，便于排查与配置网络。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/network/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="网络工具 - 在线工具合集（22个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL 解析、端口参考等，便于排查与配置网络。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "网络工具",
+            "item": "https://tools.realtime-ai.chat/tools/network/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "网络工具 - 在线工具合集（22个）| WebUtils",
+        "description": "网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL 解析、端口参考等，便于排查与配置网络。",
+        "url": "https://tools.realtime-ai.chat/tools/network/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 22,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "设备信息",
+              "url": "https://tools.realtime-ai.chat/tools/network/device-info.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "DNS 记录查询工具",
+              "url": "https://tools.realtime-ai.chat/tools/network/dns-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "HTTP 头解析器",
+              "url": "https://tools.realtime-ai.chat/tools/network/http-header-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "IP 地址计算器",
+              "url": "https://tools.realtime-ai.chat/tools/network/ip-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "IP 地址查询",
+              "url": "https://tools.realtime-ai.chat/tools/network/ip-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "IP 地址工具",
+              "url": "https://tools.realtime-ai.chat/tools/network/ip-tools.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "MAC 地址查询",
+              "url": "https://tools.realtime-ai.chat/tools/network/mac-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "端口查询器",
+              "url": "https://tools.realtime-ai.chat/tools/network/port-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "REST API 测试器",
+              "url": "https://tools.realtime-ai.chat/tools/network/rest-client.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "SSE 事件流调试器",
+              "url": "https://tools.realtime-ai.chat/tools/network/sse-client.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "SSL 证书解析器",
+              "url": "https://tools.realtime-ai.chat/tools/network/ssl-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "IP 子网计算器",
+              "url": "https://tools.realtime-ai.chat/tools/network/subnet-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "User Agent 解析器",
+              "url": "https://tools.realtime-ai.chat/tools/network/user-agent.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "WebSocket 调试器",
+              "url": "https://tools.realtime-ai.chat/tools/network/websocket-client.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "HTTP客户端",
+              "url": "https://tools.realtime-ai.chat/tools/network/http-client.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "Gravatar 头像查询",
+              "url": "https://tools.realtime-ai.chat/tools/network/gravatar-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "WHOIS查询",
+              "url": "https://tools.realtime-ai.chat/tools/network/whois-lookup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "SSL证书检查",
+              "url": "https://tools.realtime-ai.chat/tools/network/ssl-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Ip Subnet Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/network/ip-subnet-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "Port Info",
+              "url": "https://tools.realtime-ai.chat/tools/network/port-info.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Port Scanner",
+              "url": "https://tools.realtime-ai.chat/tools/network/port-scanner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "邮件头分析器",
+              "url": "https://tools.realtime-ai.chat/tools/network/email-header-analyzer.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🌐</div>
+        <h1>网络工具</h1>
+        <p class="cat-intro">
+          网络相关的在线工具，支持 IP 查询、子网计算、DNS、URL
+          解析、端口参考等，便于排查与配置网络。
+        </p>
+        <p class="cat-meta">22 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="device-info.html">
+          <span class="cat-card-icon">💻</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">设备信息</span>
+            <span class="cat-card-desc">查看设备、浏览器和系统的详细信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="dns-lookup.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">DNS 记录查询工具</span>
+            <span class="cat-card-desc">
+              DNS 记录查询工具，在线使用，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="http-header-parser.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTTP 头解析器</span>
+            <span class="cat-card-desc">HTTP 请求头解析</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ip-calculator.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">IP 地址计算器</span>
+            <span class="cat-card-desc">计算 IP 子网、网络地址、广播地址等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ip-lookup.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">IP 地址查询</span>
+            <span class="cat-card-desc">查询 IP 地址的地理位置信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ip-tools.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">IP 地址工具</span>
+            <span class="cat-card-desc">IP 地址工具集</span>
+          </span>
+        </a>
+        <a class="cat-card" href="mac-lookup.html">
+          <span class="cat-card-icon">🔎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">MAC 地址查询</span>
+            <span class="cat-card-desc">查询 MAC 地址对应的设备厂商信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="port-lookup.html">
+          <span class="cat-card-icon">🚪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">端口查询器</span>
+            <span class="cat-card-desc">常用端口号速查，包含服务名称和协议说明</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rest-client.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">REST API 测试器</span>
+            <span class="cat-card-desc">
+              REST API 测试器，在线验证，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="sse-client.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SSE 事件流调试器</span>
+            <span class="cat-card-desc">
+              SSE 事件流调试器，在线使用，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="ssl-parser.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SSL 证书解析器</span>
+            <span class="cat-card-desc">
+              SSL 证书解析器，在线分析，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="subnet-calculator.html">
+          <span class="cat-card-icon">📡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">IP 子网计算器</span>
+            <span class="cat-card-desc">计算 CIDR 子网范围、可用 IP 数量和掩码转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="user-agent.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">User Agent 解析器</span>
+            <span class="cat-card-desc">User-Agent 检测</span>
+          </span>
+        </a>
+        <a class="cat-card" href="websocket-client.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">WebSocket 调试器</span>
+            <span class="cat-card-desc">
+              WebSocket 调试器，在线使用，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="http-client.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTTP客户端</span>
+            <span class="cat-card-desc">在线API请求测试工具，支持多种请求方法和自定义配置</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gravatar-checker.html">
+          <span class="cat-card-icon">👤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Gravatar 头像查询</span>
+            <span class="cat-card-desc">通过邮箱查询 Gravatar 全球通用头像</span>
+          </span>
+        </a>
+        <a class="cat-card" href="whois-lookup.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">WHOIS查询</span>
+            <span class="cat-card-desc">域名WHOIS信息查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ssl-checker.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SSL证书检查</span>
+            <span class="cat-card-desc">检查网站SSL证书</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ip-subnet-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Ip Subnet Calculator</span>
+            <span class="cat-card-desc">
+              Ip Subnet Calculator，在线使用，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="port-info.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Port Info</span>
+            <span class="cat-card-desc">Port Info，在线使用，网络工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="port-scanner.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Port Scanner</span>
+            <span class="cat-card-desc">
+              Port Scanner，在线使用，网络工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="email-header-analyzer.html">
+          <span class="cat-card-icon">📧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">邮件头分析器</span>
+            <span class="cat-card-desc">
+              粘贴原始邮件头（Raw Email Headers），解析 Received 链路、DKIM 签名、SPF、DMARC
+              结果，可视化追踪邮件路由。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/office/index.html
+++ b/tools/office/index.html
@@ -1,0 +1,686 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>办公效率 - 在线工具合集（34个）| WebUtils</title>
+    <meta
+      name="description"
+      content="提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。"
+    />
+    <meta name="keywords" content="办公效率,在线工具,免费工具,办公效率大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/office/index.html" />
+    <meta property="og:title" content="办公效率 - 在线工具合集（34个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="办公效率 - 在线工具合集（34个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "办公效率 - 在线工具合集（34个）| WebUtils",
+        "description": "提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。",
+        "url": "https://tools.realtime-ai.chat/tools/office/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 34,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "会议时间安排",
+              "url": "https://tools.realtime-ai.chat/tools/office/meeting-scheduler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "工时统计",
+              "url": "https://tools.realtime-ai.chat/tools/office/work-hours.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "发票税额计算器",
+              "url": "https://tools.realtime-ai.chat/tools/office/invoice-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "Agenda Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/agenda-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "Attendance Sheet",
+              "url": "https://tools.realtime-ai.chat/tools/office/attendance-sheet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Barcode Label",
+              "url": "https://tools.realtime-ai.chat/tools/office/barcode-label.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "名片制作",
+              "url": "https://tools.realtime-ai.chat/tools/office/business-card-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "清单制作",
+              "url": "https://tools.realtime-ai.chat/tools/office/checklist-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "Contract Template",
+              "url": "https://tools.realtime-ai.chat/tools/office/contract-template.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "Expense Report",
+              "url": "https://tools.realtime-ai.chat/tools/office/expense-report.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "甘特图",
+              "url": "https://tools.realtime-ai.chat/tools/office/gantt-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Invoice Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "Label Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/label-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Leave Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/office/leave-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "Letter Template",
+              "url": "https://tools.realtime-ai.chat/tools/office/letter-template.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "Letterhead Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/letterhead-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "Meeting Timer",
+              "url": "https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "Minutes Template",
+              "url": "https://tools.realtime-ai.chat/tools/office/minutes-template.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Org Chart",
+              "url": "https://tools.realtime-ai.chat/tools/office/org-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "Overtime Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/office/overtime-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Presentation Timer",
+              "url": "https://tools.realtime-ai.chat/tools/office/presentation-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "Project Timeline",
+              "url": "https://tools.realtime-ai.chat/tools/office/project-timeline.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "Purchase Order",
+              "url": "https://tools.realtime-ai.chat/tools/office/purchase-order.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Quotation Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "Receipt Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/receipt-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "Resume Maker",
+              "url": "https://tools.realtime-ai.chat/tools/office/resume-maker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "Seating Chart",
+              "url": "https://tools.realtime-ai.chat/tools/office/seating-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "Signature Pad",
+              "url": "https://tools.realtime-ai.chat/tools/office/signature-pad.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Slide Notes",
+              "url": "https://tools.realtime-ai.chat/tools/office/slide-notes.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "Stamp Generator",
+              "url": "https://tools.realtime-ai.chat/tools/office/stamp-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "Task Tracker",
+              "url": "https://tools.realtime-ai.chat/tools/office/task-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "Timesheet",
+              "url": "https://tools.realtime-ai.chat/tools/office/timesheet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "Work Log",
+              "url": "https://tools.realtime-ai.chat/tools/office/work-log.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "会议成本计算器",
+              "url": "https://tools.realtime-ai.chat/tools/office/meeting-cost-calculator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📊</div>
+        <h1>办公效率</h1>
+        <p class="cat-intro">
+          提升办公效率的在线工具，涵盖文档、表格、计时、清单、格式处理等日常办公场景。
+        </p>
+        <p class="cat-meta">34 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="meeting-scheduler.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">会议时间安排</span>
+            <span class="cat-card-desc">找到适合所有人的会议时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="work-hours.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">工时统计</span>
+            <span class="cat-card-desc">记录和统计工作时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="invoice-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">发票税额计算器</span>
+            <span class="cat-card-desc">计算增值税发票金额和税额</span>
+          </span>
+        </a>
+        <a class="cat-card" href="agenda-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Agenda Maker</span>
+            <span class="cat-card-desc">
+              Agenda Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="attendance-sheet.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Attendance Sheet</span>
+            <span class="cat-card-desc">
+              Attendance Sheet，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="barcode-label.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Barcode Label</span>
+            <span class="cat-card-desc">
+              Barcode Label，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="business-card-maker.html">
+          <span class="cat-card-icon">🪪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">名片制作</span>
+            <span class="cat-card-desc">在线名片制作工具，多种风格模板，支持自定义颜色和打印</span>
+          </span>
+        </a>
+        <a class="cat-card" href="checklist-maker.html">
+          <span class="cat-card-icon">☑️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">清单制作</span>
+            <span class="cat-card-desc">创建待办清单，支持拖拽排序、进度追踪、打印导出</span>
+          </span>
+        </a>
+        <a class="cat-card" href="contract-template.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Contract Template</span>
+            <span class="cat-card-desc">
+              Contract Template，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="expense-report.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Expense Report</span>
+            <span class="cat-card-desc">
+              Expense Report，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="gantt-chart.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">甘特图</span>
+            <span class="cat-card-desc">
+              在线甘特图工具，可视化项目进度管理，支持导出图片和打印
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="invoice-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Invoice Maker</span>
+            <span class="cat-card-desc">
+              Invoice Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="label-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Label Maker</span>
+            <span class="cat-card-desc">
+              Label Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="leave-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Leave Calculator</span>
+            <span class="cat-card-desc">
+              Leave Calculator，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="letter-template.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Letter Template</span>
+            <span class="cat-card-desc">
+              Letter Template，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="letterhead-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Letterhead Maker</span>
+            <span class="cat-card-desc">
+              Letterhead Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meeting-timer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Meeting Timer</span>
+            <span class="cat-card-desc">
+              Meeting Timer，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="minutes-template.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Minutes Template</span>
+            <span class="cat-card-desc">
+              Minutes Template，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="org-chart.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Org Chart</span>
+            <span class="cat-card-desc">Org Chart，在线使用，办公效率，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="overtime-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Overtime Calculator</span>
+            <span class="cat-card-desc">
+              Overtime Calculator，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="presentation-timer.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Presentation Timer</span>
+            <span class="cat-card-desc">
+              Presentation Timer，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="project-timeline.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Project Timeline</span>
+            <span class="cat-card-desc">
+              Project Timeline，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="purchase-order.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Purchase Order</span>
+            <span class="cat-card-desc">
+              Purchase Order，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="quotation-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Quotation Maker</span>
+            <span class="cat-card-desc">
+              Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="receipt-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Receipt Maker</span>
+            <span class="cat-card-desc">
+              Receipt Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="resume-maker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Resume Maker</span>
+            <span class="cat-card-desc">
+              Resume Maker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="seating-chart.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Seating Chart</span>
+            <span class="cat-card-desc">
+              Seating Chart，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="signature-pad.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Signature Pad</span>
+            <span class="cat-card-desc">
+              Signature Pad，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="slide-notes.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Slide Notes</span>
+            <span class="cat-card-desc">
+              Slide Notes，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="stamp-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Stamp Generator</span>
+            <span class="cat-card-desc">
+              Stamp Generator，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="task-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Task Tracker</span>
+            <span class="cat-card-desc">
+              Task Tracker，在线使用，办公效率，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="timesheet.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Timesheet</span>
+            <span class="cat-card-desc">Timesheet，在线使用，办公效率，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="work-log.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Work Log</span>
+            <span class="cat-card-desc">Work Log，在线使用，办公效率，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="meeting-cost-calculator.html">
+          <span class="cat-card-icon">💼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">会议成本计算器</span>
+            <span class="cat-card-desc">计算会议的人力成本，优化会议效率</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/pets/index.html
+++ b/tools/pets/index.html
@@ -1,0 +1,274 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>宠物工具 - 在线工具合集（6个）| WebUtils</title>
+    <meta
+      name="description"
+      content="养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。"
+    />
+    <meta name="keywords" content="宠物工具,在线工具,免费工具,宠物工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/pets/index.html" />
+    <meta property="og:title" content="宠物工具 - 在线工具合集（6个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/pets/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="宠物工具 - 在线工具合集（6个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "宠物工具",
+            "item": "https://tools.realtime-ai.chat/tools/pets/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "宠物工具 - 在线工具合集（6个）| WebUtils",
+        "description": "养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。",
+        "url": "https://tools.realtime-ai.chat/tools/pets/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 6,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "宠物年龄计算",
+              "url": "https://tools.realtime-ai.chat/tools/pets/pet-age.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "宠物喂食量计算",
+              "url": "https://tools.realtime-ai.chat/tools/pets/pet-food-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "宠物年龄计算器",
+              "url": "https://tools.realtime-ai.chat/tools/pets/pet-age-calculator-cn.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "猫狗年龄计算器",
+              "url": "https://tools.realtime-ai.chat/tools/pets/pet-age-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "宠物喂食提醒",
+              "url": "https://tools.realtime-ai.chat/tools/pets/feeding-schedule.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "宠物用药剂量计算器",
+              "url": "https://tools.realtime-ai.chat/tools/pets/pet-medication-dosage.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🐾</div>
+        <h1>宠物工具</h1>
+        <p class="cat-intro">
+          养宠相关的在线工具，涵盖年龄换算、喂食量、健康提醒等宠物日常照护需求。
+        </p>
+        <p class="cat-meta">6 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="pet-age.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宠物年龄计算</span>
+            <span class="cat-card-desc">计算宠物对应的人类年龄</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pet-food-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宠物喂食量计算</span>
+            <span class="cat-card-desc">根据体重计算宠物每日喂食量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pet-age-calculator-cn.html">
+          <span class="cat-card-icon">🐾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宠物年龄计算器</span>
+            <span class="cat-card-desc">将猫狗年龄转换为人类年龄</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pet-age-calculator.html">
+          <span class="cat-card-icon">🐾</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">猫狗年龄计算器</span>
+            <span class="cat-card-desc">计算宠物相当于人类的年龄，支持狗、猫等常见宠物</span>
+          </span>
+        </a>
+        <a class="cat-card" href="feeding-schedule.html">
+          <span class="cat-card-icon">🍖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宠物喂食提醒</span>
+            <span class="cat-card-desc">宠物喂食时间提醒，记录喂食历史</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pet-medication-dosage.html">
+          <span class="cat-card-icon">💊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">宠物用药剂量计算器</span>
+            <span class="cat-card-desc">
+              根据宠物体重和兽医常用剂量标准（mg/kg），计算常见非处方用药（驱虫药、消炎药等）的参考剂量范围。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/privacy/index.html
+++ b/tools/privacy/index.html
@@ -1,0 +1,391 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>隐私安全 - 在线工具合集（14个）| WebUtils</title>
+    <meta
+      name="description"
+      content="注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。"
+    />
+    <meta name="keywords" content="隐私安全,在线工具,免费工具,隐私安全大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/privacy/index.html" />
+    <meta property="og:title" content="隐私安全 - 在线工具合集（14个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/privacy/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="隐私安全 - 在线工具合集（14个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "隐私安全",
+            "item": "https://tools.realtime-ai.chat/tools/privacy/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "隐私安全 - 在线工具合集（14个）| WebUtils",
+        "description": "注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。",
+        "url": "https://tools.realtime-ai.chat/tools/privacy/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 14,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "信用卡验证器",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/credit-card.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "AES 加密解密",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/encrypt-decrypt.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "EXIF 信息移除器",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/exif-remover.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "文件哈希校验",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/file-hash.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "身份证号码解析",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/idcard-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "日志脱敏",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/log-masker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "文件元数据查看器",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/metadata-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "密码强度检测",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/password-strength.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "随机身份生成",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/random-identity.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "随机密钥生成器",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/random-key.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "RSA 加密解密",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/rsa-tool.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "图片隐写术工具",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/steganography.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "文本加密解密",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/text-encrypt.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "文本隐写（零宽字符）工具",
+              "url": "https://tools.realtime-ai.chat/tools/privacy/zero-width-text-steganography.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🔒</div>
+        <h1>隐私安全</h1>
+        <p class="cat-intro">
+          注重隐私的在线工具，涵盖数据脱敏、匿名化、本地加密等，所有运算在本地进行，保护敏感信息不外泄。
+        </p>
+        <p class="cat-meta">14 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="credit-card.html">
+          <span class="cat-card-icon">💳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">信用卡验证器</span>
+            <span class="cat-card-desc">信用卡号验证</span>
+          </span>
+        </a>
+        <a class="cat-card" href="encrypt-decrypt.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">AES 加密解密</span>
+            <span class="cat-card-desc">使用 AES-GCM 算法进行文本加密和解密</span>
+          </span>
+        </a>
+        <a class="cat-card" href="exif-remover.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">EXIF 信息移除器</span>
+            <span class="cat-card-desc">
+              EXIF 信息移除器，在线使用，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="file-hash.html">
+          <span class="cat-card-icon">✓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文件哈希校验</span>
+            <span class="cat-card-desc">计算文件的 MD5、SHA-1、SHA-256 哈希值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="idcard-parser.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">身份证号码解析</span>
+            <span class="cat-card-desc">
+              身份证号码解析，在线分析，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="log-masker.html">
+          <span class="cat-card-icon">***</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">日志脱敏</span>
+            <span class="cat-card-desc">自动识别并脱敏日志中的 IP、邮箱、手机号等敏感信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="metadata-viewer.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文件元数据查看器</span>
+            <span class="cat-card-desc">
+              文件元数据查看器，即时预览，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="password-strength.html">
+          <span class="cat-card-icon">💪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">密码强度检测</span>
+            <span class="cat-card-desc">检测密码强度，分析安全性和破解时间估算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-identity.html">
+          <span class="cat-card-icon">🎭</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机身份生成</span>
+            <span class="cat-card-desc">生成随机假身份信息用于测试和隐私保护</span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-key.html">
+          <span class="cat-card-icon">🔑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机密钥生成器</span>
+            <span class="cat-card-desc">随机密钥生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rsa-tool.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">RSA 加密解密</span>
+            <span class="cat-card-desc">
+              RSA 加密解密，安全加解密，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="steganography.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片隐写术工具</span>
+            <span class="cat-card-desc">
+              图片隐写术工具，在线使用，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-encrypt.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本加密解密</span>
+            <span class="cat-card-desc">
+              文本加密解密，安全加解密，隐私安全，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="zero-width-text-steganography.html">
+          <span class="cat-card-icon">👁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本隐写（零宽字符）工具</span>
+            <span class="cat-card-desc">
+              将隐藏信息编码为零宽字符（U+200B
+              等）嵌入普通文本，或从文本中提取/检测隐藏的零宽字符内容。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/productivity/index.html
+++ b/tools/productivity/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>效率工具 - 在线工具合集（7个）| WebUtils</title>
+    <meta
+      name="description"
+      content="提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。"
+    />
+    <meta name="keywords" content="效率工具,在线工具,免费工具,效率工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/productivity/index.html" />
+    <meta property="og:title" content="效率工具 - 在线工具合集（7个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/productivity/index.html"
+    />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="效率工具 - 在线工具合集（7个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "效率工具",
+            "item": "https://tools.realtime-ai.chat/tools/productivity/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "效率工具 - 在线工具合集（7个）| WebUtils",
+        "description": "提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。",
+        "url": "https://tools.realtime-ai.chat/tools/productivity/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 7,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "番茄钟增强版",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/pomodoro-plus.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "习惯追踪",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/habit-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "跨时区会议安排",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/timezone-meeting.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "番茄钟计时器(高效专注)",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/pomodoro-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "专注力计时器",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/focus-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "阅读时间计算",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/reading-time.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "ICS 日历事件生成器",
+              "url": "https://tools.realtime-ai.chat/tools/productivity/ics-calendar-generator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🎯</div>
+        <h1>效率工具</h1>
+        <p class="cat-intro">提升个人效率的在线工具，涵盖待办、专注计时、习惯追踪、决策辅助等。</p>
+        <p class="cat-meta">7 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="pomodoro-plus.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">番茄钟增强版</span>
+            <span class="cat-card-desc">带统计的番茄工作法计时器</span>
+          </span>
+        </a>
+        <a class="cat-card" href="habit-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">习惯追踪</span>
+            <span class="cat-card-desc">记录和追踪每日习惯养成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="timezone-meeting.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">跨时区会议安排</span>
+            <span class="cat-card-desc">找到适合不同时区的会议时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pomodoro-timer.html">
+          <span class="cat-card-icon">🍅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">番茄钟计时器(高效专注)</span>
+            <span class="cat-card-desc">专注工作25分钟，休息5分钟，提升工作效率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="focus-timer.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">专注力计时器</span>
+            <span class="cat-card-desc">极简专注计时器，帮助保持专注，提升工作效率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="reading-time.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阅读时间计算</span>
+            <span class="cat-card-desc">计算文章阅读时间，预估阅读所需分钟数</span>
+          </span>
+        </a>
+        <a class="cat-card" href="ics-calendar-generator.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">ICS 日历事件生成器</span>
+            <span class="cat-card-desc">
+              填写事件标题、时间、地点、重复规则，生成标准 .ics 文件，可直接导入 Google Calendar /
+              Apple 日历 / Outlook。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/realestate/index.html
+++ b/tools/realestate/index.html
@@ -1,0 +1,404 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>房产工具 - 在线工具合集（16个）| WebUtils</title>
+    <meta
+      name="description"
+      content="房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。"
+    />
+    <meta name="keywords" content="房产工具,在线工具,免费工具,房产工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/realestate/index.html" />
+    <meta property="og:title" content="房产工具 - 在线工具合集（16个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/realestate/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="房产工具 - 在线工具合集（16个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "房产工具",
+            "item": "https://tools.realtime-ai.chat/tools/realestate/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "房产工具 - 在线工具合集（16个）| WebUtils",
+        "description": "房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。",
+        "url": "https://tools.realtime-ai.chat/tools/realestate/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 16,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "房贷月供计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/mortgage.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "首付计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/down-payment.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "提前还款计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/prepayment.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "贷款方案对比",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/loan-compare.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "组合贷款计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/combo-loan.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "契税计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/deed-tax.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "房产交易税费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/property-tax.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "租房成本计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/rental-cost.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "租金回报率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/rent-yield.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "租房vs买房分析",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/rent-vs-buy.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "房产投资ROI计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/property-roi.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "LPR利率调整计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/lpr-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "物业费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/property-fee.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "装修预算计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/decoration-budget.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "装修材料用量计算器",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/material-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "Rent Vs Buy",
+              "url": "https://tools.realtime-ai.chat/tools/realestate/rent-vs-buy-cn.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🏠</div>
+        <h1>房产工具</h1>
+        <p class="cat-intro">
+          房产与租房相关的在线工具，涵盖房贷、首付、税费、面积、租金计算，辅助购房与租房决策。
+        </p>
+        <p class="cat-meta">16 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="mortgage.html">
+          <span class="cat-card-icon">🏠</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">房贷月供计算器</span>
+            <span class="cat-card-desc">计算房贷月供，对比两种还款方式</span>
+          </span>
+        </a>
+        <a class="cat-card" href="down-payment.html">
+          <span class="cat-card-icon">💰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">首付计算器</span>
+            <span class="cat-card-desc">计算购房首付款及贷款额度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="prepayment.html">
+          <span class="cat-card-icon">📉</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">提前还款计算器</span>
+            <span class="cat-card-desc">计算提前还款节省的利息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="loan-compare.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">贷款方案对比</span>
+            <span class="cat-card-desc">对比不同贷款方案的成本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="combo-loan.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">组合贷款计算器</span>
+            <span class="cat-card-desc">计算公积金+商贷组合月供</span>
+          </span>
+        </a>
+        <a class="cat-card" href="deed-tax.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">契税计算器</span>
+            <span class="cat-card-desc">计算购房契税费用</span>
+          </span>
+        </a>
+        <a class="cat-card" href="property-tax.html">
+          <span class="cat-card-icon">🏛️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">房产交易税费计算器</span>
+            <span class="cat-card-desc">计算房产交易相关税费</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rental-cost.html">
+          <span class="cat-card-icon">🏢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">租房成本计算器</span>
+            <span class="cat-card-desc">计算租房总成本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rent-yield.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">租金回报率计算器</span>
+            <span class="cat-card-desc">计算房产出租的租金回报率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rent-vs-buy.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">租房vs买房分析</span>
+            <span class="cat-card-desc">分析租房和买房的长期成本对比</span>
+          </span>
+        </a>
+        <a class="cat-card" href="property-roi.html">
+          <span class="cat-card-icon">💹</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">房产投资ROI计算器</span>
+            <span class="cat-card-desc">计算房产投资的投资回报率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="lpr-calc.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">LPR利率调整计算器</span>
+            <span class="cat-card-desc">计算LPR调整后的月供变化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="property-fee.html">
+          <span class="cat-card-icon">🏘️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">物业费计算器</span>
+            <span class="cat-card-desc">计算年度物业管理费用</span>
+          </span>
+        </a>
+        <a class="cat-card" href="decoration-budget.html">
+          <span class="cat-card-icon">🔨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">装修预算计算器</span>
+            <span class="cat-card-desc">估算房屋装修预算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="material-calc.html">
+          <span class="cat-card-icon">📐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">装修材料用量计算器</span>
+            <span class="cat-card-desc">计算装修所需材料用量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="rent-vs-buy-cn.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Rent Vs Buy</span>
+            <span class="cat-card-desc">
+              Rent Vs Buy，在线使用，房产工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/security/index.html
+++ b/tools/security/index.html
@@ -1,0 +1,379 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>安全工具 - 在线工具合集（13个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。"
+    />
+    <meta name="keywords" content="安全工具,在线工具,免费工具,安全工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/security/index.html" />
+    <meta property="og:title" content="安全工具 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/security/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="安全工具 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "安全工具",
+            "item": "https://tools.realtime-ai.chat/tools/security/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "安全工具 - 在线工具合集（13个）| WebUtils",
+        "description": "在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。",
+        "url": "https://tools.realtime-ai.chat/tools/security/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 13,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Bcrypt 工具",
+              "url": "https://tools.realtime-ai.chat/tools/security/bcrypt-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Cookie 解析器",
+              "url": "https://tools.realtime-ai.chat/tools/security/cookie-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "CORS 配置生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/cors-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "CSP 策略生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/csp-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "哈希生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/hash-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "HTTP 响应头分析器",
+              "url": "https://tools.realtime-ai.chat/tools/security/header-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "安全头检测器",
+              "url": "https://tools.realtime-ai.chat/tools/security/headers-check.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "密码强度检测器",
+              "url": "https://tools.realtime-ai.chat/tools/security/password-strength.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "sitemap.xml 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/sitemap-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "TOTP 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/totp-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "URL安全化",
+              "url": "https://tools.realtime-ai.chat/tools/security/url-defang.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "Meta 标签生成器",
+              "url": "https://tools.realtime-ai.chat/tools/security/meta-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "PGP 消息加密解密",
+              "url": "https://tools.realtime-ai.chat/tools/security/pgp-encrypt-decrypt.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">🛡️</div>
+        <h1>安全工具</h1>
+        <p class="cat-intro">
+          在线安全工具集合，包括哈希校验、加解密、密码强度检测等，帮助验证数据完整性与账户安全。
+        </p>
+        <p class="cat-meta">13 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="bcrypt-generator.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Bcrypt 工具</span>
+            <span class="cat-card-desc">Bcrypt 密码哈希生成和验证</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cookie-parser.html">
+          <span class="cat-card-icon">🍪</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cookie 解析器</span>
+            <span class="cat-card-desc">
+              Cookie 解析器，在线分析，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cors-generator.html">
+          <span class="cat-card-icon">🌐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CORS 配置生成器</span>
+            <span class="cat-card-desc">
+              CORS 配置生成器，一键在线生成，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="csp-generator.html">
+          <span class="cat-card-icon">🛡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">CSP 策略生成器</span>
+            <span class="cat-card-desc">
+              CSP 策略生成器，一键在线生成，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="hash-generator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">哈希生成器</span>
+            <span class="cat-card-desc">计算文本或文件的哈希值</span>
+          </span>
+        </a>
+        <a class="cat-card" href="header-analyzer.html">
+          <span class="cat-card-icon">📡</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTTP 响应头分析器</span>
+            <span class="cat-card-desc">
+              HTTP 响应头分析器，在线分析，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="headers-check.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">安全头检测器</span>
+            <span class="cat-card-desc">
+              安全头检测器，在线分析，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="password-strength.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">密码强度检测器</span>
+            <span class="cat-card-desc">检测密码强度，提供安全建议和密码生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sitemap-generator.html">
+          <span class="cat-card-icon">🗺</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">sitemap.xml 生成器</span>
+            <span class="cat-card-desc">
+              sitemap.xml 生成器，一键在线生成，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="totp-generator.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">TOTP 生成器</span>
+            <span class="cat-card-desc">基于时间的一次性密码生成器，兼容 Google Authenticator</span>
+          </span>
+        </a>
+        <a class="cat-card" href="url-defang.html">
+          <span class="cat-card-icon">🛡️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">URL安全化</span>
+            <span class="cat-card-desc">URL 脱敏处理</span>
+          </span>
+        </a>
+        <a class="cat-card" href="meta-generator.html">
+          <span class="cat-card-icon">🔒</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Meta 标签生成器</span>
+            <span class="cat-card-desc">
+              Meta 标签生成器，一键在线生成，安全工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pgp-encrypt-decrypt.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">PGP 消息加密解密</span>
+            <span class="cat-card-desc">
+              浏览器端使用 OpenPGP.js 对文本进行 PGP 公钥加密和私钥解密，无需安装 GPG 客户端。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/seo/index.html
+++ b/tools/seo/index.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>SEO 工具 - 在线工具合集（9个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap 等，助力搜索引擎排名。"
+    />
+    <meta name="keywords" content="SEO 工具,在线工具,免费工具,SEO 工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/seo/index.html" />
+    <meta property="og:title" content="SEO 工具 - 在线工具合集（9个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap 等，助力搜索引擎排名。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/seo/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="SEO 工具 - 在线工具合集（9个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap 等，助力搜索引擎排名。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "SEO 工具",
+            "item": "https://tools.realtime-ai.chat/tools/seo/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "SEO 工具 - 在线工具合集（9个）| WebUtils",
+        "description": "面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap 等，助力搜索引擎排名。",
+        "url": "https://tools.realtime-ai.chat/tools/seo/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 9,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "标题结构分析器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/heading-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "图片Alt属性检查器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/image-alt-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "关键词密度分析器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/keyword-density.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "链接分析器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/link-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "搜索结果预览",
+              "url": "https://tools.realtime-ai.chat/tools/seo/meta-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "Meta Tags 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/meta-tags-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Robots.txt 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/robots-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "Open Graph 预览器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/og-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "Schema.org 结构化数据生成器",
+              "url": "https://tools.realtime-ai.chat/tools/seo/schema-org-generator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📈</div>
+        <h1>SEO 工具</h1>
+        <p class="cat-intro">
+          面向网站优化的在线 SEO 工具，涵盖 meta 标签、结构化数据、关键词、sitemap
+          等，助力搜索引擎排名。
+        </p>
+        <p class="cat-meta">9 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="heading-analyzer.html">
+          <span class="cat-card-icon">📑</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">标题结构分析器</span>
+            <span class="cat-card-desc">
+              标题结构分析器，在线分析，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="image-alt-checker.html">
+          <span class="cat-card-icon">🖼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">图片Alt属性检查器</span>
+            <span class="cat-card-desc">
+              图片Alt属性检查器，在线使用，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="keyword-density.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">关键词密度分析器</span>
+            <span class="cat-card-desc">
+              关键词密度分析器，在线分析，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="link-analyzer.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">链接分析器</span>
+            <span class="cat-card-desc">
+              链接分析器，在线分析，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meta-preview.html">
+          <span class="cat-card-icon">🔎</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">搜索结果预览</span>
+            <span class="cat-card-desc">
+              搜索结果预览，即时预览，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="meta-tags-generator.html">
+          <span class="cat-card-icon">🏷</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Meta Tags 生成器</span>
+            <span class="cat-card-desc">
+              Meta Tags 生成器，一键在线生成，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="robots-generator.html">
+          <span class="cat-card-icon">🤖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Robots.txt 生成器</span>
+            <span class="cat-card-desc">
+              Robots.txt 生成器，一键在线生成，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="og-preview.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Open Graph 预览器</span>
+            <span class="cat-card-desc">
+              Open Graph 预览器，在线使用，SEO 工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="schema-org-generator.html">
+          <span class="cat-card-icon">🗂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Schema.org 结构化数据生成器</span>
+            <span class="cat-card-desc">
+              填写 Schema 类型（Article/FAQ/Product），生成 JSON-LD 结构化数据代码。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/social-media/index.html
+++ b/tools/social-media/index.html
@@ -1,0 +1,369 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>社交媒体 - 在线工具合集（13个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。"
+    />
+    <meta name="keywords" content="社交媒体,在线工具,免费工具,社交媒体大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/social-media/index.html" />
+    <meta property="og:title" content="社交媒体 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/social-media/index.html"
+    />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="社交媒体 - 在线工具合集（13个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "社交媒体",
+            "item": "https://tools.realtime-ai.chat/tools/social-media/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "社交媒体 - 在线工具合集（13个）| WebUtils",
+        "description": "面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。",
+        "url": "https://tools.realtime-ai.chat/tools/social-media/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 13,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "热门话题标签生成器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/hashtag-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "发布时间建议器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/post-scheduler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "社交媒体文案生成器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/caption-writer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "长文分割器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/thread-splitter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "个人简介生成器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/bio-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "社交分享预览器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/social-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "用户名可用性检查",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/username-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "互动率计算器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/engagement-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "粉丝增长预测器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/follower-growth.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "帖子长度检查器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/post-length.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "Emoji选择器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/emoji-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "社交平台品牌色",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/social-color.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "社交媒体 OG 图生成器",
+              "url": "https://tools.realtime-ai.chat/tools/social-media/og-image-generator.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📱</div>
+        <h1>社交媒体</h1>
+        <p class="cat-intro">
+          面向自媒体与运营的在线工具，涵盖文案、标签、字数限制、封面尺寸等社媒内容制作需求。
+        </p>
+        <p class="cat-meta">13 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="hashtag-generator.html">
+          <span class="cat-card-icon">#️⃣</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">热门话题标签生成器</span>
+            <span class="cat-card-desc">根据关键词生成社交媒体热门话题标签</span>
+          </span>
+        </a>
+        <a class="cat-card" href="post-scheduler.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">发布时间建议器</span>
+            <span class="cat-card-desc">推荐各平台最佳发布时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="caption-writer.html">
+          <span class="cat-card-icon">✍️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交媒体文案生成器</span>
+            <span class="cat-card-desc">生成吸引人的社交媒体文案</span>
+          </span>
+        </a>
+        <a class="cat-card" href="thread-splitter.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">长文分割器</span>
+            <span class="cat-card-desc">将长文智能分割为社交媒体线程</span>
+          </span>
+        </a>
+        <a class="cat-card" href="bio-generator.html">
+          <span class="cat-card-icon">👤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">个人简介生成器</span>
+            <span class="cat-card-desc">生成个性化的社交媒体个人简介</span>
+          </span>
+        </a>
+        <a class="cat-card" href="social-preview.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交分享预览器</span>
+            <span class="cat-card-desc">预览链接在各平台的分享效果</span>
+          </span>
+        </a>
+        <a class="cat-card" href="username-checker.html">
+          <span class="cat-card-icon">🔍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">用户名可用性检查</span>
+            <span class="cat-card-desc">检查用户名在各平台的可用性</span>
+          </span>
+        </a>
+        <a class="cat-card" href="engagement-calc.html">
+          <span class="cat-card-icon">💬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">互动率计算器</span>
+            <span class="cat-card-desc">计算社交媒体帖子的互动率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="follower-growth.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">粉丝增长预测器</span>
+            <span class="cat-card-desc">预测粉丝增长趋势</span>
+          </span>
+        </a>
+        <a class="cat-card" href="post-length.html">
+          <span class="cat-card-icon">📏</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">帖子长度检查器</span>
+            <span class="cat-card-desc">检查帖子是否符合各平台字数限制</span>
+          </span>
+        </a>
+        <a class="cat-card" href="emoji-picker.html">
+          <span class="cat-card-icon">😀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Emoji选择器</span>
+            <span class="cat-card-desc">快速搜索和复制Emoji表情</span>
+          </span>
+        </a>
+        <a class="cat-card" href="social-color.html">
+          <span class="cat-card-icon">🎨</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交平台品牌色</span>
+            <span class="cat-card-desc">查询各社交平台的官方品牌色</span>
+          </span>
+        </a>
+        <a class="cat-card" href="og-image-generator.html">
+          <span class="cat-card-icon">🖼️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">社交媒体 OG 图生成器</span>
+            <span class="cat-card-desc">
+              选择模板、填写标题和描述，预览并下载符合各平台（Twitter Card、Facebook
+              OG、LinkedIn）尺寸的分享预览图。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/team-tools/index.html
+++ b/tools/team-tools/index.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>团队协作 - 在线工具合集（12个）| WebUtils</title>
+    <meta
+      name="description"
+      content="面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。"
+    />
+    <meta name="keywords" content="团队协作,在线工具,免费工具,团队协作大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/team-tools/index.html" />
+    <meta property="og:title" content="团队协作 - 在线工具合集（12个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/team-tools/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="团队协作 - 在线工具合集（12个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "团队协作",
+            "item": "https://tools.realtime-ai.chat/tools/team-tools/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "团队协作 - 在线工具合集（12个）| WebUtils",
+        "description": "面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。",
+        "url": "https://tools.realtime-ai.chat/tools/team-tools/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 12,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "会议议程生成器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/meeting-agenda.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "敏捷冲刺规划器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/sprint-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "任务分解器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/task-breakdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "决策矩阵",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/decision-matrix.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "RACI责任矩阵",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/raci-chart.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "站会计时器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/standup-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "回顾会议模板",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/retrospective.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "团队投票工具",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/team-vote.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "工作量评估器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/workload-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "里程碑追踪器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/milestone-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "破冰游戏生成器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/icebreaker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "反馈表单生成器",
+              "url": "https://tools.realtime-ai.chat/tools/team-tools/feedback-form.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">👥</div>
+        <h1>团队协作</h1>
+        <p class="cat-intro">
+          面向团队的在线协作工具，涵盖排期、投票、分工、会议、估时等协作场景。
+        </p>
+        <p class="cat-meta">12 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="meeting-agenda.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">会议议程生成器</span>
+            <span class="cat-card-desc">生成结构化的会议议程</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sprint-planner.html">
+          <span class="cat-card-icon">🏃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">敏捷冲刺规划器</span>
+            <span class="cat-card-desc">规划敏捷开发冲刺周期</span>
+          </span>
+        </a>
+        <a class="cat-card" href="task-breakdown.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">任务分解器</span>
+            <span class="cat-card-desc">将大任务分解为可执行的小任务</span>
+          </span>
+        </a>
+        <a class="cat-card" href="decision-matrix.html">
+          <span class="cat-card-icon">🎯</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">决策矩阵</span>
+            <span class="cat-card-desc">使用加权矩阵辅助决策</span>
+          </span>
+        </a>
+        <a class="cat-card" href="raci-chart.html">
+          <span class="cat-card-icon">👥</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">RACI责任矩阵</span>
+            <span class="cat-card-desc">创建RACI责任分配矩阵</span>
+          </span>
+        </a>
+        <a class="cat-card" href="standup-timer.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">站会计时器</span>
+            <span class="cat-card-desc">站会发言计时和记录</span>
+          </span>
+        </a>
+        <a class="cat-card" href="retrospective.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">回顾会议模板</span>
+            <span class="cat-card-desc">敏捷回顾会议模板工具</span>
+          </span>
+        </a>
+        <a class="cat-card" href="team-vote.html">
+          <span class="cat-card-icon">🗳️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">团队投票工具</span>
+            <span class="cat-card-desc">团队快速投票决策</span>
+          </span>
+        </a>
+        <a class="cat-card" href="workload-calc.html">
+          <span class="cat-card-icon">⚖️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">工作量评估器</span>
+            <span class="cat-card-desc">评估项目工作量和工时</span>
+          </span>
+        </a>
+        <a class="cat-card" href="milestone-tracker.html">
+          <span class="cat-card-icon">🏁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">里程碑追踪器</span>
+            <span class="cat-card-desc">追踪项目里程碑进度</span>
+          </span>
+        </a>
+        <a class="cat-card" href="icebreaker.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">破冰游戏生成器</span>
+            <span class="cat-card-desc">生成团队破冰游戏和问题</span>
+          </span>
+        </a>
+        <a class="cat-card" href="feedback-form.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">反馈表单生成器</span>
+            <span class="cat-card-desc">生成团队反馈收集表单</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/text/index.html
+++ b/tools/text/index.html
@@ -1,0 +1,1106 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>文本工具 - 在线工具合集（65个）| WebUtils</title>
+    <meta
+      name="description"
+      content="在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。"
+    />
+    <meta name="keywords" content="文本工具,在线工具,免费工具,文本工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/text/index.html" />
+    <meta property="og:title" content="文本工具 - 在线工具合集（65个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/text/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="文本工具 - 在线工具合集（65个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "文本工具 - 在线工具合集（65个）| WebUtils",
+        "description": "在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。",
+        "url": "https://tools.realtime-ai.chat/tools/text/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 65,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "BBCode与HTML互转",
+              "url": "https://tools.realtime-ai.chat/tools/text/bbcode-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "文本大小写转换",
+              "url": "https://tools.realtime-ai.chat/tools/text/case-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "中文简繁转换器",
+              "url": "https://tools.realtime-ai.chat/tools/text/chinese-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "中文简繁转换",
+              "url": "https://tools.realtime-ai.chat/tools/text/cn-convert.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "文本列处理器",
+              "url": "https://tools.realtime-ai.chat/tools/text/column-processor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "文本对比工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/diff-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "Emoji 搜索器",
+              "url": "https://tools.realtime-ai.chat/tools/text/emoji-search.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "文本频率分析器",
+              "url": "https://tools.realtime-ai.chat/tools/text/frequency-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "同音字检查器",
+              "url": "https://tools.realtime-ai.chat/tools/text/homophone-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "HTML ⇄ Markdown 转换",
+              "url": "https://tools.realtime-ai.chat/tools/text/html-markdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "LaTeX公式编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/text/latex-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "行号添加/移除",
+              "url": "https://tools.realtime-ai.chat/tools/text/line-number.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "行排序工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/line-sorter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "Markdown 编辑器",
+              "url": "https://tools.realtime-ai.chat/tools/text/markdown-editor.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "Markdown 预览",
+              "url": "https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "Markdown 表格生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/markdown-table.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "Markdown 转 HTML",
+              "url": "https://tools.realtime-ai.chat/tools/text/md-to-html.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "摩尔斯电码",
+              "url": "https://tools.realtime-ai.chat/tools/text/morse-code.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "NATO 字母表",
+              "url": "https://tools.realtime-ai.chat/tools/text/nato-alphabet.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "数字格式化工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/number-formatter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "盘古之白",
+              "url": "https://tools.realtime-ai.chat/tools/text/pangu-spacing.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "拼音排序工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/pinyin-sort.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "占位文本生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/placeholder-text.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "随机文本选择器",
+              "url": "https://tools.realtime-ai.chat/tools/text/random-picker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "阅读时间估算",
+              "url": "https://tools.realtime-ai.chat/tools/text/reading-time.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "富文本转纯文本",
+              "url": "https://tools.realtime-ai.chat/tools/text/richtext-to-plain.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "罗马数字转换器",
+              "url": "https://tools.realtime-ai.chat/tools/text/roman-numeral.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "双拼练习器",
+              "url": "https://tools.realtime-ai.chat/tools/text/shuangpin-trainer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Slugify 工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/slugify.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "字符串转义",
+              "url": "https://tools.realtime-ai.chat/tools/text/string-escape.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "文本模板填充器",
+              "url": "https://tools.realtime-ai.chat/tools/text/template-filler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "文本加密/解密",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-cipher.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "列处理工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-columns.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "文本对比增强版",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-compare.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "文本去重",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-dedup.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "文本 Diff",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-diff.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "文本加密工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-encrypt.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "文本频率分析",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-frequency.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "多行文本合并器",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-merge.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 40,
+              "name": "文本随机化工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-randomizer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 41,
+              "name": "文本重复工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-repeat.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 42,
+              "name": "文本翻转工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-reverse.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 43,
+              "name": "文本相似度计算",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-similarity.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 44,
+              "name": "文本排序",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-sort.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 45,
+              "name": "文本分割器",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-splitter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 46,
+              "name": "文本统计增强版",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-stats.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 47,
+              "name": "文本二进制转换器",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-to-binary.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 48,
+              "name": "文本截断工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-truncate.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 49,
+              "name": "空白字符清理",
+              "url": "https://tools.realtime-ai.chat/tools/text/whitespace-cleaner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 50,
+              "name": "字数统计",
+              "url": "https://tools.realtime-ai.chat/tools/text/word-counter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 51,
+              "name": "词频统计",
+              "url": "https://tools.realtime-ai.chat/tools/text/word-frequency.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 52,
+              "name": "去除重复行",
+              "url": "https://tools.realtime-ai.chat/tools/text/duplicate-remover.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 53,
+              "name": "倒置文字生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/upside-down-text.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 54,
+              "name": "分隔线生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/divider.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 55,
+              "name": "Lorem Ipsum 生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/lorem-ipsum.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 56,
+              "name": "汉字转拼音",
+              "url": "https://tools.realtime-ai.chat/tools/text/pinyin.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 57,
+              "name": "打字速度测试",
+              "url": "https://tools.realtime-ai.chat/tools/text/typing-test.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 58,
+              "name": "Lorem生成器",
+              "url": "https://tools.realtime-ai.chat/tools/text/lorem-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 59,
+              "name": "Slug Generator",
+              "url": "https://tools.realtime-ai.chat/tools/text/slug-generator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 60,
+              "name": "Text Case Converter",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-case-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 61,
+              "name": "Text Statistics",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-statistics.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 62,
+              "name": "Unicode Converter",
+              "url": "https://tools.realtime-ai.chat/tools/text/unicode-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 63,
+              "name": "Vigenère 密码工具",
+              "url": "https://tools.realtime-ai.chat/tools/text/vigenere-cipher.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 64,
+              "name": "文本可读性分析器",
+              "url": "https://tools.realtime-ai.chat/tools/text/text-readability-analyzer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 65,
+              "name": "变位词求解器",
+              "url": "https://tools.realtime-ai.chat/tools/text/anagram-solver.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">📝</div>
+        <h1>文本工具</h1>
+        <p class="cat-intro">
+          在线文本处理工具，支持格式化、对比、统计、大小写转换、查找替换等操作，帮你快速整理和加工各类文字内容。
+        </p>
+        <p class="cat-meta">65 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="bbcode-converter.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">BBCode与HTML互转</span>
+            <span class="cat-card-desc">
+              BBCode与HTML互转，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="case-converter.html">
+          <span class="cat-card-icon">Aa</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本大小写转换</span>
+            <span class="cat-card-desc">
+              文本大小写转换，多格式互转，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="chinese-converter.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">中文简繁转换器</span>
+            <span class="cat-card-desc">
+              中文简繁转换器，多格式互转，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="cn-convert.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">中文简繁转换</span>
+            <span class="cat-card-desc">
+              中文简繁转换，多格式互转，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="column-processor.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本列处理器</span>
+            <span class="cat-card-desc">
+              文本列处理器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="diff-checker.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本对比工具</span>
+            <span class="cat-card-desc">对比两段文本的差异</span>
+          </span>
+        </a>
+        <a class="cat-card" href="emoji-search.html">
+          <span class="cat-card-icon">😀</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Emoji 搜索器</span>
+            <span class="cat-card-desc">
+              Emoji 搜索器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="frequency-analyzer.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本频率分析器</span>
+            <span class="cat-card-desc">分析文本字符/词频分布，支持 N-gram 和词云可视化</span>
+          </span>
+        </a>
+        <a class="cat-card" href="homophone-checker.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">同音字检查器</span>
+            <span class="cat-card-desc">
+              同音字检查器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="html-markdown.html">
+          <span class="cat-card-icon">⇄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">HTML ⇄ Markdown 转换</span>
+            <span class="cat-card-desc">HTML 与 Markdown 双向转换，支持表格、代码块、链接等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="latex-editor.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">LaTeX公式编辑器</span>
+            <span class="cat-card-desc">
+              LaTeX公式编辑器，在线编辑，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="line-number.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">行号添加/移除</span>
+            <span class="cat-card-desc">为文本添加或移除行号</span>
+          </span>
+        </a>
+        <a class="cat-card" href="line-sorter.html">
+          <span class="cat-card-icon">⇅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">行排序工具</span>
+            <span class="cat-card-desc">按字母、数字或自定义规则排序文本行</span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-editor.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 编辑器</span>
+            <span class="cat-card-desc">
+              Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-preview.html">
+          <span class="cat-card-icon">M↓</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 预览</span>
+            <span class="cat-card-desc">实时 Markdown 预览，支持 GFM 语法，可导出 HTML</span>
+          </span>
+        </a>
+        <a class="cat-card" href="markdown-table.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 表格生成器</span>
+            <span class="cat-card-desc">可视化编辑 Markdown 表格，支持导入 CSV 数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="md-to-html.html">
+          <span class="cat-card-icon">📄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Markdown 转 HTML</span>
+            <span class="cat-card-desc">
+              Markdown 转 HTML，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="morse-code.html">
+          <span class="cat-card-icon">·—</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">摩尔斯电码</span>
+            <span class="cat-card-desc">文本与摩尔斯电码互转，支持音频播放</span>
+          </span>
+        </a>
+        <a class="cat-card" href="nato-alphabet.html">
+          <span class="cat-card-icon">🅰️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">NATO 字母表</span>
+            <span class="cat-card-desc">NATO 音标字母表转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="number-formatter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">数字格式化工具</span>
+            <span class="cat-card-desc">
+              数字格式化工具，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pangu-spacing.html">
+          <span class="cat-card-icon">盘</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">盘古之白</span>
+            <span class="cat-card-desc">自动在中英文之间添加空格，优化排版</span>
+          </span>
+        </a>
+        <a class="cat-card" href="pinyin-sort.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">拼音排序工具</span>
+            <span class="cat-card-desc">
+              拼音排序工具，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="placeholder-text.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">占位文本生成器</span>
+            <span class="cat-card-desc">
+              占位文本生成器，一键在线生成，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="random-picker.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">随机文本选择器</span>
+            <span class="cat-card-desc">
+              随机文本选择器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="reading-time.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">阅读时间估算</span>
+            <span class="cat-card-desc">估算文章阅读时间，支持中英文混合统计</span>
+          </span>
+        </a>
+        <a class="cat-card" href="richtext-to-plain.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">富文本转纯文本</span>
+            <span class="cat-card-desc">
+              富文本转纯文本，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="roman-numeral.html">
+          <span class="cat-card-icon">Ⅳ</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">罗马数字转换器</span>
+            <span class="cat-card-desc">罗马数字转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="shuangpin-trainer.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">双拼练习器</span>
+            <span class="cat-card-desc">
+              双拼练习器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="slugify.html">
+          <span class="cat-card-icon">🔗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Slugify 工具</span>
+            <span class="cat-card-desc">生成 URL slug</span>
+          </span>
+        </a>
+        <a class="cat-card" href="string-escape.html">
+          <span class="cat-card-icon">\</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字符串转义</span>
+            <span class="cat-card-desc">字符串转义和反转义</span>
+          </span>
+        </a>
+        <a class="cat-card" href="template-filler.html">
+          <span class="cat-card-icon">📋</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本模板填充器</span>
+            <span class="cat-card-desc">文本模板变量填充，支持批量生成和 CSV 导入</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-cipher.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本加密/解密</span>
+            <span class="cat-card-desc">多种古典加密算法：凯撒、ROT13、栅栏等</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-columns.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">列处理工具</span>
+            <span class="cat-card-desc">处理 CSV/TSV 格式的列数据</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-compare.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本对比增强版</span>
+            <span class="cat-card-desc">增强版文本对比，支持分栏/统一视图，忽略大小写和空白</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-dedup.html">
+          <span class="cat-card-icon">⊖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本去重</span>
+            <span class="cat-card-desc">去除重复行，支持保持顺序和忽略大小写</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-diff.html">
+          <span class="cat-card-icon">±</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本 Diff</span>
+            <span class="cat-card-desc">文本差异对比，左右并排显示，行内差异高亮</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-encrypt.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本加密工具</span>
+            <span class="cat-card-desc">
+              文本加密工具，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-frequency.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本频率分析</span>
+            <span class="cat-card-desc">
+              文本频率分析，在线分析，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-merge.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">多行文本合并器</span>
+            <span class="cat-card-desc">
+              多行文本合并器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-randomizer.html">
+          <span class="cat-card-icon">🎲</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本随机化工具</span>
+            <span class="cat-card-desc">文本随机打乱</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-repeat.html">
+          <span class="cat-card-icon">🔁</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本重复工具</span>
+            <span class="cat-card-desc">将文本重复指定次数，支持自定义分隔符</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-reverse.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本翻转工具</span>
+            <span class="cat-card-desc">
+              文本翻转工具，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-similarity.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本相似度计算</span>
+            <span class="cat-card-desc">
+              文本相似度计算，快速计算结果，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-sort.html">
+          <span class="cat-card-icon">↕</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本排序</span>
+            <span class="cat-card-desc">按字母、数字、长度等方式排序文本行</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-splitter.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本分割器</span>
+            <span class="cat-card-desc">
+              文本分割器，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-stats.html">
+          <span class="cat-card-icon">📊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本统计增强版</span>
+            <span class="cat-card-desc">文本统计分析</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-to-binary.html">
+          <span class="cat-card-icon">🔢</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本二进制转换器</span>
+            <span class="cat-card-desc">文本与二进制、十六进制、八进制等格式互转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-truncate.html">
+          <span class="cat-card-icon">✂️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本截断工具</span>
+            <span class="cat-card-desc">按字符、单词或句子截断文本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="whitespace-cleaner.html">
+          <span class="cat-card-icon">␣</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">空白字符清理</span>
+            <span class="cat-card-desc">清理多余空白、空行、行首尾空格</span>
+          </span>
+        </a>
+        <a class="cat-card" href="word-counter.html">
+          <span class="cat-card-icon">Aa</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">字数统计</span>
+            <span class="cat-card-desc">统计字符、单词、句子、段落数量</span>
+          </span>
+        </a>
+        <a class="cat-card" href="word-frequency.html">
+          <span class="cat-card-icon">📈</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">词频统计</span>
+            <span class="cat-card-desc">统计文本中单词出现的频率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="duplicate-remover.html">
+          <span class="cat-card-icon">🔄</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">去除重复行</span>
+            <span class="cat-card-desc">在线去除文本重复行，支持忽略大小写、空行等选项</span>
+          </span>
+        </a>
+        <a class="cat-card" href="upside-down-text.html">
+          <span class="cat-card-icon">🙃</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">倒置文字生成器</span>
+            <span class="cat-card-desc">生成上下颠倒的文字效果，支持镜像翻转</span>
+          </span>
+        </a>
+        <a class="cat-card" href="divider.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">分隔线生成器</span>
+            <span class="cat-card-desc">
+              分隔线生成器，一键在线生成，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="lorem-ipsum.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Lorem Ipsum 生成器</span>
+            <span class="cat-card-desc">
+              Lorem Ipsum 生成器，一键在线生成，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pinyin.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">汉字转拼音</span>
+            <span class="cat-card-desc">
+              汉字转拼音，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="typing-test.html">
+          <span class="cat-card-icon">📝</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">打字速度测试</span>
+            <span class="cat-card-desc">
+              打字速度测试，在线验证，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="lorem-generator.html">
+          <span class="cat-card-icon">📜</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Lorem生成器</span>
+            <span class="cat-card-desc">生成Lorem占位文本</span>
+          </span>
+        </a>
+        <a class="cat-card" href="slug-generator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Slug Generator</span>
+            <span class="cat-card-desc">
+              Slug Generator，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-case-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Text Case Converter</span>
+            <span class="cat-card-desc">
+              Text Case Converter，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-statistics.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Text Statistics</span>
+            <span class="cat-card-desc">
+              Text Statistics，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="unicode-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Unicode Converter</span>
+            <span class="cat-card-desc">
+              Unicode Converter，在线使用，文本工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="vigenere-cipher.html">
+          <span class="cat-card-icon">🔐</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Vigenère 密码工具</span>
+            <span class="cat-card-desc">
+              使用 Vigenère 多字母替换密码对文本进行加密和解密，支持显示加密表格，兼容大小写和中文。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="text-readability-analyzer.html">
+          <span class="cat-card-icon">📖</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">文本可读性分析器</span>
+            <span class="cat-card-desc">
+              计算英文文本的 Flesch-Kincaid、Gunning Fog、SMOG
+              等可读性指数，指出平均句长、音节数和阅读年级。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="anagram-solver.html">
+          <span class="cat-card-icon">🔤</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">变位词求解器</span>
+            <span class="cat-card-desc">
+              输入一组字母，找出所有可能的英文变位词（Anagram）组合，支持按长度过滤，内嵌常用词典。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/time/index.html
+++ b/tools/time/index.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>时间工具 - 在线工具合集（14个）| WebUtils</title>
+    <meta
+      name="description"
+      content="时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。"
+    />
+    <meta name="keywords" content="时间工具,在线工具,免费工具,时间工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/time/index.html" />
+    <meta property="og:title" content="时间工具 - 在线工具合集（14个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/time/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="时间工具 - 在线工具合集（14个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "时间工具",
+            "item": "https://tools.realtime-ai.chat/tools/time/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "时间工具 - 在线工具合集（14个）| WebUtils",
+        "description": "时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。",
+        "url": "https://tools.realtime-ai.chat/tools/time/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 14,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "农历日历",
+              "url": "https://tools.realtime-ai.chat/tools/time/chinese-calendar.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "纪念日倒计时",
+              "url": "https://tools.realtime-ai.chat/tools/time/countdown-event.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "倒计时器",
+              "url": "https://tools.realtime-ai.chat/tools/time/countdown.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "Cron 表达式解析",
+              "url": "https://tools.realtime-ai.chat/tools/time/cron-parser.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "日期计算器",
+              "url": "https://tools.realtime-ai.chat/tools/time/date-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "跨时区会议时间协调器",
+              "url": "https://tools.realtime-ai.chat/tools/time/meeting-scheduler.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "番茄钟计时器",
+              "url": "https://tools.realtime-ai.chat/tools/time/pomodoro.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "秒表计时器",
+              "url": "https://tools.realtime-ai.chat/tools/time/stopwatch.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "时间戳转换",
+              "url": "https://tools.realtime-ai.chat/tools/time/timestamp.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "时区转换器",
+              "url": "https://tools.realtime-ai.chat/tools/time/timezone-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "工时计算器",
+              "url": "https://tools.realtime-ai.chat/tools/time/work-hours.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "世界时钟",
+              "url": "https://tools.realtime-ai.chat/tools/time/world-clock.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "倒计时定时器",
+              "url": "https://tools.realtime-ai.chat/tools/time/countdown-timer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "新年倒计时",
+              "url": "https://tools.realtime-ai.chat/tools/time/new-year-countdown.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">⏰</div>
+        <h1>时间工具</h1>
+        <p class="cat-intro">
+          时间与日期相关的在线工具，包括时间戳转换、时区换算、倒计时、日期计算等，轻松处理跨时区与时间格式问题。
+        </p>
+        <p class="cat-meta">14 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="chinese-calendar.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">农历日历</span>
+            <span class="cat-card-desc">农历日历，在线使用，时间工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="countdown-event.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">纪念日倒计时</span>
+            <span class="cat-card-desc">管理重要日期和纪念日，支持每年重复提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="countdown.html">
+          <span class="cat-card-icon">⏳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">倒计时器</span>
+            <span class="cat-card-desc">设定倒计时或目标日期倒数，支持通知提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="cron-parser.html">
+          <span class="cat-card-icon">⚙</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Cron 表达式解析</span>
+            <span class="cat-card-desc">解析 Cron 表达式，展示可读描述和下次执行时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="date-calculator.html">
+          <span class="cat-card-icon">📅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">日期计算器</span>
+            <span class="cat-card-desc">计算日期差异、日期推算、工作日统计</span>
+          </span>
+        </a>
+        <a class="cat-card" href="meeting-scheduler.html">
+          <span class="cat-card-icon">⏰</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">跨时区会议时间协调器</span>
+            <span class="cat-card-desc">
+              跨时区会议时间协调器，在线使用，时间工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="pomodoro.html">
+          <span class="cat-card-icon">🍅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">番茄钟计时器</span>
+            <span class="cat-card-desc">
+              番茄钟计时器，精准计时，时间工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="stopwatch.html">
+          <span class="cat-card-icon">⏱️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">秒表计时器</span>
+            <span class="cat-card-desc">在线秒表，支持计次、暂停、毫秒精度显示</span>
+          </span>
+        </a>
+        <a class="cat-card" href="timestamp.html">
+          <span class="cat-card-icon">⏱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">时间戳转换</span>
+            <span class="cat-card-desc">时间戳与日期互转，支持多种格式和时区</span>
+          </span>
+        </a>
+        <a class="cat-card" href="timezone-converter.html">
+          <span class="cat-card-icon">🌍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">时区转换器</span>
+            <span class="cat-card-desc">在不同时区之间转换时间</span>
+          </span>
+        </a>
+        <a class="cat-card" href="work-hours.html">
+          <span class="cat-card-icon">💼</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">工时计算器</span>
+            <span class="cat-card-desc">计算工作时长、加班时间和薪资估算</span>
+          </span>
+        </a>
+        <a class="cat-card" href="world-clock.html">
+          <span class="cat-card-icon">🌍</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">世界时钟</span>
+            <span class="cat-card-desc">世界时钟，在线使用，时间工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="countdown-timer.html">
+          <span class="cat-card-icon">⏳</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">倒计时定时器</span>
+            <span class="cat-card-desc">可自定义的倒计时器，支持预设时间和提醒</span>
+          </span>
+        </a>
+        <a class="cat-card" href="new-year-countdown.html">
+          <span class="cat-card-icon">🎆</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">新年倒计时</span>
+            <span class="cat-card-desc">精致美观的新年倒计时页面，支持主题切换与分享链接</span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/tools/travel/index.html
+++ b/tools/travel/index.html
@@ -1,0 +1,743 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>旅行工具 - 在线工具合集（39个）| WebUtils</title>
+    <meta
+      name="description"
+      content="旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。"
+    />
+    <meta name="keywords" content="旅行工具,在线工具,免费工具,旅行工具大全" />
+    <meta name="author" content="WebUtils" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/travel/index.html" />
+    <meta property="og:title" content="旅行工具 - 在线工具合集（39个）| WebUtils" />
+    <meta
+      property="og:description"
+      content="旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/index.html" />
+    <meta property="og:site_name" content="WebUtils" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="旅行工具 - 在线工具合集（39个）| WebUtils" />
+    <meta
+      name="twitter:description"
+      content="旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。"
+    />
+    <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "旅行工具 - 在线工具合集（39个）| WebUtils",
+        "description": "旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。",
+        "url": "https://tools.realtime-ai.chat/tools/travel/index.html",
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": 39,
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "旅行打包清单",
+              "url": "https://tools.realtime-ai.chat/tools/travel/packing-list.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "时差倒时差计算",
+              "url": "https://tools.realtime-ai.chat/tools/travel/jet-lag-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "旅行预算计算",
+              "url": "https://tools.realtime-ai.chat/tools/travel/travel-budget.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 4,
+              "name": "货币兑换提示",
+              "url": "https://tools.realtime-ai.chat/tools/travel/currency-tips.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 5,
+              "name": "油费计算器",
+              "url": "https://tools.realtime-ai.chat/tools/automotive/fuel-cost.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 6,
+              "name": "签证要求查询",
+              "url": "https://tools.realtime-ai.chat/tools/travel/visa-requirements.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 7,
+              "name": "紧急联系方式",
+              "url": "https://tools.realtime-ai.chat/tools/travel/emergency-contacts.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 8,
+              "name": "常用语手册",
+              "url": "https://tools.realtime-ai.chat/tools/travel/phrase-book.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 9,
+              "name": "尺码转换器",
+              "url": "https://tools.realtime-ai.chat/tools/travel/size-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 10,
+              "name": "电源插座指南",
+              "url": "https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 11,
+              "name": "行车方向指南",
+              "url": "https://tools.realtime-ai.chat/tools/travel/driving-side.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 12,
+              "name": "证件照规格",
+              "url": "https://tools.realtime-ai.chat/tools/travel/passport-photo.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 13,
+              "name": "行李限制查询",
+              "url": "https://tools.realtime-ai.chat/tools/travel/baggage-limit.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 14,
+              "name": "SIM 卡指南",
+              "url": "https://tools.realtime-ai.chat/tools/travel/sim-card-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 15,
+              "name": "旅行准备清单",
+              "url": "https://tools.realtime-ai.chat/tools/travel/travel-checklist.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 16,
+              "name": "胎压转换",
+              "url": "https://tools.realtime-ai.chat/tools/automotive/tire-pressure-calc.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 17,
+              "name": "Baggage Tracker",
+              "url": "https://tools.realtime-ai.chat/tools/travel/baggage-tracker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 18,
+              "name": "Currency Exchange",
+              "url": "https://tools.realtime-ai.chat/tools/travel/currency-exchange.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 19,
+              "name": "Distance Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/travel/distance-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 20,
+              "name": "Flight Time",
+              "url": "https://tools.realtime-ai.chat/tools/travel/flight-time.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 21,
+              "name": "Fuel Cost",
+              "url": "https://tools.realtime-ai.chat/tools/travel/fuel-cost.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 22,
+              "name": "Hotel Cost",
+              "url": "https://tools.realtime-ai.chat/tools/travel/hotel-cost.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 23,
+              "name": "Itinerary Planner",
+              "url": "https://tools.realtime-ai.chat/tools/travel/itinerary-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 24,
+              "name": "Luggage Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 25,
+              "name": "Season Guide",
+              "url": "https://tools.realtime-ai.chat/tools/travel/season-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 26,
+              "name": "Time Difference",
+              "url": "https://tools.realtime-ai.chat/tools/travel/time-difference.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 27,
+              "name": "Timezone Converter",
+              "url": "https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 28,
+              "name": "Tip Guide",
+              "url": "https://tools.realtime-ai.chat/tools/travel/tip-guide.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 29,
+              "name": "Toll Calculator",
+              "url": "https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 30,
+              "name": "Travel Insurance",
+              "url": "https://tools.realtime-ai.chat/tools/travel/travel-insurance.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 31,
+              "name": "Trip Budget",
+              "url": "https://tools.realtime-ai.chat/tools/travel/trip-budget.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 32,
+              "name": "Trip Cost Splitter",
+              "url": "https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 33,
+              "name": "Vaccine Checker",
+              "url": "https://tools.realtime-ai.chat/tools/travel/vaccine-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 34,
+              "name": "Visa Checker",
+              "url": "https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 35,
+              "name": "Weather Planner",
+              "url": "https://tools.realtime-ai.chat/tools/travel/weather-planner.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 36,
+              "name": "旅行世界时钟",
+              "url": "https://tools.realtime-ai.chat/tools/travel/world-clock.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 37,
+              "name": "油耗成本计算器",
+              "url": "https://tools.realtime-ai.chat/tools/automotive/fuel-calculator.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 38,
+              "name": "GPX 轨迹查看器",
+              "url": "https://tools.realtime-ai.chat/tools/travel/gpx-track-viewer.html"
+            },
+            {
+              "@type": "ListItem",
+              "position": 39,
+              "name": "潮汐时刻查询",
+              "url": "https://tools.realtime-ai.chat/tools/travel/tide-chart-viewer.html"
+            }
+          ]
+        }
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/css/tool-base.css" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+      .cat-main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: calc(var(--nav-height) + var(--space-6)) var(--space-5) var(--space-10);
+      }
+      .cat-hero {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
+      .cat-hero-icon {
+        font-size: 3rem;
+        line-height: 1;
+      }
+      .cat-hero h1 {
+        font-size: 1.9rem;
+        margin: var(--space-3) 0 var(--space-2);
+      }
+      .cat-intro {
+        max-width: 640px;
+        margin: 0 auto var(--space-3);
+        color: var(--text-secondary);
+        line-height: 1.7;
+      }
+      .cat-meta {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .cat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: var(--space-3);
+      }
+      .cat-card {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        background: var(--bg-card);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          border-color var(--transition),
+          transform var(--transition);
+      }
+      .cat-card:hover {
+        border-color: var(--accent-cyan);
+        transform: translateY(-2px);
+      }
+      .cat-card-icon {
+        flex-shrink: 0;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+      .cat-card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .cat-card-name {
+        font-weight: 600;
+      }
+      .cat-card-desc {
+        font-size: 0.82rem;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .cat-faq {
+        margin-top: var(--space-10);
+      }
+      .cat-faq h2 {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+      }
+      .cat-footer {
+        margin-top: var(--space-8);
+        text-align: center;
+      }
+      .cat-footer a {
+        font-size: 0.9rem;
+        color: var(--accent-cyan);
+        text-decoration: none;
+      }
+      .cat-footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+    <script src="../../assets/js/tool-chrome.js"></script>
+  </head>
+  <body>
+    <main class="cat-main">
+      <header class="cat-hero">
+        <div class="cat-hero-icon">✈️</div>
+        <h1>旅行工具</h1>
+        <p class="cat-intro">
+          旅行规划相关的在线工具，涵盖行李清单、时差、预算、汇率、里程计算等出行需求。
+        </p>
+        <p class="cat-meta">39 个工具 · 纯本地运行 · 免费 · 无广告</p>
+      </header>
+      <section class="cat-grid">
+        <a class="cat-card" href="packing-list.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">旅行打包清单</span>
+            <span class="cat-card-desc">智能旅行打包清单，按目的地和天数生成</span>
+          </span>
+        </a>
+        <a class="cat-card" href="jet-lag-calc.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">时差倒时差计算</span>
+            <span class="cat-card-desc">计算跨时区旅行的时差影响</span>
+          </span>
+        </a>
+        <a class="cat-card" href="travel-budget.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">旅行预算计算</span>
+            <span class="cat-card-desc">规划和追踪旅行预算支出</span>
+          </span>
+        </a>
+        <a class="cat-card" href="currency-tips.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">货币兑换提示</span>
+            <span class="cat-card-desc">实时汇率查询和换汇建议</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../automotive/fuel-cost.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">油费计算器</span>
+            <span class="cat-card-desc">计算行车油费和油耗</span>
+          </span>
+        </a>
+        <a class="cat-card" href="visa-requirements.html">
+          <span class="cat-card-icon">✈️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">签证要求查询</span>
+            <span class="cat-card-desc">查询不同国家的签证要求和入境政策</span>
+          </span>
+        </a>
+        <a class="cat-card" href="emergency-contacts.html">
+          <span class="cat-card-icon">🆘</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">紧急联系方式</span>
+            <span class="cat-card-desc">旅行紧急联系信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="phrase-book.html">
+          <span class="cat-card-icon">💬</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">常用语手册</span>
+            <span class="cat-card-desc">旅行常用外语短语</span>
+          </span>
+        </a>
+        <a class="cat-card" href="size-converter.html">
+          <span class="cat-card-icon">👕</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">尺码转换器</span>
+            <span class="cat-card-desc">服装鞋码国际转换</span>
+          </span>
+        </a>
+        <a class="cat-card" href="power-adapter.html">
+          <span class="cat-card-icon">🔌</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">电源插座指南</span>
+            <span class="cat-card-desc">各国电源插座类型</span>
+          </span>
+        </a>
+        <a class="cat-card" href="driving-side.html">
+          <span class="cat-card-icon">🚗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">行车方向指南</span>
+            <span class="cat-card-desc">各国驾驶方向查询</span>
+          </span>
+        </a>
+        <a class="cat-card" href="passport-photo.html">
+          <span class="cat-card-icon">📸</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">证件照规格</span>
+            <span class="cat-card-desc">各国证件照尺寸要求</span>
+          </span>
+        </a>
+        <a class="cat-card" href="baggage-limit.html">
+          <span class="cat-card-icon">✈️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">行李限制查询</span>
+            <span class="cat-card-desc">航空公司行李规定</span>
+          </span>
+        </a>
+        <a class="cat-card" href="sim-card-guide.html">
+          <span class="cat-card-icon">📱</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">SIM 卡指南</span>
+            <span class="cat-card-desc">旅行目的地 SIM 卡信息</span>
+          </span>
+        </a>
+        <a class="cat-card" href="travel-checklist.html">
+          <span class="cat-card-icon">✅</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">旅行准备清单</span>
+            <span class="cat-card-desc">出行前准备事项清单</span>
+          </span>
+        </a>
+        <a class="cat-card" href="../automotive/tire-pressure-calc.html">
+          <span class="cat-card-icon">🚗</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">胎压转换</span>
+            <span class="cat-card-desc">轮胎压力单位转换PSI/Bar/kPa</span>
+          </span>
+        </a>
+        <a class="cat-card" href="baggage-tracker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Baggage Tracker</span>
+            <span class="cat-card-desc">
+              Baggage Tracker，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="currency-exchange.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Currency Exchange</span>
+            <span class="cat-card-desc">
+              Currency Exchange，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="distance-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Distance Calculator</span>
+            <span class="cat-card-desc">
+              Distance Calculator，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="flight-time.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Flight Time</span>
+            <span class="cat-card-desc">
+              Flight Time，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="fuel-cost.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Fuel Cost</span>
+            <span class="cat-card-desc">Fuel Cost，在线使用，旅行工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="hotel-cost.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Hotel Cost</span>
+            <span class="cat-card-desc">
+              Hotel Cost，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="itinerary-planner.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Itinerary Planner</span>
+            <span class="cat-card-desc">
+              Itinerary Planner，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="luggage-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Luggage Calculator</span>
+            <span class="cat-card-desc">
+              Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="season-guide.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Season Guide</span>
+            <span class="cat-card-desc">
+              Season Guide，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="time-difference.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Time Difference</span>
+            <span class="cat-card-desc">
+              Time Difference，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="timezone-converter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Timezone Converter</span>
+            <span class="cat-card-desc">
+              Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tip-guide.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Tip Guide</span>
+            <span class="cat-card-desc">Tip Guide，在线使用，旅行工具，浏览器本地运行无需上传</span>
+          </span>
+        </a>
+        <a class="cat-card" href="toll-calculator.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Toll Calculator</span>
+            <span class="cat-card-desc">
+              Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="travel-insurance.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Travel Insurance</span>
+            <span class="cat-card-desc">
+              Travel Insurance，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="trip-budget.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Trip Budget</span>
+            <span class="cat-card-desc">
+              Trip Budget，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="trip-cost-splitter.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Trip Cost Splitter</span>
+            <span class="cat-card-desc">
+              Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="vaccine-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Vaccine Checker</span>
+            <span class="cat-card-desc">
+              Vaccine Checker，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="visa-checker.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Visa Checker</span>
+            <span class="cat-card-desc">
+              Visa Checker，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="weather-planner.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">Weather Planner</span>
+            <span class="cat-card-desc">
+              Weather Planner，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="world-clock.html">
+          <span class="cat-card-icon">🔧</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">旅行世界时钟</span>
+            <span class="cat-card-desc">
+              旅行世界时钟，在线使用，旅行工具，浏览器本地运行无需上传
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="../automotive/fuel-calculator.html">
+          <span class="cat-card-icon">⛽</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">油耗成本计算器</span>
+            <span class="cat-card-desc">计算汽车油耗、行驶成本和燃油效率</span>
+          </span>
+        </a>
+        <a class="cat-card" href="gpx-track-viewer.html">
+          <span class="cat-card-icon">🗺️</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">GPX 轨迹查看器</span>
+            <span class="cat-card-desc">
+              上传 .gpx 文件，在地图上绘制 GPS
+              轨迹，显示总距离、爬升量、速度统计和时间轴，纯浏览器本地解析。
+            </span>
+          </span>
+        </a>
+        <a class="cat-card" href="tide-chart-viewer.html">
+          <span class="cat-card-icon">🌊</span>
+          <span class="cat-card-body">
+            <span class="cat-card-name">潮汐时刻查询</span>
+            <span class="cat-card-desc">
+              基于调和分析（Harmonic
+              Analysis）在浏览器端计算主要港口/地点的潮高曲线，展示当日高低潮时刻和潮差。
+            </span>
+          </span>
+        </a>
+      </section>
+      <footer class="cat-footer">
+        <a href="../../index.html">← 返回 WebUtils 全部工具</a>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## 背景

路线 A（流量站）执行清单第 3 步 —— 分类页做成内容枢纽。

调研发现：除 `ai-coding` 外没有分类落地页，分类浏览全靠首页锚点。本 PR 按既定方案「脚本生成」补齐。

## 改动

- **`tools.json`** —— 35 个分类各新增 `intro` 品类导购文案字段
- **`scripts/sync-all.js`** —— 新增 `generateCategoryPages()`：从 `tools.json` 用模板生成 `tools/<cat>/index.html`，含 SEO meta、`BreadcrumbList` + `CollectionPage` 结构化数据、工具卡片网格、共享基座悬浮外壳；并把分类页 URL 纳入 sitemap
- 已登记为工具的分类首页（`ai-coding` 手工导航页）**不覆盖**
- **测试** —— `sync.test.js` 的 sitemap loc 数校验改为「工具数 + 首页 + 分类落地页」并新增分类页存在性检查；`data-quality.test.js` 游离文件检查跳过 `tools/*/index.html`
- **`CLAUDE.md`** —— 补充分类落地页说明

## 结果

- 生成 34 个分类落地页（`ai-coding` 沿用既有页）
- sitemap：1087 → 1121 URL
- 所有 1081 条工具卡片链接已脚本校验有效（含 40 条跨目录链接），0 死链
- 二次 `npm run sync` 幂等，无额外 diff

## 验证

- `npm run lint` —— 1125 文件 0 错误
- `npm test` —— 54/54 通过
- `npm run format:check` —— 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)