### PR TITLE
fix: align Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "public": true,
-  "outputDirectory": ".",
+  "outputDirectory": "dist",
   "cleanUrls": true,
   "trailingSlash": false,
   "headers": [


### PR DESCRIPTION
## Summary\n- Set Vercel output directory to dist so Preview deployments use the actual npm run build artifact\n\n## Verification\n- npm run lint\n- npm test\n- npx prettier --check vercel.json\n- npm run build\n- npx vercel pull --yes --scope chico-projects && npx vercel build --scope chico-projects\n- git diff --check\n\nStacked on #175 to avoid unrelated master baseline lint drift.