### PR TITLE
fix: harden standalone HTML export

### DIFF
--- a/scripts/export-standalone.mjs
+++ b/scripts/export-standalone.mjs
@@ -19,15 +19,40 @@ function isExternalUrl(value) {
   return /^(https?:)?\/\//i.test(value) || /^(data|mailto|tel):/i.test(value);
 }
 
+function relativeFromRoot(filePath) {
+  return toPosix(path.relative(ROOT, filePath));
+}
+
+function isInsideRoot(filePath) {
+  const relative = path.relative(ROOT, filePath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function assertInsideRoot(filePath, label) {
+  if (!isInsideRoot(filePath)) {
+    throw new Error(`Refusing to ${label} outside repository: ${filePath}`);
+  }
+}
+
+function escapeInlineScript(js) {
+  return js.replace(/<\/script/gi, '<\\/script');
+}
+
+function escapeInlineStyle(css) {
+  return css.replace(/<\/style/gi, '<\\/style');
+}
+
 function readFileIfExists(filePath) {
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-    throw new Error(`Missing local dependency: ${toPosix(path.relative(ROOT, filePath))}`);
+    throw new Error(`Missing local dependency: ${relativeFromRoot(filePath)}`);
   }
   return fs.readFileSync(filePath, 'utf8');
 }
 
 function resolveLocalDependency(htmlPath, ref) {
-  return path.resolve(path.dirname(htmlPath), ref);
+  const localPath = path.resolve(path.dirname(htmlPath), ref);
+  assertInsideRoot(localPath, 'inline dependency');
+  return localPath;
 }
 
 function stripLocalNonEssentialLinks(html, htmlPath) {
@@ -40,7 +65,7 @@ function stripLocalNonEssentialLinks(html, htmlPath) {
     if (!isIcon && !isManifest) return tag;
 
     const localPath = resolveLocalDependency(htmlPath, href);
-    const relPath = toPosix(path.relative(ROOT, localPath));
+    const relPath = relativeFromRoot(localPath);
     return `\n    <!-- Standalone export omitted local ${isManifest ? 'manifest' : 'icon'}: ${relPath} -->`;
   });
 }
@@ -52,8 +77,8 @@ function inlineLocalStylesheets(html, htmlPath) {
     if (!href || isExternalUrl(href) || !/\bstylesheet\b/i.test(rel)) return tag;
 
     const localPath = resolveLocalDependency(htmlPath, href);
-    const css = readFileIfExists(localPath);
-    const relPath = toPosix(path.relative(ROOT, localPath));
+    const css = escapeInlineStyle(readFileIfExists(localPath));
+    const relPath = relativeFromRoot(localPath);
     return `<style data-standalone-inlined="${relPath}">\n${css}\n</style>`;
   });
 }
@@ -65,8 +90,8 @@ function inlineLocalScripts(html, htmlPath) {
       if (isExternalUrl(src)) return tag;
 
       const localPath = resolveLocalDependency(htmlPath, src);
-      const js = readFileIfExists(localPath);
-      const relPath = toPosix(path.relative(ROOT, localPath));
+      const js = escapeInlineScript(readFileIfExists(localPath));
+      const relPath = relativeFromRoot(localPath);
       const attrs = `${before}${after}`
         .replace(/\s*defer\b/gi, '')
         .replace(/\s*async\b/gi, '')
@@ -110,6 +135,7 @@ const toolPath = toPosix(path.normalize(input));
 const htmlPath = path.resolve(ROOT, toolPath);
 
 try {
+  assertInsideRoot(htmlPath, 'read tool');
   assertRegisteredTool(toolPath);
   let html = readFileIfExists(htmlPath);
   html = stripLocalNonEssentialLinks(html, htmlPath);

--- a/tests/standalone-export.test.js
+++ b/tests/standalone-export.test.js
@@ -6,7 +6,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { section, test, assert, ROOT } from './_harness.js';
 
 section('独立 HTML 导出');
@@ -33,6 +33,12 @@ function runExport(toolPath) {
     cwd: ROOT,
     stdio: 'pipe'
   });
+}
+
+function exportedInlineScriptBodies(html) {
+  return [
+    ...html.matchAll(/<script[^>]*data-standalone-inlined="[^"]+"[^>]*>([\s\S]*?)<\/script>/gi)
+  ].map((match) => match[1]);
 }
 
 test('可导出多个代表性已登记工具为 standalone HTML', () => {
@@ -74,4 +80,50 @@ test('standalone HTML 不保留本地共享资源引用', () => {
     }
   }
   assert(bad.length === 0, bad.join('\n'));
+});
+
+test('standalone HTML 转义内联脚本中的结束标签序列', () => {
+  const bad = [];
+  for (const toolPath of toolPaths) {
+    const html = exportedHtml(toolPath);
+    const scriptBodies = exportedInlineScriptBodies(html);
+    if (scriptBodies.some((body) => /<\/script/i.test(body))) {
+      bad.push(`${toolPath}: 内联脚本包含未转义 </script>`);
+    }
+  }
+  assert(bad.length === 0, bad.join('\n'));
+});
+
+test('standalone 导出拒绝内联仓库外本地依赖', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webutils-escape-fixture-'));
+  const fixturePath = path.join(fixtureDir, 'outside.css');
+  const toolPath = 'tools/dev/json-formatter.html';
+  const originalTool = fs.readFileSync(path.join(ROOT, toolPath), 'utf8');
+  const originalToolsJson = fs.readFileSync(path.join(ROOT, 'tools.json'), 'utf8');
+  const relativeOutside = path.relative(path.join(ROOT, 'tools/dev'), fixturePath);
+
+  fs.writeFileSync(fixturePath, 'body { color: red; }');
+
+  try {
+    const patchedTool = originalTool.replace(
+      '</head>',
+      `  <link rel="stylesheet" href="${relativeOutside}" />\n  </head>`
+    );
+    fs.writeFileSync(path.join(ROOT, toolPath), patchedTool);
+
+    const result = spawnSync('node', ['scripts/export-standalone.mjs', toolPath, outDir], {
+      cwd: ROOT,
+      encoding: 'utf8'
+    });
+
+    assert(result.status !== 0, '导出应拒绝仓库外依赖');
+    assert(
+      result.stderr.includes('outside repository'),
+      `错误信息应说明仓库外依赖，实际为: ${result.stderr}`
+    );
+  } finally {
+    fs.writeFileSync(path.join(ROOT, toolPath), originalTool);
+    fs.writeFileSync(path.join(ROOT, 'tools.json'), originalToolsJson);
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary\n- Escape HTML end-tag sequences in inlined local CSS/JS for standalone exports\n- Refuse to inline local dependencies outside the repository root\n- Add regression coverage for script end-tag escaping and repo-bound dependency resolution\n\n## Verification\n- npm run lint\n- npm test\n- npx prettier --check scripts/export-standalone.mjs tests/standalone-export.test.js\n- npm run build\n- git diff --check\n\nStacked on #175.