### PR TITLE
style: prettier format the 62 files changed in functional QA PR (#178)

### DIFF
--- a/tools/calculator/tip-calculator.html
+++ b/tools/calculator/tip-calculator.html
@@ -6,17 +6,29 @@
     <title>小费/AA计算器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="tip calculator 小费/aa计算器" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="小费/AA计算器 - WebUtils" />
-    <meta property="og:description" content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="小费/AA计算器 - WebUtils" />
-    <meta name="twitter:description" content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="小费/AA计算器，快速计算结果，计算器，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "计算器",
-      "item": "https://tools.realtime-ai.chat/tools/calculator/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "小费/AA计算器",
-      "item": "https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "计算器",
+            "item": "https://tools.realtime-ai.chat/tools/calculator/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "小费/AA计算器",
+            "item": "https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "小费/AA计算器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "小费/AA计算器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,592 +103,603 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap" rel="stylesheet">
-<style>
-  body {
-    min-height: 100vh;
-    background:
-      radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent), var(--bg-deep);
-  }
 
-  .tip-wrap {
-    max-width: 520px;
-    margin: 0 auto;
-    padding: 56px 20px 140px;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        min-height: 100vh;
+        background:
+          radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent),
+          var(--bg-deep);
+      }
 
-  .tip-head {
-    text-align: center;
-    margin-bottom: var(--space-8);
-  }
+      .tip-wrap {
+        max-width: 520px;
+        margin: 0 auto;
+        padding: 56px 20px 140px;
+      }
 
-  .tip-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: 5px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--accent-cyan);
-    background: var(--glow-cyan);
-    border: 1px solid var(--tb-glass-border);
-    border-radius: var(--radius-full);
-  }
+      .tip-head {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
 
-  .tip-head h1 {
-    margin: var(--space-4) 0 var(--space-2);
-    font-size: 30px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-  }
+      .tip-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 5px 12px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-cyan);
+        background: var(--glow-cyan);
+        border: 1px solid var(--tb-glass-border);
+        border-radius: var(--radius-full);
+      }
 
-  .tip-head p {
-    margin: 0;
-    color: var(--text-muted);
-    font-size: 14px;
-  }
+      .tip-head h1 {
+        margin: var(--space-4) 0 var(--space-2);
+        font-size: 30px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
 
-  .tip-card {
-    position: relative;
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-  }
+      .tip-head p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 14px;
+      }
 
-  .tip-card::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
-  }
+      .tip-card {
+        position: relative;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-lg);
+        overflow: hidden;
+      }
 
-  .tip-body {
-    padding: var(--space-8) var(--space-6) var(--space-6);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-6);
-  }
+      .tip-card::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
+      }
 
-  .field-label {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: var(--space-3);
-    font-size: 13px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    color: var(--text-secondary);
-  }
+      .tip-body {
+        padding: var(--space-8) var(--space-6) var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-6);
+      }
 
-  .field-hint {
-    font-weight: 500;
-    color: var(--text-muted);
-  }
+      .field-label {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: var(--space-3);
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: var(--text-secondary);
+      }
 
-  .amount-box {
-    display: flex;
-    align-items: center;
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    padding: 0 var(--space-4);
-    transition:
-      border-color var(--transition-fast),
-      box-shadow var(--transition-fast);
-  }
+      .field-hint {
+        font-weight: 500;
+        color: var(--text-muted);
+      }
 
-  .amount-box:focus-within {
-    border-color: var(--accent-cyan);
-    box-shadow: 0 0 0 3px var(--glow-cyan);
-  }
+      .amount-box {
+        display: flex;
+        align-items: center;
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        padding: 0 var(--space-4);
+        transition:
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
 
-  .amount-box .sign {
-    font-family: var(--font-mono);
-    font-size: 22px;
-    font-weight: 700;
-    color: var(--text-muted);
-  }
+      .amount-box:focus-within {
+        border-color: var(--accent-cyan);
+        box-shadow: 0 0 0 3px var(--glow-cyan);
+      }
 
-  .amount-box input {
-    flex: 1;
-    width: 100%;
-    border: none;
-    background: none;
-    outline: none;
-    padding: var(--space-4) var(--space-2);
-    font-family: var(--font-mono);
-    font-size: 28px;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
+      .amount-box .sign {
+        font-family: var(--font-mono);
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--text-muted);
+      }
 
-  .amount-box input::placeholder {
-    color: var(--border-strong);
-  }
+      .amount-box input {
+        flex: 1;
+        width: 100%;
+        border: none;
+        background: none;
+        outline: none;
+        padding: var(--space-4) var(--space-2);
+        font-family: var(--font-mono);
+        font-size: 28px;
+        font-weight: 700;
+        color: var(--text-primary);
+      }
 
-  .chips {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: var(--space-2);
-  }
+      .amount-box input::placeholder {
+        color: var(--border-strong);
+      }
 
-  .chip {
-    padding: 11px 0;
-    font-family: var(--font-mono);
-    font-size: 15px;
-    font-weight: 700;
-    color: var(--text-secondary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .chips {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: var(--space-2);
+      }
 
-  .chip:hover {
-    color: var(--text-primary);
-    border-color: var(--accent-cyan);
-  }
+      .chip {
+        padding: 11px 0;
+        font-family: var(--font-mono);
+        font-size: 15px;
+        font-weight: 700;
+        color: var(--text-secondary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .chip.active {
-    color: #06121a;
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .chip:hover {
+        color: var(--text-primary);
+        border-color: var(--accent-cyan);
+      }
 
-  .custom-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    margin-top: var(--space-3);
-  }
+      .chip.active {
+        color: #06121a;
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .custom-row input[type="range"] {
-    flex: 1;
-    accent-color: var(--accent-cyan);
-  }
+      .custom-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-top: var(--space-3);
+      }
 
-  .custom-pct {
-    min-width: 56px;
-    text-align: right;
-    font-family: var(--font-mono);
-    font-size: 15px;
-    font-weight: 700;
-    color: var(--accent-cyan);
-  }
+      .custom-row input[type="range"] {
+        flex: 1;
+        accent-color: var(--accent-cyan);
+      }
 
-  .stepper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    padding: var(--space-2);
-  }
+      .custom-pct {
+        min-width: 56px;
+        text-align: right;
+        font-family: var(--font-mono);
+        font-size: 15px;
+        font-weight: 700;
+        color: var(--accent-cyan);
+      }
 
-  .stepper button {
-    width: 44px;
-    height: 44px;
-    font-size: 22px;
-    font-weight: 700;
-    color: var(--text-primary);
-    background: var(--bg-card);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .stepper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        padding: var(--space-2);
+      }
 
-  .stepper button:hover {
-    border-color: var(--accent-cyan);
-    color: var(--accent-cyan);
-  }
+      .stepper button {
+        width: 44px;
+        height: 44px;
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--text-primary);
+        background: var(--bg-card);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .stepper .count {
-    font-family: var(--font-mono);
-    font-size: 22px;
-    font-weight: 700;
-  }
+      .stepper button:hover {
+        border-color: var(--accent-cyan);
+        color: var(--accent-cyan);
+      }
 
-  .stepper .count small {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-muted);
-  }
+      .stepper .count {
+        font-family: var(--font-mono);
+        font-size: 22px;
+        font-weight: 700;
+      }
 
-  .round-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 14px;
-    color: var(--text-secondary);
-  }
+      .stepper .count small {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-muted);
+      }
 
-  .switch {
-    position: relative;
-    width: 46px;
-    height: 26px;
-    flex-shrink: 0;
-  }
+      .round-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 14px;
+        color: var(--text-secondary);
+      }
 
-  .switch input {
-    position: absolute;
-    opacity: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    cursor: pointer;
-  }
+      .switch {
+        position: relative;
+        width: 46px;
+        height: 26px;
+        flex-shrink: 0;
+      }
 
-  .switch .track {
-    position: absolute;
-    inset: 0;
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-full);
-    transition:
-      background var(--transition-fast),
-      border-color var(--transition-fast);
-  }
+      .switch input {
+        position: absolute;
+        opacity: 0;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        cursor: pointer;
+      }
 
-  .switch .track::after {
-    content: "";
-    position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 18px;
-    height: 18px;
-    background: var(--text-muted);
-    border-radius: 50%;
-    transition:
-      transform var(--transition-fast),
-      background var(--transition-fast);
-  }
+      .switch .track {
+        position: absolute;
+        inset: 0;
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-full);
+        transition:
+          background var(--transition-fast),
+          border-color var(--transition-fast);
+      }
 
-  .switch input:checked + .track {
-    background: var(--glow-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .switch .track::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        width: 18px;
+        height: 18px;
+        background: var(--text-muted);
+        border-radius: 50%;
+        transition:
+          transform var(--transition-fast),
+          background var(--transition-fast);
+      }
 
-  .switch input:checked + .track::after {
-    transform: translateX(20px);
-    background: var(--accent-cyan);
-  }
+      .switch input:checked + .track {
+        background: var(--glow-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .result {
-    background: linear-gradient(160deg, var(--bg-surface), var(--bg-input));
-    border-top: 1px solid var(--border-subtle);
-    padding: var(--space-6);
-  }
+      .switch input:checked + .track::after {
+        transform: translateX(20px);
+        background: var(--accent-cyan);
+      }
 
-  .result-hero {
-    text-align: center;
-    margin-bottom: var(--space-5);
-  }
+      .result {
+        background: linear-gradient(160deg, var(--bg-surface), var(--bg-input));
+        border-top: 1px solid var(--border-subtle);
+        padding: var(--space-6);
+      }
 
-  .result-hero .cap {
-    font-size: 13px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    color: var(--text-muted);
-  }
+      .result-hero {
+        text-align: center;
+        margin-bottom: var(--space-5);
+      }
 
-  .result-hero .big {
-    margin-top: var(--space-1);
-    font-family: var(--font-mono);
-    font-size: 46px;
-    font-weight: 700;
-    line-height: 1.1;
-    letter-spacing: -0.02em;
-    background: linear-gradient(120deg, var(--accent-cyan), var(--accent-blue));
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
+      .result-hero .cap {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        color: var(--text-muted);
+      }
 
-  .breakdown {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
+      .result-hero .big {
+        margin-top: var(--space-1);
+        font-family: var(--font-mono);
+        font-size: 46px;
+        font-weight: 700;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+        background: linear-gradient(120deg, var(--accent-cyan), var(--accent-blue));
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
 
-  .b-row {
-    display: flex;
-    justify-content: space-between;
-    padding: var(--space-2) 0;
-    font-size: 14px;
-    color: var(--text-secondary);
-  }
+      .breakdown {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
 
-  .b-row.total {
-    margin-top: var(--space-1);
-    padding-top: var(--space-3);
-    border-top: 1px dashed var(--border-strong);
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
+      .b-row {
+        display: flex;
+        justify-content: space-between;
+        padding: var(--space-2) 0;
+        font-size: 14px;
+        color: var(--text-secondary);
+      }
 
-  .b-row .v {
-    font-family: var(--font-mono);
-    font-weight: 700;
-    color: var(--text-primary);
-  }
+      .b-row.total {
+        margin-top: var(--space-1);
+        padding-top: var(--space-3);
+        border-top: 1px dashed var(--border-strong);
+        font-size: 16px;
+        font-weight: 700;
+        color: var(--text-primary);
+      }
 
-  .tip-foot {
-    margin-top: var(--space-6);
-    text-align: center;
-    font-size: 12px;
-    color: var(--text-muted);
-    line-height: 1.7;
-  }
+      .b-row .v {
+        font-family: var(--font-mono);
+        font-weight: 700;
+        color: var(--text-primary);
+      }
 
-  @media (max-width: 480px) {
-    .tip-wrap {
-      padding: 36px 14px 140px;
-    }
+      .tip-foot {
+        margin-top: var(--space-6);
+        text-align: center;
+        font-size: 12px;
+        color: var(--text-muted);
+        line-height: 1.7;
+      }
 
-    .tip-head h1 {
-      font-size: 25px;
-    }
+      @media (max-width: 480px) {
+        .tip-wrap {
+          padding: 36px 14px 140px;
+        }
 
-    .result-hero .big {
-      font-size: 38px;
-    }
-  }
-</style>
+        .tip-head h1 {
+          font-size: 25px;
+        }
+
+        .result-hero .big {
+          font-size: 38px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="tip-wrap">
-  <header class="tip-head">
-    <span class="tip-badge">计算工具</span>
-    <h1>小费计算器</h1>
-    <p>输入账单与小费比例，自动算出小费、总额并按人数 AA 分摊</p>
-  </header>
+        <header class="tip-head">
+          <span class="tip-badge">计算工具</span>
+          <h1>小费计算器</h1>
+          <p>输入账单与小费比例，自动算出小费、总额并按人数 AA 分摊</p>
+        </header>
 
-  <section class="tip-card">
-    <div class="tip-body">
-      <div>
-        <div class="field-label"><span>账单金额</span></div>
-        <div class="amount-box">
-          <span class="sign">¥</span>
-          <input type="number" id="bill" inputmode="decimal" min="0" step="0.01" placeholder="0.00" aria-label="账单金额">
-        </div>
-      </div>
+        <section class="tip-card">
+          <div class="tip-body">
+            <div>
+              <div class="field-label"><span>账单金额</span></div>
+              <div class="amount-box">
+                <span class="sign">¥</span>
+                <input
+                  type="number"
+                  id="bill"
+                  inputmode="decimal"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  aria-label="账单金额"
+                />
+              </div>
+            </div>
 
-      <div>
-        <div class="field-label">
-          <span>小费比例</span>
-          <span class="field-hint" id="pctEcho">15%</span>
-        </div>
-        <div class="chips" id="chips">
-          <button class="chip" type="button" data-pct="10">10%</button>
-          <button class="chip active" type="button" data-pct="15">15%</button>
-          <button class="chip" type="button" data-pct="18">18%</button>
-          <button class="chip" type="button" data-pct="20">20%</button>
-          <button class="chip" type="button" data-pct="25">25%</button>
-        </div>
-        <div class="custom-row">
-          <input type="range" id="pctRange" min="0" max="40" step="1" value="15">
-          <span class="custom-pct" id="customPct">自定义</span>
-        </div>
-      </div>
+            <div>
+              <div class="field-label">
+                <span>小费比例</span>
+                <span class="field-hint" id="pctEcho">15%</span>
+              </div>
+              <div class="chips" id="chips">
+                <button class="chip" type="button" data-pct="10">10%</button>
+                <button class="chip active" type="button" data-pct="15">15%</button>
+                <button class="chip" type="button" data-pct="18">18%</button>
+                <button class="chip" type="button" data-pct="20">20%</button>
+                <button class="chip" type="button" data-pct="25">25%</button>
+              </div>
+              <div class="custom-row">
+                <input type="range" id="pctRange" min="0" max="40" step="1" value="15" />
+                <span class="custom-pct" id="customPct">自定义</span>
+              </div>
+            </div>
 
-      <div>
-        <div class="field-label"><span>用餐人数</span></div>
-        <div class="stepper">
-          <button type="button" id="minus" aria-label="减少人数">−</button>
-          <span class="count">
-            <span id="people">1</span>
-            <small>人</small>
-          </span>
-          <button type="button" id="plus" aria-label="增加人数">+</button>
-        </div>
-      </div>
+            <div>
+              <div class="field-label"><span>用餐人数</span></div>
+              <div class="stepper">
+                <button type="button" id="minus" aria-label="减少人数">−</button>
+                <span class="count">
+                  <span id="people">1</span>
+                  <small>人</small>
+                </span>
+                <button type="button" id="plus" aria-label="增加人数">+</button>
+              </div>
+            </div>
 
-      <label class="round-row" for="roundUp">
-        <span>每人金额向上取整</span>
-        <span class="switch">
-          <input type="checkbox" id="roundUp">
-          <span class="track"></span>
-        </span>
-      </label>
+            <label class="round-row" for="roundUp">
+              <span>每人金额向上取整</span>
+              <span class="switch">
+                <input type="checkbox" id="roundUp" />
+                <span class="track"></span>
+              </span>
+            </label>
+          </div>
+
+          <div class="result">
+            <div class="result-hero">
+              <div class="cap">每人应付</div>
+              <div class="big" id="perPerson">¥0.00</div>
+            </div>
+            <div class="breakdown">
+              <div class="b-row">
+                <span>账单金额</span>
+                <span class="v" id="rBill">¥0.00</span>
+              </div>
+              <div class="b-row">
+                <span>
+                  小费
+                  <span id="rPctTag">· 15%</span>
+                </span>
+                <span class="v" id="rTip">¥0.00</span>
+              </div>
+              <div class="b-row total">
+                <span>合计支付</span>
+                <span class="v" id="rTotal">¥0.00</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <p class="tip-foot">
+          全部计算在你的浏览器本地完成，不会上传任何数据。
+          <br />
+          参数实时保存在网址里，复制链接即可分享这笔账单。
+        </p>
+      </main>
     </div>
 
-    <div class="result">
-      <div class="result-hero">
-        <div class="cap">每人应付</div>
-        <div class="big" id="perPerson">¥0.00</div>
-      </div>
-      <div class="breakdown">
-        <div class="b-row">
-          <span>账单金额</span>
-          <span class="v" id="rBill">¥0.00</span>
-        </div>
-        <div class="b-row">
-          <span>
-            小费
-            <span id="rPctTag">· 15%</span>
-          </span>
-          <span class="v" id="rTip">¥0.00</span>
-        </div>
-        <div class="b-row total">
-          <span>合计支付</span>
-          <span class="v" id="rTotal">¥0.00</span>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <p class="tip-foot">
-    全部计算在你的浏览器本地完成，不会上传任何数据。
-    <br>
-    参数实时保存在网址里，复制链接即可分享这笔账单。
-  </p>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "计算工具",
-              "item": "https://tools.realtime-ai.chat/#calculator"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "小费计算器",
-              "item": "https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "计算工具",
+            "item": "https://tools.realtime-ai.chat/#calculator"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "小费计算器",
+            "item": "https://tools.realtime-ai.chat/tools/calculator/tip-calculator.html"
+          }
+        ]
+      }
     </script>
     <script>
+      (function () {
+        var state = { bill: 0, pct: 15, people: 1, round: false };
 
-  (function () {
-          var state = { bill: 0, pct: 15, people: 1, round: false };
+        var $ = function (id) {
+          return document.getElementById(id);
+        };
+        var fmt = function (n) {
+          return "¥" + (Math.round(n * 100) / 100).toFixed(2);
+        };
 
-          var $ = function (id) {
-            return document.getElementById(id);
-          };
-          var fmt = function (n) {
-            return "¥" + (Math.round(n * 100) / 100).toFixed(2);
-          };
-
-          function render() {
-            var tip = state.bill * (state.pct / 100);
-            var total = state.bill + tip;
-            var per = total / state.people;
-            if (state.round) {
-              per = Math.ceil(per);
-              total = per * state.people;
-              tip = total - state.bill;
-            }
-            $("perPerson").textContent = fmt(per);
-            $("rBill").textContent = fmt(state.bill);
-            $("rTip").textContent = fmt(tip);
-            $("rTotal").textContent = fmt(total);
-            $("rPctTag").textContent = " · " + state.pct + "%";
-            $("pctEcho").textContent = state.pct + "%";
-            syncHash();
+        function render() {
+          var tip = state.bill * (state.pct / 100);
+          var total = state.bill + tip;
+          var per = total / state.people;
+          if (state.round) {
+            per = Math.ceil(per);
+            total = per * state.people;
+            tip = total - state.bill;
           }
+          $("perPerson").textContent = fmt(per);
+          $("rBill").textContent = fmt(state.bill);
+          $("rTip").textContent = fmt(tip);
+          $("rTotal").textContent = fmt(total);
+          $("rPctTag").textContent = " · " + state.pct + "%";
+          $("pctEcho").textContent = state.pct + "%";
+          syncHash();
+        }
 
-          function syncChips() {
-            var matched = false;
-            document.querySelectorAll(".chip").forEach(function (c) {
-              var on = Number(c.dataset.pct) === state.pct;
-              c.classList.toggle("active", on);
-              if (on) matched = true;
-            });
-            $("customPct").textContent = matched ? "自定义" : state.pct + "%";
-            $("pctRange").value = state.pct;
+        function syncChips() {
+          var matched = false;
+          document.querySelectorAll(".chip").forEach(function (c) {
+            var on = Number(c.dataset.pct) === state.pct;
+            c.classList.toggle("active", on);
+            if (on) matched = true;
+          });
+          $("customPct").textContent = matched ? "自定义" : state.pct + "%";
+          $("pctRange").value = state.pct;
+        }
+
+        function syncHash() {
+          var p = new URLSearchParams();
+          if (state.bill) p.set("b", state.bill);
+          p.set("p", state.pct);
+          p.set("n", state.people);
+          if (state.round) p.set("r", "1");
+          history.replaceState(null, "", "#" + p.toString());
+        }
+
+        function loadHash() {
+          var p = new URLSearchParams(location.hash.slice(1));
+          if (p.has("b")) {
+            state.bill = parseFloat(p.get("b")) || 0;
+            $("bill").value = state.bill || "";
           }
-
-          function syncHash() {
-            var p = new URLSearchParams();
-            if (state.bill) p.set("b", state.bill);
-            p.set("p", state.pct);
-            p.set("n", state.people);
-            if (state.round) p.set("r", "1");
-            history.replaceState(null, "", "#" + p.toString());
+          if (p.has("p")) state.pct = Math.min(40, Math.max(0, parseInt(p.get("p"), 10) || 15));
+          if (p.has("n")) state.people = Math.max(1, parseInt(p.get("n"), 10) || 1);
+          if (p.get("r") === "1") {
+            state.round = true;
+            $("roundUp").checked = true;
           }
+          $("people").textContent = state.people;
+        }
 
-          function loadHash() {
-            var p = new URLSearchParams(location.hash.slice(1));
-            if (p.has("b")) {
-              state.bill = parseFloat(p.get("b")) || 0;
-              $("bill").value = state.bill || "";
-            }
-            if (p.has("p")) state.pct = Math.min(40, Math.max(0, parseInt(p.get("p"), 10) || 15));
-            if (p.has("n")) state.people = Math.max(1, parseInt(p.get("n"), 10) || 1);
-            if (p.get("r") === "1") {
-              state.round = true;
-              $("roundUp").checked = true;
-            }
-            $("people").textContent = state.people;
-          }
+        $("bill").addEventListener("input", function () {
+          state.bill = parseFloat(this.value) || 0;
+          render();
+        });
 
-          $("bill").addEventListener("input", function () {
-            state.bill = parseFloat(this.value) || 0;
-            render();
-          });
-
-          $("chips").addEventListener("click", function (e) {
-            var chip = e.target.closest(".chip");
-            if (!chip) return;
-            state.pct = Number(chip.dataset.pct);
-            syncChips();
-            render();
-          });
-
-          $("pctRange").addEventListener("input", function () {
-            state.pct = Number(this.value);
-            syncChips();
-            render();
-          });
-
-          $("minus").addEventListener("click", function () {
-            state.people = Math.max(1, state.people - 1);
-            $("people").textContent = state.people;
-            render();
-          });
-
-          $("plus").addEventListener("click", function () {
-            state.people = Math.min(99, state.people + 1);
-            $("people").textContent = state.people;
-            render();
-          });
-
-          $("roundUp").addEventListener("change", function () {
-            state.round = this.checked;
-            render();
-          });
-
-          loadHash();
+        $("chips").addEventListener("click", function (e) {
+          var chip = e.target.closest(".chip");
+          if (!chip) return;
+          state.pct = Number(chip.dataset.pct);
           syncChips();
           render();
-        })();
-</script>
-    
+        });
+
+        $("pctRange").addEventListener("input", function () {
+          state.pct = Number(this.value);
+          syncChips();
+          render();
+        });
+
+        $("minus").addEventListener("click", function () {
+          state.people = Math.max(1, state.people - 1);
+          $("people").textContent = state.people;
+          render();
+        });
+
+        $("plus").addEventListener("click", function () {
+          state.people = Math.min(99, state.people + 1);
+          $("people").textContent = state.people;
+          render();
+        });
+
+        $("roundUp").addEventListener("change", function () {
+          state.round = this.checked;
+          render();
+        });
+
+        loadHash();
+        syncChips();
+        render();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/converter/weight-converter.html
+++ b/tools/converter/weight-converter.html
@@ -10,13 +10,22 @@
     <meta name="keywords" content="weight converter" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/converter/weight-converter.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="Weight Converter - WebUtils" />
-    <meta property="og:description" content="Weight Converter，在线使用，转换器，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Weight Converter，在线使用，转换器，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/converter/weight-converter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Weight Converter - WebUtils" />
-    <meta name="twitter:description" content="Weight Converter，在线使用，转换器，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Weight Converter，在线使用，转换器，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "转换器",
-      "item": "https://tools.realtime-ai.chat/tools/converter/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Weight Converter",
-      "item": "https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "转换器",
+            "item": "https://tools.realtime-ai.chat/tools/converter/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Weight Converter",
+            "item": "https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Weight Converter - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Weight Converter - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,348 +100,358 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap" rel="stylesheet">
-<style>
-  body {
-    min-height: 100vh;
-    background:
-      radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent), var(--bg-deep);
-  }
 
-  .tool-wrap {
-    max-width: 580px;
-    margin: 0 auto;
-    padding: 56px 20px 140px;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        min-height: 100vh;
+        background:
+          radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent),
+          var(--bg-deep);
+      }
 
-  .tool-head {
-    text-align: center;
-    margin-bottom: var(--space-8);
-  }
+      .tool-wrap {
+        max-width: 580px;
+        margin: 0 auto;
+        padding: 56px 20px 140px;
+      }
 
-  .tool-badge {
-    display: inline-block;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--accent-cyan);
-    background: var(--glow-cyan);
-    border: 1px solid var(--tb-glass-border);
-    border-radius: var(--radius-full);
-  }
+      .tool-head {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
 
-  .tool-head h1 {
-    margin: var(--space-4) 0 var(--space-2);
-    font-size: 29px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-  }
+      .tool-badge {
+        display: inline-block;
+        padding: 5px 12px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-cyan);
+        background: var(--glow-cyan);
+        border: 1px solid var(--tb-glass-border);
+        border-radius: var(--radius-full);
+      }
 
-  .tool-head p {
-    margin: 0;
-    font-size: 14px;
-    color: var(--text-muted);
-  }
+      .tool-head h1 {
+        margin: var(--space-4) 0 var(--space-2);
+        font-size: 29px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
 
-  .panel {
-    position: relative;
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-  }
+      .tool-head p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
 
-  .panel::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
-  }
+      .panel {
+        position: relative;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-lg);
+        overflow: hidden;
+      }
 
-  .panel-body {
-    padding: var(--space-8) var(--space-6) var(--space-6);
-  }
+      .panel::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
+      }
 
-  .quick {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-    margin-bottom: var(--space-5);
-  }
+      .panel-body {
+        padding: var(--space-8) var(--space-6) var(--space-6);
+      }
 
-  .quick button {
-    padding: 7px 13px;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-secondary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-full);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .quick {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin-bottom: var(--space-5);
+      }
 
-  .quick button:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .quick button {
+        padding: 7px 13px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-full);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-  }
+      .quick button:hover {
+        color: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .input-row input {
-    flex: 1;
-    min-width: 0;
-    padding: 14px 16px;
-    font-family: var(--font-mono);
-    font-size: 24px;
-    font-weight: 700;
-    color: var(--text-primary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    transition:
-      border-color var(--transition-fast),
-      box-shadow var(--transition-fast);
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+      }
 
-  .input-row select {
-    width: 130px;
-    padding: 0 12px;
-    font-family: var(--font-sans);
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--text-primary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    cursor: pointer;
-  }
+      .input-row input {
+        flex: 1;
+        min-width: 0;
+        padding: 14px 16px;
+        font-family: var(--font-mono);
+        font-size: 24px;
+        font-weight: 700;
+        color: var(--text-primary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        transition:
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
 
-  .input-row input:focus,
-  .input-row select:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-    box-shadow: 0 0 0 3px var(--glow-cyan);
-  }
+      .input-row select {
+        width: 130px;
+        padding: 0 12px;
+        font-family: var(--font-sans);
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text-primary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        cursor: pointer;
+      }
 
-  .group-label {
-    margin: var(--space-6) 0 var(--space-3);
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-muted);
-  }
+      .input-row input:focus,
+      .input-row select:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+        box-shadow: 0 0 0 3px var(--glow-cyan);
+      }
 
-  .results {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
+      .group-label {
+        margin: var(--space-6) 0 var(--space-3);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
 
-  .row {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    padding: 11px 14px;
-    border: 1px solid transparent;
-    border-radius: var(--radius-md);
-    transition: background var(--transition-fast);
-  }
+      .results {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
 
-  .row:hover {
-    background: var(--bg-input);
-  }
+      .row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 11px 14px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        transition: background var(--transition-fast);
+      }
 
-  .row .unit {
-    font-size: 14px;
-    color: var(--text-secondary);
-  }
+      .row:hover {
+        background: var(--bg-input);
+      }
 
-  .row .val {
-    font-family: var(--font-mono);
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
+      .row .unit {
+        font-size: 14px;
+        color: var(--text-secondary);
+      }
 
-  .row.highlight {
-    background: var(--glow-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .row .val {
+        font-family: var(--font-mono);
+        font-size: 16px;
+        font-weight: 700;
+        color: var(--text-primary);
+      }
 
-  .row.highlight .unit,
-  .row.highlight .val {
-    color: var(--accent-cyan);
-  }
+      .row.highlight {
+        background: var(--glow-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .tool-foot {
-    margin-top: var(--space-6);
-    text-align: center;
-    font-size: 12px;
-    color: var(--text-muted);
-  }
+      .row.highlight .unit,
+      .row.highlight .val {
+        color: var(--accent-cyan);
+      }
 
-  @media (max-width: 480px) {
-    .tool-wrap {
-      padding: 36px 14px 140px;
-    }
+      .tool-foot {
+        margin-top: var(--space-6);
+        text-align: center;
+        font-size: 12px;
+        color: var(--text-muted);
+      }
 
-    .tool-head h1 {
-      font-size: 24px;
-    }
-  }
-</style>
+      @media (max-width: 480px) {
+        .tool-wrap {
+          padding: 36px 14px 140px;
+        }
+
+        .tool-head h1 {
+          font-size: 24px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="tool-wrap">
-  <header class="tool-head">
-    <span class="tool-badge">转换工具</span>
-    <h1>重量单位换算器</h1>
-    <p>公制、英制、市制重量单位一键互转，实时计算、纯本地运行</p>
-  </header>
+        <header class="tool-head">
+          <span class="tool-badge">转换工具</span>
+          <h1>重量单位换算器</h1>
+          <p>公制、英制、市制重量单位一键互转，实时计算、纯本地运行</p>
+        </header>
 
-  <section class="panel">
-    <div class="panel-body">
-      <div class="quick" id="quick">
-        <button type="button" data-v="1" data-u="kg">1 千克</button>
-        <button type="button" data-v="1" data-u="lb">1 磅</button>
-        <button type="button" data-v="1" data-u="jin">1 斤</button>
-        <button type="button" data-v="1" data-u="oz">1 盎司</button>
-        <button type="button" data-v="100" data-u="g">100 克</button>
-      </div>
+        <section class="panel">
+          <div class="panel-body">
+            <div class="quick" id="quick">
+              <button type="button" data-v="1" data-u="kg">1 千克</button>
+              <button type="button" data-v="1" data-u="lb">1 磅</button>
+              <button type="button" data-v="1" data-u="jin">1 斤</button>
+              <button type="button" data-v="1" data-u="oz">1 盎司</button>
+              <button type="button" data-v="100" data-u="g">100 克</button>
+            </div>
 
-      <div class="input-row">
-        <input type="number" id="valueInput" value="1" inputmode="decimal" aria-label="数值" placeholder="0">
-        <select id="unitSelect" aria-label="单位">
-          <option value="kg">千克 kg</option>
-          <option value="g">克 g</option>
-          <option value="mg">毫克 mg</option>
-          <option value="t">吨 t</option>
-          <option value="lb">磅 lb</option>
-          <option value="oz">盎司 oz</option>
-          <option value="jin">斤</option>
-          <option value="liang">两</option>
-          <option value="qian">钱</option>
-        </select>
-      </div>
+            <div class="input-row">
+              <input
+                type="number"
+                id="valueInput"
+                value="1"
+                inputmode="decimal"
+                aria-label="数值"
+                placeholder="0"
+              />
+              <select id="unitSelect" aria-label="单位">
+                <option value="kg">千克 kg</option>
+                <option value="g">克 g</option>
+                <option value="mg">毫克 mg</option>
+                <option value="t">吨 t</option>
+                <option value="lb">磅 lb</option>
+                <option value="oz">盎司 oz</option>
+                <option value="jin">斤</option>
+                <option value="liang">两</option>
+                <option value="qian">钱</option>
+              </select>
+            </div>
 
-      <div class="group-label">公制单位</div>
-      <div class="results" id="metricResults"></div>
-      <div class="group-label">英制单位</div>
-      <div class="results" id="imperialResults"></div>
-      <div class="group-label">市制单位</div>
-      <div class="results" id="chineseResults"></div>
+            <div class="group-label">公制单位</div>
+            <div class="results" id="metricResults"></div>
+            <div class="group-label">英制单位</div>
+            <div class="results" id="imperialResults"></div>
+            <div class="group-label">市制单位</div>
+            <div class="results" id="chineseResults"></div>
+          </div>
+        </section>
+
+        <p class="tool-foot">全部换算在你的浏览器本地完成，不会上传任何数据。</p>
+      </main>
     </div>
-  </section>
 
-  <p class="tool-foot">全部换算在你的浏览器本地完成，不会上传任何数据。</p>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "转换工具",
-              "item": "https://tools.realtime-ai.chat/#converter"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "重量单位换算器",
-              "item": "https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "转换工具",
+            "item": "https://tools.realtime-ai.chat/#converter"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "重量单位换算器",
+            "item": "https://tools.realtime-ai.chat/tools/converter/weight-converter.html"
+          }
+        ]
+      }
     </script>
     <script>
+      (function () {
+        var units = {
+          t: { name: "吨 (t)", factor: 1000000 },
+          kg: { name: "千克 (kg)", factor: 1000 },
+          g: { name: "克 (g)", factor: 1 },
+          mg: { name: "毫克 (mg)", factor: 0.001 },
+          lb: { name: "磅 (lb)", factor: 453.592 },
+          oz: { name: "盎司 (oz)", factor: 28.3495 },
+          st: { name: "英石 (st)", factor: 6350.29 },
+          jin: { name: "斤", factor: 500 },
+          liang: { name: "两", factor: 50 },
+          qian: { name: "钱", factor: 5 }
+        };
 
-  (function () {
-          var units = {
-            t: { name: "吨 (t)", factor: 1000000 },
-            kg: { name: "千克 (kg)", factor: 1000 },
-            g: { name: "克 (g)", factor: 1 },
-            mg: { name: "毫克 (mg)", factor: 0.001 },
-            lb: { name: "磅 (lb)", factor: 453.592 },
-            oz: { name: "盎司 (oz)", factor: 28.3495 },
-            st: { name: "英石 (st)", factor: 6350.29 },
-            jin: { name: "斤", factor: 500 },
-            liang: { name: "两", factor: 50 },
-            qian: { name: "钱", factor: 5 }
-          };
+        var valueEl = document.getElementById("valueInput");
+        var unitEl = document.getElementById("unitSelect");
 
-          var valueEl = document.getElementById("valueInput");
-          var unitEl = document.getElementById("unitSelect");
-
-          function formatNum(n) {
-            if (Math.abs(n) >= 1e6 || (Math.abs(n) < 0.0001 && n !== 0)) {
-              return n.toExponential(4);
-            }
-            return Number.isInteger(n) ? String(n) : n.toFixed(4).replace(/\.?0+$/, "");
+        function formatNum(n) {
+          if (Math.abs(n) >= 1e6 || (Math.abs(n) < 0.0001 && n !== 0)) {
+            return n.toExponential(4);
           }
+          return Number.isInteger(n) ? String(n) : n.toFixed(4).replace(/\.?0+$/, "");
+        }
 
-          function render(keys, containerId, grams, fromUnit) {
-            document.getElementById(containerId).innerHTML = keys
-              .map(function (u) {
-                var result = grams / units[u].factor;
-                return (
-                  '<div class="row' +
-                  (u === fromUnit ? " highlight" : "") +
-                  '"><span class="unit">' +
-                  units[u].name +
-                  '</span><span class="val">' +
-                  formatNum(result) +
-                  "</span></div>"
-                );
-              })
-              .join("");
-          }
+        function render(keys, containerId, grams, fromUnit) {
+          document.getElementById(containerId).innerHTML = keys
+            .map(function (u) {
+              var result = grams / units[u].factor;
+              return (
+                '<div class="row' +
+                (u === fromUnit ? " highlight" : "") +
+                '"><span class="unit">' +
+                units[u].name +
+                '</span><span class="val">' +
+                formatNum(result) +
+                "</span></div>"
+              );
+            })
+            .join("");
+        }
 
-          function convert() {
-            var value = parseFloat(valueEl.value) || 0;
-            var fromUnit = unitEl.value;
-            var grams = value * units[fromUnit].factor;
-            render(["t", "kg", "g", "mg"], "metricResults", grams, fromUnit);
-            render(["lb", "oz", "st"], "imperialResults", grams, fromUnit);
-            render(["jin", "liang", "qian"], "chineseResults", grams, fromUnit);
-          }
+        function convert() {
+          var value = parseFloat(valueEl.value) || 0;
+          var fromUnit = unitEl.value;
+          var grams = value * units[fromUnit].factor;
+          render(["t", "kg", "g", "mg"], "metricResults", grams, fromUnit);
+          render(["lb", "oz", "st"], "imperialResults", grams, fromUnit);
+          render(["jin", "liang", "qian"], "chineseResults", grams, fromUnit);
+        }
 
-          valueEl.addEventListener("input", convert);
-          unitEl.addEventListener("change", convert);
+        valueEl.addEventListener("input", convert);
+        unitEl.addEventListener("change", convert);
 
-          document.getElementById("quick").addEventListener("click", function (e) {
-            var btn = e.target.closest("button");
-            if (!btn) return;
-            valueEl.value = btn.dataset.v;
-            unitEl.value = btn.dataset.u;
-            convert();
-          });
-
+        document.getElementById("quick").addEventListener("click", function (e) {
+          var btn = e.target.closest("button");
+          if (!btn) return;
+          valueEl.value = btn.dataset.v;
+          unitEl.value = btn.dataset.u;
           convert();
-        })();
-</script>
-    
+        });
+
+        convert();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/bar-chart.html
+++ b/tools/data/bar-chart.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Bar Chart - WebUtils" />
-    <meta property="og:description" content="Bar Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Bar Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/bar-chart.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Bar Chart - WebUtils" />
-    <meta name="twitter:description" content="Bar Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Bar Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Bar Chart",
-      "item": "https://tools.realtime-ai.chat/tools/data/bar-chart.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Bar Chart",
+            "item": "https://tools.realtime-ai.chat/tools/data/bar-chart.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Bar Chart - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Bar Chart - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,915 +94,922 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="color"] {
-    width: 50px;
-    height: 40px;
-    padding: 2px;
-    cursor: pointer;
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="color"] {
+        width: 50px;
+        height: 40px;
+        padding: 2px;
+        cursor: pointer;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .inline-group {
-    display: flex;
-    gap: 12px;
-    align-items: flex-end;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  .inline-group .input-group {
-    flex: 1;
-    margin-bottom: 0;
-  }
+      .inline-group {
+        display: flex;
+        gap: 12px;
+        align-items: flex-end;
+      }
 
-  .color-inputs {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
+      .inline-group .input-group {
+        flex: 1;
+        margin-bottom: 0;
+      }
 
-  .color-input-wrap {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-  }
+      .color-inputs {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
 
-  .color-input-wrap span {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-  }
+      .color-input-wrap {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .color-input-wrap span {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .chart-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    min-height: 400px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .chart-placeholder {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    text-align: center;
-  }
+      .chart-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        min-height: 400px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
 
-  #chartCanvas {
-    max-width: 100%;
-    max-height: 100%;
-  }
+      .chart-placeholder {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        text-align: center;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      #chartCanvas {
+        max-width: 100%;
+        max-height: 100%;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  .example-data {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 8px;
-    font-family: var(--font-mono);
-  }
+      .toast.error {
+        background: var(--accent-red);
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .example-data {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 8px;
+        font-family: var(--font-mono);
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .inline-group {
-      flex-direction: column;
-      align-items: stretch;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .inline-group {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">柱状图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        柱状图生成器
-      </h1>
-      <p>创建柱状图和条形图，支持自定义样式和导出PNG</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">柱状图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              柱状图生成器
+            </h1>
+            <p>创建柱状图和条形图，支持自定义样式和导出PNG</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- Left Panel: Input & Settings -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">数据 (每行一条: 标签,数值)</label>
-            <textarea id="dataInput" placeholder="苹果,120
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- Left Panel: Input & Settings -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">数据 (每行一条: 标签,数值)</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder="苹果,120
 香蕉,85
 橙子,95
 葡萄,70
-西瓜,150"></textarea>
-            <div class="example-data">
-              示例格式: 标签,数值 或 CSV格式（第一列为标签，第二列为数值）
-            </div>
-          </div>
-        </div>
+西瓜,150"
+                  ></textarea>
+                  <div class="example-data">
+                    示例格式: 标签,数值 或 CSV格式（第一列为标签，第二列为数值）
+                  </div>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">图表设置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="柱状图标题" value="销售数据">
-          </div>
-          <div class="inline-group">
-            <div class="input-group">
-              <label class="input-label">X轴标签</label>
-              <input type="text" id="xAxisLabel" placeholder="X轴" value="类别">
-            </div>
-            <div class="input-group">
-              <label class="input-label">Y轴标签</label>
-              <input type="text" id="yAxisLabel" placeholder="Y轴" value="数量">
-            </div>
-          </div>
-          <div class="inline-group" style="margin-top: 16px">
-            <div class="input-group">
-              <label class="input-label">图表类型</label>
-              <select id="chartType">
-                <option value="vertical">垂直柱状图</option>
-                <option value="horizontal">水平条形图</option>
-              </select>
-            </div>
-          </div>
-        </div>
+              <div class="tool-section">
+                <div class="section-title">图表设置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input type="text" id="chartTitle" placeholder="柱状图标题" value="销售数据" />
+                </div>
+                <div class="inline-group">
+                  <div class="input-group">
+                    <label class="input-label">X轴标签</label>
+                    <input type="text" id="xAxisLabel" placeholder="X轴" value="类别" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">Y轴标签</label>
+                    <input type="text" id="yAxisLabel" placeholder="Y轴" value="数量" />
+                  </div>
+                </div>
+                <div class="inline-group" style="margin-top: 16px">
+                  <div class="input-group">
+                    <label class="input-label">图表类型</label>
+                    <select id="chartType">
+                      <option value="vertical">垂直柱状图</option>
+                      <option value="horizontal">水平条形图</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">颜色设置</div>
-          <div class="input-group">
-            <label class="input-label">柱状颜色 (可添加多个，循环使用)</label>
-            <div class="color-inputs" id="colorInputs">
-              <div class="color-input-wrap">
-                <input type="color" class="bar-color" value="#00f5d4">
-                <span>1</span>
+              <div class="tool-section">
+                <div class="section-title">颜色设置</div>
+                <div class="input-group">
+                  <label class="input-label">柱状颜色 (可添加多个，循环使用)</label>
+                  <div class="color-inputs" id="colorInputs">
+                    <div class="color-input-wrap">
+                      <input type="color" class="bar-color" value="#00f5d4" />
+                      <span>1</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="bar-color" value="#f72585" />
+                      <span>2</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="bar-color" value="#fbbf24" />
+                      <span>3</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="bar-color" value="#10b981" />
+                      <span>4</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="bar-color" value="#a855f7" />
+                      <span>5</span>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="color-input-wrap">
-                <input type="color" class="bar-color" value="#f72585">
-                <span>2</span>
+
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
+                <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
               </div>
-              <div class="color-input-wrap">
-                <input type="color" class="bar-color" value="#fbbf24">
-                <span>3</span>
+            </div>
+
+            <!-- Right Panel: Chart Output -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">图表预览</div>
+                <div class="chart-container" id="chartContainer">
+                  <canvas id="chartCanvas"></canvas>
+                  <div class="chart-placeholder" id="chartPlaceholder">
+                    输入数据后点击"生成图表"
+                  </div>
+                </div>
               </div>
-              <div class="color-input-wrap">
-                <input type="color" class="bar-color" value="#10b981">
-                <span>4</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="bar-color" value="#a855f7">
-                <span>5</span>
+              <div class="btn-row" style="margin-top: 16px">
+                <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
+                <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
               </div>
             </div>
           </div>
-        </div>
-
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
-          <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        </div>
-      </div>
-
-      <!-- Right Panel: Chart Output -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">图表预览</div>
-          <div class="chart-container" id="chartContainer">
-            <canvas id="chartCanvas"></canvas>
-            <div class="chart-placeholder" id="chartPlaceholder">输入数据后点击"生成图表"</div>
-          </div>
-        </div>
-        <div class="btn-row" style="margin-top: 16px">
-          <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
-          <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "柱状图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/bar-chart.html"
-            }
-          ]
-        }
-
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "柱状图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/bar-chart.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      let chartInstance = null;
 
-  let chartInstance = null;
-
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          // 如果有图表，重新生成以更新颜色
-          if (chartInstance) {
-            generateChart();
-          }
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        // 如果有图表，重新生成以更新颜色
+        if (chartInstance) {
+          generateChart();
         }
+      }
 
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
 
-        // 解析数据
-        function parseData(input) {
-          const lines = input
-            .trim()
-            .split("\n")
-            .filter((line) => line.trim());
-          if (lines.length === 0) return null;
+      // 解析数据
+      function parseData(input) {
+        const lines = input
+          .trim()
+          .split("\n")
+          .filter((line) => line.trim());
+        if (lines.length === 0) return null;
 
-          const data = { labels: [], values: [] };
+        const data = { labels: [], values: [] };
 
-          for (const line of lines) {
-            // 支持逗号、制表符、分号分隔
-            const parts = line.split(/[,\t;]/).map((p) => p.trim());
-            if (parts.length >= 2) {
-              const label = parts[0];
-              const value = parseFloat(parts[1]);
-              if (label && !isNaN(value)) {
-                data.labels.push(label);
-                data.values.push(value);
-              }
+        for (const line of lines) {
+          // 支持逗号、制表符、分号分隔
+          const parts = line.split(/[,\t;]/).map((p) => p.trim());
+          if (parts.length >= 2) {
+            const label = parts[0];
+            const value = parseFloat(parts[1]);
+            if (label && !isNaN(value)) {
+              data.labels.push(label);
+              data.values.push(value);
             }
           }
-
-          return data.labels.length > 0 ? data : null;
         }
 
-        // 获取颜色数组
-        function getColors() {
-          const colorInputs = document.querySelectorAll(".bar-color");
-          return Array.from(colorInputs).map((input) => input.value);
+        return data.labels.length > 0 ? data : null;
+      }
+
+      // 获取颜色数组
+      function getColors() {
+        const colorInputs = document.querySelectorAll(".bar-color");
+        return Array.from(colorInputs).map((input) => input.value);
+      }
+
+      // 生成图表
+      function generateChart() {
+        const input = document.getElementById("dataInput").value;
+        const data = parseData(input);
+
+        if (!data) {
+          showToast("请输入有效的数据格式", true);
+          return;
         }
 
-        // 生成图表
-        function generateChart() {
-          const input = document.getElementById("dataInput").value;
-          const data = parseData(input);
+        const chartTitle = document.getElementById("chartTitle").value || "柱状图";
+        const xAxisLabel = document.getElementById("xAxisLabel").value || "";
+        const yAxisLabel = document.getElementById("yAxisLabel").value || "";
+        const chartType = document.getElementById("chartType").value;
+        const colors = getColors();
 
-          if (!data) {
-            showToast("请输入有效的数据格式", true);
-            return;
-          }
+        // 为每个数据项分配颜色
+        const backgroundColors = data.values.map((_, i) => colors[i % colors.length]);
+        const borderColors = backgroundColors.map((c) => c);
 
-          const chartTitle = document.getElementById("chartTitle").value || "柱状图";
-          const xAxisLabel = document.getElementById("xAxisLabel").value || "";
-          const yAxisLabel = document.getElementById("yAxisLabel").value || "";
-          const chartType = document.getElementById("chartType").value;
-          const colors = getColors();
+        // 隐藏占位符
+        document.getElementById("chartPlaceholder").style.display = "none";
 
-          // 为每个数据项分配颜色
-          const backgroundColors = data.values.map((_, i) => colors[i % colors.length]);
-          const borderColors = backgroundColors.map((c) => c);
+        // 销毁旧图表
+        if (chartInstance) {
+          chartInstance.destroy();
+        }
 
-          // 隐藏占位符
-          document.getElementById("chartPlaceholder").style.display = "none";
+        const ctx = document.getElementById("chartCanvas").getContext("2d");
 
-          // 销毁旧图表
-          if (chartInstance) {
-            chartInstance.destroy();
-          }
+        // 获取当前主题
+        const isLight = document.body.getAttribute("data-theme") === "light";
+        const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
+        const gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
 
-          const ctx = document.getElementById("chartCanvas").getContext("2d");
+        const isHorizontal = chartType === "horizontal";
 
-          // 获取当前主题
-          const isLight = document.body.getAttribute("data-theme") === "light";
-          const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
-          const gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
-
-          const isHorizontal = chartType === "horizontal";
-
-          chartInstance = new Chart(ctx, {
-            type: "bar",
-            data: {
-              labels: data.labels,
-              datasets: [
-                {
-                  label: chartTitle,
-                  data: data.values,
-                  backgroundColor: backgroundColors,
-                  borderColor: borderColors,
-                  borderWidth: 2,
-                  borderRadius: 4,
-                  borderSkipped: false
+        chartInstance = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: data.labels,
+            datasets: [
+              {
+                label: chartTitle,
+                data: data.values,
+                backgroundColor: backgroundColors,
+                borderColor: borderColors,
+                borderWidth: 2,
+                borderRadius: 4,
+                borderSkipped: false
+              }
+            ]
+          },
+          options: {
+            indexAxis: isHorizontal ? "y" : "x",
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              title: {
+                display: true,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "bold",
+                  family: "'Space Grotesk', sans-serif"
+                },
+                padding: {
+                  top: 10,
+                  bottom: 20
                 }
-              ]
+              },
+              legend: {
+                display: false
+              },
+              tooltip: {
+                backgroundColor: isLight ? "#fff" : "#1a1a24",
+                titleColor: textColor,
+                bodyColor: textColor,
+                borderColor: gridColor,
+                borderWidth: 1,
+                cornerRadius: 4,
+                titleFont: {
+                  family: "'JetBrains Mono', monospace"
+                },
+                bodyFont: {
+                  family: "'JetBrains Mono', monospace"
+                }
+              }
             },
-            options: {
-              indexAxis: isHorizontal ? "y" : "x",
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: {
+            scales: {
+              x: {
                 title: {
-                  display: true,
-                  text: chartTitle,
+                  display: !!xAxisLabel,
+                  text: isHorizontal ? yAxisLabel : xAxisLabel,
                   color: textColor,
                   font: {
-                    size: 16,
-                    weight: "bold",
-                    family: "'Space Grotesk', sans-serif"
-                  },
-                  padding: {
-                    top: 10,
-                    bottom: 20
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
                   }
                 },
-                legend: {
-                  display: false
-                },
-                tooltip: {
-                  backgroundColor: isLight ? "#fff" : "#1a1a24",
-                  titleColor: textColor,
-                  bodyColor: textColor,
-                  borderColor: gridColor,
-                  borderWidth: 1,
-                  cornerRadius: 4,
-                  titleFont: {
-                    family: "'JetBrains Mono', monospace"
-                  },
-                  bodyFont: {
+                ticks: {
+                  color: textColor,
+                  font: {
                     family: "'JetBrains Mono', monospace"
                   }
+                },
+                grid: {
+                  color: gridColor,
+                  drawBorder: false
                 }
               },
-              scales: {
-                x: {
-                  title: {
-                    display: !!xAxisLabel,
-                    text: isHorizontal ? yAxisLabel : xAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace"
-                    }
-                  },
-                  grid: {
-                    color: gridColor,
-                    drawBorder: false
+              y: {
+                title: {
+                  display: !!yAxisLabel,
+                  text: isHorizontal ? xAxisLabel : yAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
                   }
                 },
-                y: {
-                  title: {
-                    display: !!yAxisLabel,
-                    text: isHorizontal ? xAxisLabel : yAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace"
-                    }
-                  },
-                  grid: {
-                    color: gridColor,
-                    drawBorder: false
-                  },
-                  beginAtZero: true
-                }
-              },
-              animation: {
-                duration: 800,
-                easing: "easeOutQuart"
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace"
+                  }
+                },
+                grid: {
+                  color: gridColor,
+                  drawBorder: false
+                },
+                beginAtZero: true
               }
+            },
+            animation: {
+              duration: 800,
+              easing: "easeOutQuart"
             }
-          });
-
-          // 保存到 localStorage
-          saveState();
-          showToast("图表生成成功");
-        }
-
-        // 导出PNG
-        function exportPNG() {
-          if (!chartInstance) {
-            showToast("请先生成图表", true);
-            return;
           }
+        });
 
-          const canvas = document.getElementById("chartCanvas");
-          const link = document.createElement("a");
-          link.download = "bar-chart.png";
-          link.href = canvas.toDataURL("image/png", 1.0);
-          link.click();
-          showToast("PNG已下载");
+        // 保存到 localStorage
+        saveState();
+        showToast("图表生成成功");
+      }
+
+      // 导出PNG
+      function exportPNG() {
+        if (!chartInstance) {
+          showToast("请先生成图表", true);
+          return;
         }
 
-        // 分享功能
-        function shareChart() {
-          const state = {
-            data: document.getElementById("dataInput").value,
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            type: document.getElementById("chartType").value,
-            colors: getColors()
-          };
+        const canvas = document.getElementById("chartCanvas");
+        const link = document.createElement("a");
+        link.download = "bar-chart.png";
+        link.href = canvas.toDataURL("image/png", 1.0);
+        link.click();
+        showToast("PNG已下载");
+      }
 
-          const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
-          const url = window.location.href.split("#")[0] + "#" + encoded;
+      // 分享功能
+      function shareChart() {
+        const state = {
+          data: document.getElementById("dataInput").value,
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          type: document.getElementById("chartType").value,
+          colors: getColors()
+        };
 
-          navigator.clipboard
-            .writeText(url)
-            .then(() => {
-              showToast("分享链接已复制到剪贴板");
-            })
-            .catch(() => {
-              showToast("复制失败，请手动复制URL", true);
+        const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
+        const url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(() => {
+            showToast("分享链接已复制到剪贴板");
+          })
+          .catch(() => {
+            showToast("复制失败，请手动复制URL", true);
+          });
+      }
+
+      // 从URL加载状态
+      function loadFromUrl() {
+        const hash = window.location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          const state = JSON.parse(decodeURIComponent(atob(hash)));
+          if (state.data) document.getElementById("dataInput").value = state.data;
+          if (state.title) document.getElementById("chartTitle").value = state.title;
+          if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
+          if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
+          if (state.type) document.getElementById("chartType").value = state.type;
+          if (state.colors && Array.isArray(state.colors)) {
+            const colorInputs = document.querySelectorAll(".bar-color");
+            state.colors.forEach((color, i) => {
+              if (colorInputs[i]) colorInputs[i].value = color;
             });
-        }
-
-        // 从URL加载状态
-        function loadFromUrl() {
-          const hash = window.location.hash.slice(1);
-          if (!hash) return false;
-
-          try {
-            const state = JSON.parse(decodeURIComponent(atob(hash)));
-            if (state.data) document.getElementById("dataInput").value = state.data;
-            if (state.title) document.getElementById("chartTitle").value = state.title;
-            if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
-            if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
-            if (state.type) document.getElementById("chartType").value = state.type;
-            if (state.colors && Array.isArray(state.colors)) {
-              const colorInputs = document.querySelectorAll(".bar-color");
-              state.colors.forEach((color, i) => {
-                if (colorInputs[i]) colorInputs[i].value = color;
-              });
-            }
-            return true;
-          } catch (e) {
-            return false;
           }
+          return true;
+        } catch (e) {
+          return false;
         }
+      }
 
-        // 保存状态到 localStorage
-        function saveState() {
-          const state = {
-            data: document.getElementById("dataInput").value,
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            type: document.getElementById("chartType").value,
-            colors: getColors()
-          };
-          localStorage.setItem("bar-chart-state", JSON.stringify(state));
-        }
+      // 保存状态到 localStorage
+      function saveState() {
+        const state = {
+          data: document.getElementById("dataInput").value,
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          type: document.getElementById("chartType").value,
+          colors: getColors()
+        };
+        localStorage.setItem("bar-chart-state", JSON.stringify(state));
+      }
 
-        // 从 localStorage 加载状态
-        function loadState() {
-          const saved = localStorage.getItem("bar-chart-state");
-          if (!saved) return false;
+      // 从 localStorage 加载状态
+      function loadState() {
+        const saved = localStorage.getItem("bar-chart-state");
+        if (!saved) return false;
 
-          try {
-            const state = JSON.parse(saved);
-            if (state.data) document.getElementById("dataInput").value = state.data;
-            if (state.title) document.getElementById("chartTitle").value = state.title;
-            if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
-            if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
-            if (state.type) document.getElementById("chartType").value = state.type;
-            if (state.colors && Array.isArray(state.colors)) {
-              const colorInputs = document.querySelectorAll(".bar-color");
-              state.colors.forEach((color, i) => {
-                if (colorInputs[i]) colorInputs[i].value = color;
-              });
-            }
-            return true;
-          } catch (e) {
-            return false;
+        try {
+          const state = JSON.parse(saved);
+          if (state.data) document.getElementById("dataInput").value = state.data;
+          if (state.title) document.getElementById("chartTitle").value = state.title;
+          if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
+          if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
+          if (state.type) document.getElementById("chartType").value = state.type;
+          if (state.colors && Array.isArray(state.colors)) {
+            const colorInputs = document.querySelectorAll(".bar-color");
+            state.colors.forEach((color, i) => {
+              if (colorInputs[i]) colorInputs[i].value = color;
+            });
           }
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("dataInput").value = "";
+        document.getElementById("chartTitle").value = "销售数据";
+        document.getElementById("xAxisLabel").value = "类别";
+        document.getElementById("yAxisLabel").value = "数量";
+        document.getElementById("chartType").value = "vertical";
+
+        // 重置颜色
+        const defaultColors = ["#00f5d4", "#f72585", "#fbbf24", "#10b981", "#a855f7"];
+        const colorInputs = document.querySelectorAll(".bar-color");
+        defaultColors.forEach((color, i) => {
+          if (colorInputs[i]) colorInputs[i].value = color;
+        });
+
+        // 销毁图表
+        if (chartInstance) {
+          chartInstance.destroy();
+          chartInstance = null;
+        }
+        document.getElementById("chartPlaceholder").style.display = "block";
+
+        // 清除 localStorage
+        localStorage.removeItem("bar-chart-state");
+
+        // 清除 URL hash
+        history.replaceState(null, "", window.location.pathname);
+
+        showToast("已清空");
+      }
+
+      // 显示提示
+      function showToast(msg, isError = false) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.toggle("error", isError);
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // 初始化
+      (function init() {
+        // 优先从URL加载，否则从localStorage加载
+        const loadedFromUrl = loadFromUrl();
+        if (!loadedFromUrl) {
+          loadState();
         }
 
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("dataInput").value = "";
-          document.getElementById("chartTitle").value = "销售数据";
-          document.getElementById("xAxisLabel").value = "类别";
-          document.getElementById("yAxisLabel").value = "数量";
-          document.getElementById("chartType").value = "vertical";
-
-          // 重置颜色
-          const defaultColors = ["#00f5d4", "#f72585", "#fbbf24", "#10b981", "#a855f7"];
-          const colorInputs = document.querySelectorAll(".bar-color");
-          defaultColors.forEach((color, i) => {
-            if (colorInputs[i]) colorInputs[i].value = color;
-          });
-
-          // 销毁图表
-          if (chartInstance) {
-            chartInstance.destroy();
-            chartInstance = null;
-          }
-          document.getElementById("chartPlaceholder").style.display = "block";
-
-          // 清除 localStorage
-          localStorage.removeItem("bar-chart-state");
-
-          // 清除 URL hash
-          history.replaceState(null, "", window.location.pathname);
-
-          showToast("已清空");
+        // 如果有数据，自动生成图表
+        const dataInput = document.getElementById("dataInput").value;
+        if (dataInput.trim()) {
+          generateChart();
         }
 
-        // 显示提示
-        function showToast(msg, isError = false) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.toggle("error", isError);
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
+        // 监听输入变化保存状态
+        const inputs = ["dataInput", "chartTitle", "xAxisLabel", "yAxisLabel", "chartType"];
+        inputs.forEach((id) => {
+          document.getElementById(id).addEventListener("input", saveState);
+        });
 
-        // 初始化
-        (function init() {
-          // 优先从URL加载，否则从localStorage加载
-          const loadedFromUrl = loadFromUrl();
-          if (!loadedFromUrl) {
-            loadState();
-          }
+        // 监听颜色变化
+        document.querySelectorAll(".bar-color").forEach((input) => {
+          input.addEventListener("change", saveState);
+        });
+      })();
+    </script>
 
-          // 如果有数据，自动生成图表
-          const dataInput = document.getElementById("dataInput").value;
-          if (dataInput.trim()) {
-            generateChart();
-          }
-
-          // 监听输入变化保存状态
-          const inputs = ["dataInput", "chartTitle", "xAxisLabel", "yAxisLabel", "chartType"];
-          inputs.forEach((id) => {
-            document.getElementById(id).addEventListener("input", saveState);
-          });
-
-          // 监听颜色变化
-          document.querySelectorAll(".bar-color").forEach((input) => {
-            input.addEventListener("change", saveState);
-          });
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/chart-maker.html
+++ b/tools/data/chart-maker.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Chart Maker - WebUtils" />
-    <meta property="og:description" content="Chart Maker，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Chart Maker，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/chart-maker.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Chart Maker - WebUtils" />
-    <meta name="twitter:description" content="Chart Maker，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Chart Maker，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Chart Maker",
-      "item": "https://tools.realtime-ai.chat/tools/data/chart-maker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Chart Maker",
+            "item": "https://tools.realtime-ai.chat/tools/data/chart-maker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Chart Maker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Chart Maker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1480 +94,1505 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 380px 1fr;
-    gap: 24px;
-  }
-
-  @media (max-width: 1000px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .tool-section {
-    margin-bottom: 20px;
-  }
-
-  .tool-section:last-child {
-    margin-bottom: 0;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 12px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .input-group {
-    margin-bottom: 12px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 6px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input[type="color"] {
-    width: 40px;
-    height: 36px;
-    padding: 2px;
-    cursor: pointer;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 140px;
-    resize: vertical;
-    line-height: 1.5;
-  }
-
-  .inline-group {
-    display: flex;
-    gap: 10px;
-    align-items: flex-end;
-  }
-
-  .inline-group .input-group {
-    flex: 1;
-    margin-bottom: 0;
-  }
-
-  .chart-type-selector {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 8px;
-  }
-
-  .chart-type-btn {
-    padding: 10px 8px;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 500;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    background: var(--bg-input);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .chart-type-btn .icon {
-    font-size: 1.2rem;
-  }
-
-  .chart-type-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .chart-type-btn.active {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-    border-color: var(--color-accent-cyan);
-  }
-
-  .color-inputs {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-  }
-
-  .color-input-wrap {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-  }
-
-  .color-input-wrap span {
-    font-size: 0.65rem;
-    color: var(--color-text-muted);
-  }
-
-  .color-input-wrap input[type="color"] {
-    width: 32px;
-    height: 32px;
-  }
-
-  .settings-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .checkbox-group {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-  }
-
-  .checkbox-group input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    accent-color: var(--color-accent-cyan);
-    cursor: pointer;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .chart-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    min-height: 450px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-  }
-
-  .chart-placeholder {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    text-align: center;
-  }
-
-  .chart-placeholder .icon {
-    font-size: 3rem;
-    display: block;
-    margin-bottom: 12px;
-    opacity: 0.5;
-  }
-
-  #chartCanvas {
-    max-width: 100%;
-    max-height: 100%;
-  }
-
-  .output-panel {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .output-panel .tool-section {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .output-panel .chart-container {
-    flex: 1;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  .toast.error {
-    background: var(--accent-red);
-  }
-
-  .example-data {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 6px;
-    font-family: var(--font-mono);
-    line-height: 1.4;
-  }
-
-  .tabs {
-    display: flex;
-    gap: 4px;
-    margin-bottom: 12px;
-    background: var(--bg-input);
-    border-radius: var(--radius-sm);
-    padding: 4px;
-  }
-
-  .tab {
-    flex: 1;
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s ease;
-  }
-
-  .tab:hover {
-    color: var(--color-text-primary);
-  }
-
-  .tab.active {
-    background: var(--color-bg-card);
-    color: var(--color-accent-cyan);
-  }
-
-  .sample-btn {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    padding: 4px 8px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .sample-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .inline-group {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .chart-type-selector {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 380px 1fr;
+        gap: 24px;
+      }
+
+      @media (max-width: 1000px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .tool-section {
+        margin-bottom: 20px;
+      }
+
+      .tool-section:last-child {
+        margin-bottom: 0;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 12px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .input-group {
+        margin-bottom: 12px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 6px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 8px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input[type="color"] {
+        width: 40px;
+        height: 36px;
+        padding: 2px;
+        cursor: pointer;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 140px;
+        resize: vertical;
+        line-height: 1.5;
+      }
+
+      .inline-group {
+        display: flex;
+        gap: 10px;
+        align-items: flex-end;
+      }
+
+      .inline-group .input-group {
+        flex: 1;
+        margin-bottom: 0;
+      }
+
+      .chart-type-selector {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+      }
+
+      .chart-type-btn {
+        padding: 10px 8px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 500;
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: var(--bg-input);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .chart-type-btn .icon {
+        font-size: 1.2rem;
+      }
+
+      .chart-type-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .chart-type-btn.active {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+        border-color: var(--color-accent-cyan);
+      }
+
+      .color-inputs {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+      }
+
+      .color-input-wrap {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+      }
+
+      .color-input-wrap span {
+        font-size: 0.65rem;
+        color: var(--color-text-muted);
+      }
+
+      .color-input-wrap input[type="color"] {
+        width: 32px;
+        height: 32px;
+      }
+
+      .settings-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
+
+      .checkbox-group input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-accent-cyan);
+        cursor: pointer;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .chart-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        min-height: 450px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
+
+      .chart-placeholder {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        text-align: center;
+      }
+
+      .chart-placeholder .icon {
+        font-size: 3rem;
+        display: block;
+        margin-bottom: 12px;
+        opacity: 0.5;
+      }
+
+      #chartCanvas {
+        max-width: 100%;
+        max-height: 100%;
+      }
+
+      .output-panel {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .output-panel .tool-section {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .output-panel .chart-container {
+        flex: 1;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      .toast.error {
+        background: var(--accent-red);
+      }
+
+      .example-data {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 6px;
+        font-family: var(--font-mono);
+        line-height: 1.4;
+      }
+
+      .tabs {
+        display: flex;
+        gap: 4px;
+        margin-bottom: 12px;
+        background: var(--bg-input);
+        border-radius: var(--radius-sm);
+        padding: 4px;
+      }
+
+      .tab {
+        flex: 1;
+        padding: 8px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .tab:hover {
+        color: var(--color-text-primary);
+      }
+
+      .tab.active {
+        background: var(--color-bg-card);
+        color: var(--color-accent-cyan);
+      }
+
+      .sample-btn {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        padding: 4px 8px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .sample-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .inline-group {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .chart-type-selector {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">图表生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        图表生成器
-      </h1>
-      <p>支持柱状图、折线图、饼图、环形图、雷达图、极地图，可自定义样式并导出PNG</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- Left Panel: Input & Settings -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="tabs">
-            <button class="tab active" data-tab="simple" onclick="switchTab('simple')">
-              简单模式
-            </button>
-            <button class="tab" data-tab="multi" onclick="switchTab('multi')">多数据集</button>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">图表生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              图表生成器
+            </h1>
+            <p>支持柱状图、折线图、饼图、环形图、雷达图、极地图，可自定义样式并导出PNG</p>
           </div>
-          <div class="input-group">
-            <div style="
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                margin-bottom: 6px;
-              ">
-              <label class="input-label" style="margin-bottom: 0">CSV 数据</label>
-              <button class="sample-btn" onclick="loadSampleData()">加载示例</button>
-            </div>
-            <textarea id="dataInput" placeholder="标签,数值
+        </header>
+
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- Left Panel: Input & Settings -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="tabs">
+                  <button class="tab active" data-tab="simple" onclick="switchTab('simple')">
+                    简单模式
+                  </button>
+                  <button class="tab" data-tab="multi" onclick="switchTab('multi')">
+                    多数据集
+                  </button>
+                </div>
+                <div class="input-group">
+                  <div
+                    style="
+                      display: flex;
+                      justify-content: space-between;
+                      align-items: center;
+                      margin-bottom: 6px;
+                    "
+                  >
+                    <label class="input-label" style="margin-bottom: 0">CSV 数据</label>
+                    <button class="sample-btn" onclick="loadSampleData()">加载示例</button>
+                  </div>
+                  <textarea
+                    id="dataInput"
+                    placeholder="标签,数值
 苹果,120
 香蕉,85
 橙子,95
 葡萄,70
-西瓜,150"></textarea>
-            <div class="example-data" id="dataHint">
-              简单模式: 每行 "标签,数值"
-              <br>
-              多数据集: 首行为标签，后续行为 "系列名,值1,值2,..."
+西瓜,150"
+                  ></textarea>
+                  <div class="example-data" id="dataHint">
+                    简单模式: 每行 "标签,数值"
+                    <br />
+                    多数据集: 首行为标签，后续行为 "系列名,值1,值2,..."
+                  </div>
+                </div>
+              </div>
+
+              <div class="tool-section">
+                <div class="section-title">图表类型</div>
+                <div class="chart-type-selector">
+                  <button
+                    class="chart-type-btn active"
+                    data-type="bar"
+                    onclick="selectChartType('bar')"
+                  >
+                    <span class="icon">📊</span>
+                    柱状图
+                  </button>
+                  <button class="chart-type-btn" data-type="line" onclick="selectChartType('line')">
+                    <span class="icon">📈</span>
+                    折线图
+                  </button>
+                  <button class="chart-type-btn" data-type="pie" onclick="selectChartType('pie')">
+                    <span class="icon">🥧</span>
+                    饼图
+                  </button>
+                  <button
+                    class="chart-type-btn"
+                    data-type="doughnut"
+                    onclick="selectChartType('doughnut')"
+                  >
+                    <span class="icon">🍩</span>
+                    环形图
+                  </button>
+                  <button
+                    class="chart-type-btn"
+                    data-type="radar"
+                    onclick="selectChartType('radar')"
+                  >
+                    <span class="icon">🕸️</span>
+                    雷达图
+                  </button>
+                  <button
+                    class="chart-type-btn"
+                    data-type="polarArea"
+                    onclick="selectChartType('polarArea')"
+                  >
+                    <span class="icon">🎯</span>
+                    极地图
+                  </button>
+                </div>
+              </div>
+
+              <div class="tool-section">
+                <div class="section-title">图表设置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input type="text" id="chartTitle" placeholder="图表标题" value="数据统计" />
+                </div>
+                <div class="inline-group" id="axisLabels">
+                  <div class="input-group">
+                    <label class="input-label">X轴标签</label>
+                    <input type="text" id="xAxisLabel" placeholder="X轴" value="" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">Y轴标签</label>
+                    <input type="text" id="yAxisLabel" placeholder="Y轴" value="" />
+                  </div>
+                </div>
+                <div class="input-group">
+                  <label class="input-label">图例位置</label>
+                  <select id="legendPosition">
+                    <option value="top">顶部</option>
+                    <option value="bottom">底部</option>
+                    <option value="left">左侧</option>
+                    <option value="right">右侧</option>
+                    <option value="none">隐藏</option>
+                  </select>
+                </div>
+                <div class="settings-row" style="margin-top: 12px">
+                  <label class="checkbox-group">
+                    <input type="checkbox" id="showAnimation" checked="" />
+                    动画效果
+                  </label>
+                  <label class="checkbox-group">
+                    <input type="checkbox" id="showGrid" checked="" />
+                    显示网格
+                  </label>
+                  <label class="checkbox-group">
+                    <input type="checkbox" id="fillArea" />
+                    填充区域
+                  </label>
+                </div>
+              </div>
+
+              <div class="tool-section">
+                <div class="section-title">颜色方案</div>
+                <div class="input-group">
+                  <div class="color-inputs" id="colorInputs">
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#00f5d4" />
+                      <span>1</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#f72585" />
+                      <span>2</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#fbbf24" />
+                      <span>3</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#10b981" />
+                      <span>4</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#a855f7" />
+                      <span>5</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#3b82f6" />
+                      <span>6</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#f43f5e" />
+                      <span>7</span>
+                    </div>
+                    <div class="color-input-wrap">
+                      <input type="color" class="chart-color" value="#8b5cf6" />
+                      <span>8</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
+                <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+              </div>
+            </div>
+
+            <!-- Right Panel: Chart Output -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">图表预览</div>
+                <div class="chart-container" id="chartContainer">
+                  <canvas id="chartCanvas"></canvas>
+                  <div class="chart-placeholder" id="chartPlaceholder">
+                    <span class="icon">📊</span>
+                    输入数据后点击"生成图表"
+                  </div>
+                </div>
+              </div>
+              <div class="btn-row" style="margin-top: 16px">
+                <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
+                <button class="btn btn-secondary" onclick="copyToClipboard()">📋 复制图片</button>
+                <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
+              </div>
             </div>
           </div>
-        </div>
-
-        <div class="tool-section">
-          <div class="section-title">图表类型</div>
-          <div class="chart-type-selector">
-            <button class="chart-type-btn active" data-type="bar" onclick="selectChartType('bar')">
-              <span class="icon">📊</span>
-              柱状图
-            </button>
-            <button class="chart-type-btn" data-type="line" onclick="selectChartType('line')">
-              <span class="icon">📈</span>
-              折线图
-            </button>
-            <button class="chart-type-btn" data-type="pie" onclick="selectChartType('pie')">
-              <span class="icon">🥧</span>
-              饼图
-            </button>
-            <button class="chart-type-btn" data-type="doughnut" onclick="selectChartType('doughnut')">
-              <span class="icon">🍩</span>
-              环形图
-            </button>
-            <button class="chart-type-btn" data-type="radar" onclick="selectChartType('radar')">
-              <span class="icon">🕸️</span>
-              雷达图
-            </button>
-            <button class="chart-type-btn" data-type="polarArea" onclick="selectChartType('polarArea')">
-              <span class="icon">🎯</span>
-              极地图
-            </button>
-          </div>
-        </div>
-
-        <div class="tool-section">
-          <div class="section-title">图表设置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="图表标题" value="数据统计">
-          </div>
-          <div class="inline-group" id="axisLabels">
-            <div class="input-group">
-              <label class="input-label">X轴标签</label>
-              <input type="text" id="xAxisLabel" placeholder="X轴" value="">
-            </div>
-            <div class="input-group">
-              <label class="input-label">Y轴标签</label>
-              <input type="text" id="yAxisLabel" placeholder="Y轴" value="">
-            </div>
-          </div>
-          <div class="input-group">
-            <label class="input-label">图例位置</label>
-            <select id="legendPosition">
-              <option value="top">顶部</option>
-              <option value="bottom">底部</option>
-              <option value="left">左侧</option>
-              <option value="right">右侧</option>
-              <option value="none">隐藏</option>
-            </select>
-          </div>
-          <div class="settings-row" style="margin-top: 12px">
-            <label class="checkbox-group">
-              <input type="checkbox" id="showAnimation" checked="">
-              动画效果
-            </label>
-            <label class="checkbox-group">
-              <input type="checkbox" id="showGrid" checked="">
-              显示网格
-            </label>
-            <label class="checkbox-group">
-              <input type="checkbox" id="fillArea">
-              填充区域
-            </label>
-          </div>
-        </div>
-
-        <div class="tool-section">
-          <div class="section-title">颜色方案</div>
-          <div class="input-group">
-            <div class="color-inputs" id="colorInputs">
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#00f5d4">
-                <span>1</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#f72585">
-                <span>2</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#fbbf24">
-                <span>3</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#10b981">
-                <span>4</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#a855f7">
-                <span>5</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#3b82f6">
-                <span>6</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#f43f5e">
-                <span>7</span>
-              </div>
-              <div class="color-input-wrap">
-                <input type="color" class="chart-color" value="#8b5cf6">
-                <span>8</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
-          <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        </div>
-      </div>
-
-      <!-- Right Panel: Chart Output -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">图表预览</div>
-          <div class="chart-container" id="chartContainer">
-            <canvas id="chartCanvas"></canvas>
-            <div class="chart-placeholder" id="chartPlaceholder">
-              <span class="icon">📊</span>
-              输入数据后点击"生成图表"
-            </div>
-          </div>
-        </div>
-        <div class="btn-row" style="margin-top: 16px">
-          <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
-          <button class="btn btn-secondary" onclick="copyToClipboard()">📋 复制图片</button>
-          <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "图表生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/chart-maker.html"
-            }
-          ]
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "图表生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/chart-maker.html"
+          }
+        ]
+      }
+    </script>
+    <script>
+      let chartInstance = null;
+      let currentChartType = "bar";
+      let currentDataMode = "simple";
+
+      // 示例数据
+      const sampleData = {
+        simple: {
+          bar: "类别,销量\n苹果,120\n香蕉,85\n橙子,95\n葡萄,70\n西瓜,150",
+          line: "月份,访问量\n1月,1200\n2月,1900\n3月,1500\n4月,2100\n5月,2400\n6月,1800",
+          pie: "浏览器,市场份额\nChrome,65\nSafari,19\nFirefox,8\nEdge,5\n其他,3",
+          doughnut: "支出,金额\n餐饮,800\n交通,300\n购物,500\n娱乐,400\n其他,200",
+          radar: "技能,得分\nHTML,90\nCSS,85\nJavaScript,80\nReact,75\nNode.js,70\nPython,65",
+          polarArea: "季度,收入\nQ1,2500\nQ2,3200\nQ3,2800\nQ4,3800"
+        },
+        multi: {
+          bar: "月份,1月,2月,3月,4月,5月,6月\n产品A,65,59,80,81,56,55\n产品B,28,48,40,19,86,27\n产品C,45,25,60,70,45,80",
+          line: "月份,1月,2月,3月,4月,5月,6月\n收入,4000,4500,5200,4800,5800,6200\n支出,3200,3500,3800,3600,4000,4200\n利润,800,1000,1400,1200,1800,2000",
+          radar:
+            "维度,沟通,技术,领导,创新,执行\n员工A,80,90,70,85,75\n员工B,70,75,85,80,90\n员工C,85,70,80,90,70"
+        }
+      };
+
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        if (chartInstance) {
+          generateChart();
+        }
+      }
+
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // 切换数据模式
+      function switchTab(mode) {
+        currentDataMode = mode;
+        document.querySelectorAll(".tab").forEach(function (t) {
+          t.classList.remove("active");
+        });
+        document.querySelector('.tab[data-tab="' + mode + '"]').classList.add("active");
+
+        var hint = document.getElementById("dataHint");
+        // Clear existing content
+        while (hint.firstChild) {
+          hint.removeChild(hint.firstChild);
         }
 
-  </script>
-    <script>
+        if (mode === "simple") {
+          hint.appendChild(document.createTextNode('简单模式: 每行 "标签,数值"'));
+          hint.appendChild(document.createElement("br"));
+          hint.appendChild(document.createTextNode("支持逗号、制表符、分号分隔"));
+        } else {
+          hint.appendChild(document.createTextNode("多数据集: 首行为标签列表"));
+          hint.appendChild(document.createElement("br"));
+          hint.appendChild(document.createTextNode('后续行为 "系列名,值1,值2,..."'));
+        }
+        saveState();
+      }
 
-  let chartInstance = null;
-        let currentChartType = "bar";
-        let currentDataMode = "simple";
+      // 选择图表类型
+      function selectChartType(type) {
+        currentChartType = type;
+        document.querySelectorAll(".chart-type-btn").forEach(function (btn) {
+          btn.classList.remove("active");
+        });
+        document.querySelector('.chart-type-btn[data-type="' + type + '"]').classList.add("active");
 
-        // 示例数据
-        const sampleData = {
-          simple: {
-            bar: "类别,销量\n苹果,120\n香蕉,85\n橙子,95\n葡萄,70\n西瓜,150",
-            line: "月份,访问量\n1月,1200\n2月,1900\n3月,1500\n4月,2100\n5月,2400\n6月,1800",
-            pie: "浏览器,市场份额\nChrome,65\nSafari,19\nFirefox,8\nEdge,5\n其他,3",
-            doughnut: "支出,金额\n餐饮,800\n交通,300\n购物,500\n娱乐,400\n其他,200",
-            radar: "技能,得分\nHTML,90\nCSS,85\nJavaScript,80\nReact,75\nNode.js,70\nPython,65",
-            polarArea: "季度,收入\nQ1,2500\nQ2,3200\nQ3,2800\nQ4,3800"
+        // 显示/隐藏轴标签设置
+        var axisLabels = document.getElementById("axisLabels");
+        var fillArea = document.getElementById("fillArea").parentElement;
+        var showGrid = document.getElementById("showGrid").parentElement;
+
+        if (["pie", "doughnut", "polarArea"].indexOf(type) !== -1) {
+          axisLabels.style.display = "none";
+          showGrid.style.display = "none";
+        } else {
+          axisLabels.style.display = "flex";
+          showGrid.style.display = "flex";
+        }
+
+        fillArea.style.display = type === "line" || type === "radar" ? "flex" : "none";
+
+        saveState();
+      }
+
+      // 加载示例数据
+      function loadSampleData() {
+        var data = sampleData[currentDataMode];
+        var sample = data[currentChartType] || data.bar || Object.values(data)[0];
+        document.getElementById("dataInput").value = sample;
+        saveState();
+        showToast("示例数据已加载");
+      }
+
+      // 解析简单数据 (标签,数值)
+      function parseSimpleData(input) {
+        var lines = input
+          .trim()
+          .split("\n")
+          .filter(function (line) {
+            return line.trim();
+          });
+        if (lines.length === 0) return null;
+
+        var data = { labels: [], datasets: [{ data: [] }] };
+        var hasHeader = false;
+
+        // 检查第一行是否为表头
+        var firstLine = lines[0].split(/[,\t;]/).map(function (p) {
+          return p.trim();
+        });
+        if (firstLine.length >= 2 && isNaN(parseFloat(firstLine[1]))) {
+          hasHeader = true;
+        }
+
+        var startIdx = hasHeader ? 1 : 0;
+
+        for (var i = startIdx; i < lines.length; i++) {
+          var parts = lines[i].split(/[,\t;]/).map(function (p) {
+            return p.trim();
+          });
+          if (parts.length >= 2) {
+            var label = parts[0];
+            var value = parseFloat(parts[1]);
+            if (label && !isNaN(value)) {
+              data.labels.push(label);
+              data.datasets[0].data.push(value);
+            }
+          }
+        }
+
+        return data.labels.length > 0 ? data : null;
+      }
+
+      // 解析多数据集 (首行标签，后续行为系列)
+      function parseMultiData(input) {
+        var lines = input
+          .trim()
+          .split("\n")
+          .filter(function (line) {
+            return line.trim();
+          });
+        if (lines.length < 2) return null;
+
+        // 首行为标签
+        var headerParts = lines[0].split(/[,\t;]/).map(function (p) {
+          return p.trim();
+        });
+        var labels = headerParts.slice(1); // 跳过第一列(列名标题)
+
+        if (labels.length === 0) return null;
+
+        var data = { labels: labels, datasets: [] };
+
+        for (var i = 1; i < lines.length; i++) {
+          var parts = lines[i].split(/[,\t;]/).map(function (p) {
+            return p.trim();
+          });
+          if (parts.length >= 2) {
+            var seriesName = parts[0];
+            var values = parts
+              .slice(1)
+              .map(function (v) {
+                return parseFloat(v);
+              })
+              .filter(function (v) {
+                return !isNaN(v);
+              });
+            if (seriesName && values.length > 0) {
+              data.datasets.push({
+                label: seriesName,
+                data: values
+              });
+            }
+          }
+        }
+
+        return data.datasets.length > 0 ? data : null;
+      }
+
+      // 获取颜色数组
+      function getColors() {
+        var colorInputs = document.querySelectorAll(".chart-color");
+        return Array.from(colorInputs).map(function (input) {
+          return input.value;
+        });
+      }
+
+      // 添加透明度到颜色
+      function addAlpha(hex, alpha) {
+        var r = parseInt(hex.slice(1, 3), 16);
+        var g = parseInt(hex.slice(3, 5), 16);
+        var b = parseInt(hex.slice(5, 7), 16);
+        return "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")";
+      }
+
+      // 生成图表
+      function generateChart() {
+        var input = document.getElementById("dataInput").value;
+        var data = currentDataMode === "simple" ? parseSimpleData(input) : parseMultiData(input);
+
+        if (!data) {
+          showToast("请输入有效的数据格式", true);
+          return;
+        }
+
+        var chartTitle = document.getElementById("chartTitle").value || "";
+        var xAxisLabel = document.getElementById("xAxisLabel").value || "";
+        var yAxisLabel = document.getElementById("yAxisLabel").value || "";
+        var legendPosition = document.getElementById("legendPosition").value;
+        var showAnimation = document.getElementById("showAnimation").checked;
+        var showGrid = document.getElementById("showGrid").checked;
+        var fillArea = document.getElementById("fillArea").checked;
+        var colors = getColors();
+
+        // 隐藏占位符
+        document.getElementById("chartPlaceholder").style.display = "none";
+        document.getElementById("chartCanvas").style.display = "block";
+
+        // 销毁旧图表
+        if (chartInstance) {
+          chartInstance.destroy();
+        }
+
+        var ctx = document.getElementById("chartCanvas").getContext("2d");
+
+        // 获取当前主题
+        var isLight = document.body.getAttribute("data-theme") === "light";
+        var textColor = isLight ? "#1a1a1a" : "#e8e8ed";
+        var gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
+
+        // 准备数据集
+        var datasets = data.datasets.map(function (ds, i) {
+          var color = colors[i % colors.length];
+          var isPieType = ["pie", "doughnut", "polarArea"].indexOf(currentChartType) !== -1;
+
+          var baseConfig = {
+            label: ds.label || chartTitle || "数据",
+            data: ds.data,
+            backgroundColor: isPieType
+              ? data.labels.map(function (_, j) {
+                  return addAlpha(colors[j % colors.length], 0.8);
+                })
+              : addAlpha(color, currentChartType === "line" && fillArea ? 0.2 : 0.8),
+            borderColor: isPieType
+              ? data.labels.map(function (_, j) {
+                  return colors[j % colors.length];
+                })
+              : color,
+            borderWidth: 2
+          };
+
+          // 类型特定配置
+          if (currentChartType === "bar") {
+            baseConfig.borderRadius = 4;
+            baseConfig.borderSkipped = false;
+          } else if (currentChartType === "line") {
+            baseConfig.tension = 0.3;
+            baseConfig.fill = fillArea;
+            baseConfig.pointRadius = 4;
+            baseConfig.pointHoverRadius = 6;
+          } else if (currentChartType === "radar") {
+            baseConfig.fill = fillArea;
+            baseConfig.pointRadius = 4;
+          }
+
+          return baseConfig;
+        });
+
+        // 图表配置
+        var config = {
+          type: currentChartType,
+          data: {
+            labels: data.labels,
+            datasets: datasets
           },
-          multi: {
-            bar: "月份,1月,2月,3月,4月,5月,6月\n产品A,65,59,80,81,56,55\n产品B,28,48,40,19,86,27\n产品C,45,25,60,70,45,80",
-            line: "月份,1月,2月,3月,4月,5月,6月\n收入,4000,4500,5200,4800,5800,6200\n支出,3200,3500,3800,3600,4000,4200\n利润,800,1000,1400,1200,1800,2000",
-            radar:
-              "维度,沟通,技术,领导,创新,执行\n员工A,80,90,70,85,75\n员工B,70,75,85,80,90\n员工C,85,70,80,90,70"
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: showAnimation
+              ? {
+                  duration: 800,
+                  easing: "easeOutQuart"
+                }
+              : false,
+            plugins: {
+              title: {
+                display: !!chartTitle,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "bold",
+                  family: "'Space Grotesk', sans-serif"
+                },
+                padding: {
+                  top: 10,
+                  bottom: 20
+                }
+              },
+              legend: {
+                display: legendPosition !== "none",
+                position: legendPosition === "none" ? "top" : legendPosition,
+                labels: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 12
+                  },
+                  usePointStyle: true,
+                  padding: 16
+                }
+              },
+              tooltip: {
+                backgroundColor: isLight ? "#fff" : "#1a1a24",
+                titleColor: textColor,
+                bodyColor: textColor,
+                borderColor: gridColor,
+                borderWidth: 1,
+                cornerRadius: 4,
+                titleFont: {
+                  family: "'JetBrains Mono', monospace"
+                },
+                bodyFont: {
+                  family: "'JetBrains Mono', monospace"
+                }
+              }
+            }
           }
         };
 
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          if (chartInstance) {
-            generateChart();
-          }
-        }
-
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // 切换数据模式
-        function switchTab(mode) {
-          currentDataMode = mode;
-          document.querySelectorAll(".tab").forEach(function (t) {
-            t.classList.remove("active");
-          });
-          document.querySelector('.tab[data-tab="' + mode + '"]').classList.add("active");
-
-          var hint = document.getElementById("dataHint");
-          // Clear existing content
-          while (hint.firstChild) {
-            hint.removeChild(hint.firstChild);
-          }
-
-          if (mode === "simple") {
-            hint.appendChild(document.createTextNode('简单模式: 每行 "标签,数值"'));
-            hint.appendChild(document.createElement("br"));
-            hint.appendChild(document.createTextNode("支持逗号、制表符、分号分隔"));
-          } else {
-            hint.appendChild(document.createTextNode("多数据集: 首行为标签列表"));
-            hint.appendChild(document.createElement("br"));
-            hint.appendChild(document.createTextNode('后续行为 "系列名,值1,值2,..."'));
-          }
-          saveState();
-        }
-
-        // 选择图表类型
-        function selectChartType(type) {
-          currentChartType = type;
-          document.querySelectorAll(".chart-type-btn").forEach(function (btn) {
-            btn.classList.remove("active");
-          });
-          document.querySelector('.chart-type-btn[data-type="' + type + '"]').classList.add("active");
-
-          // 显示/隐藏轴标签设置
-          var axisLabels = document.getElementById("axisLabels");
-          var fillArea = document.getElementById("fillArea").parentElement;
-          var showGrid = document.getElementById("showGrid").parentElement;
-
-          if (["pie", "doughnut", "polarArea"].indexOf(type) !== -1) {
-            axisLabels.style.display = "none";
-            showGrid.style.display = "none";
-          } else {
-            axisLabels.style.display = "flex";
-            showGrid.style.display = "flex";
-          }
-
-          fillArea.style.display = type === "line" || type === "radar" ? "flex" : "none";
-
-          saveState();
-        }
-
-        // 加载示例数据
-        function loadSampleData() {
-          var data = sampleData[currentDataMode];
-          var sample = data[currentChartType] || data.bar || Object.values(data)[0];
-          document.getElementById("dataInput").value = sample;
-          saveState();
-          showToast("示例数据已加载");
-        }
-
-        // 解析简单数据 (标签,数值)
-        function parseSimpleData(input) {
-          var lines = input
-            .trim()
-            .split("\n")
-            .filter(function (line) {
-              return line.trim();
-            });
-          if (lines.length === 0) return null;
-
-          var data = { labels: [], datasets: [{ data: [] }] };
-          var hasHeader = false;
-
-          // 检查第一行是否为表头
-          var firstLine = lines[0].split(/[,\t;]/).map(function (p) {
-            return p.trim();
-          });
-          if (firstLine.length >= 2 && isNaN(parseFloat(firstLine[1]))) {
-            hasHeader = true;
-          }
-
-          var startIdx = hasHeader ? 1 : 0;
-
-          for (var i = startIdx; i < lines.length; i++) {
-            var parts = lines[i].split(/[,\t;]/).map(function (p) {
-              return p.trim();
-            });
-            if (parts.length >= 2) {
-              var label = parts[0];
-              var value = parseFloat(parts[1]);
-              if (label && !isNaN(value)) {
-                data.labels.push(label);
-                data.datasets[0].data.push(value);
-              }
-            }
-          }
-
-          return data.labels.length > 0 ? data : null;
-        }
-
-        // 解析多数据集 (首行标签，后续行为系列)
-        function parseMultiData(input) {
-          var lines = input
-            .trim()
-            .split("\n")
-            .filter(function (line) {
-              return line.trim();
-            });
-          if (lines.length < 2) return null;
-
-          // 首行为标签
-          var headerParts = lines[0].split(/[,\t;]/).map(function (p) {
-            return p.trim();
-          });
-          var labels = headerParts.slice(1); // 跳过第一列(列名标题)
-
-          if (labels.length === 0) return null;
-
-          var data = { labels: labels, datasets: [] };
-
-          for (var i = 1; i < lines.length; i++) {
-            var parts = lines[i].split(/[,\t;]/).map(function (p) {
-              return p.trim();
-            });
-            if (parts.length >= 2) {
-              var seriesName = parts[0];
-              var values = parts
-                .slice(1)
-                .map(function (v) {
-                  return parseFloat(v);
-                })
-                .filter(function (v) {
-                  return !isNaN(v);
-                });
-              if (seriesName && values.length > 0) {
-                data.datasets.push({
-                  label: seriesName,
-                  data: values
-                });
-              }
-            }
-          }
-
-          return data.datasets.length > 0 ? data : null;
-        }
-
-        // 获取颜色数组
-        function getColors() {
-          var colorInputs = document.querySelectorAll(".chart-color");
-          return Array.from(colorInputs).map(function (input) {
-            return input.value;
-          });
-        }
-
-        // 添加透明度到颜色
-        function addAlpha(hex, alpha) {
-          var r = parseInt(hex.slice(1, 3), 16);
-          var g = parseInt(hex.slice(3, 5), 16);
-          var b = parseInt(hex.slice(5, 7), 16);
-          return "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")";
-        }
-
-        // 生成图表
-        function generateChart() {
-          var input = document.getElementById("dataInput").value;
-          var data = currentDataMode === "simple" ? parseSimpleData(input) : parseMultiData(input);
-
-          if (!data) {
-            showToast("请输入有效的数据格式", true);
-            return;
-          }
-
-          var chartTitle = document.getElementById("chartTitle").value || "";
-          var xAxisLabel = document.getElementById("xAxisLabel").value || "";
-          var yAxisLabel = document.getElementById("yAxisLabel").value || "";
-          var legendPosition = document.getElementById("legendPosition").value;
-          var showAnimation = document.getElementById("showAnimation").checked;
-          var showGrid = document.getElementById("showGrid").checked;
-          var fillArea = document.getElementById("fillArea").checked;
-          var colors = getColors();
-
-          // 隐藏占位符
-          document.getElementById("chartPlaceholder").style.display = "none";
-          document.getElementById("chartCanvas").style.display = "block";
-
-          // 销毁旧图表
-          if (chartInstance) {
-            chartInstance.destroy();
-          }
-
-          var ctx = document.getElementById("chartCanvas").getContext("2d");
-
-          // 获取当前主题
-          var isLight = document.body.getAttribute("data-theme") === "light";
-          var textColor = isLight ? "#1a1a1a" : "#e8e8ed";
-          var gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
-
-          // 准备数据集
-          var datasets = data.datasets.map(function (ds, i) {
-            var color = colors[i % colors.length];
-            var isPieType = ["pie", "doughnut", "polarArea"].indexOf(currentChartType) !== -1;
-
-            var baseConfig = {
-              label: ds.label || chartTitle || "数据",
-              data: ds.data,
-              backgroundColor: isPieType
-                ? data.labels.map(function (_, j) {
-                    return addAlpha(colors[j % colors.length], 0.8);
-                  })
-                : addAlpha(color, currentChartType === "line" && fillArea ? 0.2 : 0.8),
-              borderColor: isPieType
-                ? data.labels.map(function (_, j) {
-                    return colors[j % colors.length];
-                  })
-                : color,
-              borderWidth: 2
-            };
-
-            // 类型特定配置
-            if (currentChartType === "bar") {
-              baseConfig.borderRadius = 4;
-              baseConfig.borderSkipped = false;
-            } else if (currentChartType === "line") {
-              baseConfig.tension = 0.3;
-              baseConfig.fill = fillArea;
-              baseConfig.pointRadius = 4;
-              baseConfig.pointHoverRadius = 6;
-            } else if (currentChartType === "radar") {
-              baseConfig.fill = fillArea;
-              baseConfig.pointRadius = 4;
-            }
-
-            return baseConfig;
-          });
-
-          // 图表配置
-          var config = {
-            type: currentChartType,
-            data: {
-              labels: data.labels,
-              datasets: datasets
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              animation: showAnimation
-                ? {
-                    duration: 800,
-                    easing: "easeOutQuart"
-                  }
-                : false,
-              plugins: {
-                title: {
-                  display: !!chartTitle,
-                  text: chartTitle,
+        // 添加轴配置 (非饼图/环形图)
+        var isPieType = ["pie", "doughnut", "polarArea"].indexOf(currentChartType) !== -1;
+        if (!isPieType) {
+          if (currentChartType === "radar") {
+            config.options.scales = {
+              r: {
+                angleLines: {
+                  color: gridColor
+                },
+                grid: {
+                  color: gridColor,
+                  display: showGrid
+                },
+                pointLabels: {
                   color: textColor,
                   font: {
-                    size: 16,
-                    weight: "bold",
-                    family: "'Space Grotesk', sans-serif"
-                  },
-                  padding: {
-                    top: 10,
-                    bottom: 20
+                    family: "'JetBrains Mono', monospace",
+                    size: 11
                   }
                 },
-                legend: {
-                  display: legendPosition !== "none",
-                  position: legendPosition === "none" ? "top" : legendPosition,
-                  labels: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 12
-                    },
-                    usePointStyle: true,
-                    padding: 16
-                  }
-                },
-                tooltip: {
-                  backgroundColor: isLight ? "#fff" : "#1a1a24",
-                  titleColor: textColor,
-                  bodyColor: textColor,
-                  borderColor: gridColor,
-                  borderWidth: 1,
-                  cornerRadius: 4,
-                  titleFont: {
-                    family: "'JetBrains Mono', monospace"
-                  },
-                  bodyFont: {
-                    family: "'JetBrains Mono', monospace"
+                ticks: {
+                  color: textColor,
+                  backdropColor: "transparent",
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 10
                   }
                 }
               }
-            }
-          };
-
-          // 添加轴配置 (非饼图/环形图)
-          var isPieType = ["pie", "doughnut", "polarArea"].indexOf(currentChartType) !== -1;
-          if (!isPieType) {
-            if (currentChartType === "radar") {
-              config.options.scales = {
-                r: {
-                  angleLines: {
-                    color: gridColor
-                  },
-                  grid: {
-                    color: gridColor,
-                    display: showGrid
-                  },
-                  pointLabels: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 11
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    backdropColor: "transparent",
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 10
-                    }
-                  }
-                }
-              };
-            } else {
-              config.options.scales = {
-                x: {
-                  title: {
-                    display: !!xAxisLabel,
-                    text: xAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 11
-                    }
-                  },
-                  grid: {
-                    color: gridColor,
-                    display: showGrid,
-                    drawBorder: false
+            };
+          } else {
+            config.options.scales = {
+              x: {
+                title: {
+                  display: !!xAxisLabel,
+                  text: xAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
                   }
                 },
-                y: {
-                  title: {
-                    display: !!yAxisLabel,
-                    text: yAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 11
-                    }
-                  },
-                  grid: {
-                    color: gridColor,
-                    display: showGrid,
-                    drawBorder: false
-                  },
-                  beginAtZero: true
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 11
+                  }
+                },
+                grid: {
+                  color: gridColor,
+                  display: showGrid,
+                  drawBorder: false
                 }
-              };
-            }
+              },
+              y: {
+                title: {
+                  display: !!yAxisLabel,
+                  text: yAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
+                  }
+                },
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 11
+                  }
+                },
+                grid: {
+                  color: gridColor,
+                  display: showGrid,
+                  drawBorder: false
+                },
+                beginAtZero: true
+              }
+            };
           }
-
-          chartInstance = new Chart(ctx, config);
-
-          // 保存状态
-          saveState();
-          showToast("图表生成成功");
         }
 
-        // 导出PNG
-        function exportPNG() {
-          if (!chartInstance) {
-            showToast("请先生成图表", true);
-            return;
-          }
+        chartInstance = new Chart(ctx, config);
 
+        // 保存状态
+        saveState();
+        showToast("图表生成成功");
+      }
+
+      // 导出PNG
+      function exportPNG() {
+        if (!chartInstance) {
+          showToast("请先生成图表", true);
+          return;
+        }
+
+        var canvas = document.getElementById("chartCanvas");
+
+        // 创建临时canvas以添加背景
+        var tempCanvas = document.createElement("canvas");
+        var tempCtx = tempCanvas.getContext("2d");
+        tempCanvas.width = canvas.width;
+        tempCanvas.height = canvas.height;
+
+        // 填充背景色
+        var isLight = document.body.getAttribute("data-theme") === "light";
+        tempCtx.fillStyle = isLight ? "#ffffff" : "#1a1a24";
+        tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
+
+        // 绘制图表
+        tempCtx.drawImage(canvas, 0, 0);
+
+        var link = document.createElement("a");
+        link.download = "chart-" + currentChartType + "-" + Date.now() + ".png";
+        link.href = tempCanvas.toDataURL("image/png", 1.0);
+        link.click();
+        showToast("PNG已下载");
+      }
+
+      // 复制图片到剪贴板
+      function copyToClipboard() {
+        if (!chartInstance) {
+          showToast("请先生成图表", true);
+          return;
+        }
+
+        try {
           var canvas = document.getElementById("chartCanvas");
 
-          // 创建临时canvas以添加背景
+          // 创建临时canvas
           var tempCanvas = document.createElement("canvas");
           var tempCtx = tempCanvas.getContext("2d");
           tempCanvas.width = canvas.width;
           tempCanvas.height = canvas.height;
 
-          // 填充背景色
           var isLight = document.body.getAttribute("data-theme") === "light";
           tempCtx.fillStyle = isLight ? "#ffffff" : "#1a1a24";
           tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
-
-          // 绘制图表
           tempCtx.drawImage(canvas, 0, 0);
 
-          var link = document.createElement("a");
-          link.download = "chart-" + currentChartType + "-" + Date.now() + ".png";
-          link.href = tempCanvas.toDataURL("image/png", 1.0);
-          link.click();
-          showToast("PNG已下载");
+          tempCanvas.toBlob(function (blob) {
+            try {
+              navigator.clipboard
+                .write([new ClipboardItem({ "image/png": blob })])
+                .then(function () {
+                  showToast("图片已复制到剪贴板");
+                })
+                .catch(function () {
+                  showToast("复制失败，请使用导出功能", true);
+                });
+            } catch (e) {
+              showToast("复制失败，请使用导出功能", true);
+            }
+          }, "image/png");
+        } catch (e) {
+          showToast("复制失败", true);
         }
+      }
 
-        // 复制图片到剪贴板
-        function copyToClipboard() {
-          if (!chartInstance) {
-            showToast("请先生成图表", true);
-            return;
-          }
+      // 分享功能
+      function shareChart() {
+        var state = getState();
+        var encoded = btoa(encodeURIComponent(JSON.stringify(state)));
+        var url = window.location.href.split("#")[0] + "#" + encoded;
 
-          try {
-            var canvas = document.getElementById("chartCanvas");
+        navigator.clipboard
+          .writeText(url)
+          .then(function () {
+            showToast("分享链接已复制到剪贴板");
+          })
+          .catch(function () {
+            showToast("复制失败，请手动复制URL", true);
+          });
+      }
 
-            // 创建临时canvas
-            var tempCanvas = document.createElement("canvas");
-            var tempCtx = tempCanvas.getContext("2d");
-            tempCanvas.width = canvas.width;
-            tempCanvas.height = canvas.height;
+      // 获取当前状态
+      function getState() {
+        return {
+          data: document.getElementById("dataInput").value,
+          type: currentChartType,
+          mode: currentDataMode,
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          legend: document.getElementById("legendPosition").value,
+          animation: document.getElementById("showAnimation").checked,
+          grid: document.getElementById("showGrid").checked,
+          fill: document.getElementById("fillArea").checked,
+          colors: getColors()
+        };
+      }
 
-            var isLight = document.body.getAttribute("data-theme") === "light";
-            tempCtx.fillStyle = isLight ? "#ffffff" : "#1a1a24";
-            tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
-            tempCtx.drawImage(canvas, 0, 0);
+      // 从URL加载状态
+      function loadFromUrl() {
+        var hash = window.location.hash.slice(1);
+        if (!hash) return false;
 
-            tempCanvas.toBlob(function (blob) {
-              try {
-                navigator.clipboard
-                  .write([new ClipboardItem({ "image/png": blob })])
-                  .then(function () {
-                    showToast("图片已复制到剪贴板");
-                  })
-                  .catch(function () {
-                    showToast("复制失败，请使用导出功能", true);
-                  });
-              } catch (e) {
-                showToast("复制失败，请使用导出功能", true);
-              }
-            }, "image/png");
-          } catch (e) {
-            showToast("复制失败", true);
-          }
+        try {
+          var state = JSON.parse(decodeURIComponent(atob(hash)));
+          applyState(state);
+          return true;
+        } catch (e) {
+          return false;
         }
+      }
 
-        // 分享功能
-        function shareChart() {
-          var state = getState();
-          var encoded = btoa(encodeURIComponent(JSON.stringify(state)));
-          var url = window.location.href.split("#")[0] + "#" + encoded;
-
-          navigator.clipboard
-            .writeText(url)
-            .then(function () {
-              showToast("分享链接已复制到剪贴板");
-            })
-            .catch(function () {
-              showToast("复制失败，请手动复制URL", true);
-            });
+      // 应用状态
+      function applyState(state) {
+        if (state.data) document.getElementById("dataInput").value = state.data;
+        if (state.type) {
+          currentChartType = state.type;
+          selectChartType(state.type);
         }
-
-        // 获取当前状态
-        function getState() {
-          return {
-            data: document.getElementById("dataInput").value,
-            type: currentChartType,
-            mode: currentDataMode,
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            legend: document.getElementById("legendPosition").value,
-            animation: document.getElementById("showAnimation").checked,
-            grid: document.getElementById("showGrid").checked,
-            fill: document.getElementById("fillArea").checked,
-            colors: getColors()
-          };
+        if (state.mode) {
+          currentDataMode = state.mode;
+          switchTab(state.mode);
         }
-
-        // 从URL加载状态
-        function loadFromUrl() {
-          var hash = window.location.hash.slice(1);
-          if (!hash) return false;
-
-          try {
-            var state = JSON.parse(decodeURIComponent(atob(hash)));
-            applyState(state);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 应用状态
-        function applyState(state) {
-          if (state.data) document.getElementById("dataInput").value = state.data;
-          if (state.type) {
-            currentChartType = state.type;
-            selectChartType(state.type);
-          }
-          if (state.mode) {
-            currentDataMode = state.mode;
-            switchTab(state.mode);
-          }
-          if (state.title !== undefined) document.getElementById("chartTitle").value = state.title;
-          if (state.xAxis !== undefined) document.getElementById("xAxisLabel").value = state.xAxis;
-          if (state.yAxis !== undefined) document.getElementById("yAxisLabel").value = state.yAxis;
-          if (state.legend) document.getElementById("legendPosition").value = state.legend;
-          if (state.animation !== undefined)
-            document.getElementById("showAnimation").checked = state.animation;
-          if (state.grid !== undefined) document.getElementById("showGrid").checked = state.grid;
-          if (state.fill !== undefined) document.getElementById("fillArea").checked = state.fill;
-          if (state.colors && Array.isArray(state.colors)) {
-            var colorInputs = document.querySelectorAll(".chart-color");
-            state.colors.forEach(function (color, i) {
-              if (colorInputs[i]) colorInputs[i].value = color;
-            });
-          }
-        }
-
-        // 保存状态到 localStorage
-        function saveState() {
-          localStorage.setItem("chart-maker-state", JSON.stringify(getState()));
-        }
-
-        // 从 localStorage 加载状态
-        function loadState() {
-          var saved = localStorage.getItem("chart-maker-state");
-          if (!saved) return false;
-
-          try {
-            var state = JSON.parse(saved);
-            applyState(state);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("dataInput").value = "";
-          document.getElementById("chartTitle").value = "数据统计";
-          document.getElementById("xAxisLabel").value = "";
-          document.getElementById("yAxisLabel").value = "";
-          document.getElementById("legendPosition").value = "top";
-          document.getElementById("showAnimation").checked = true;
-          document.getElementById("showGrid").checked = true;
-          document.getElementById("fillArea").checked = false;
-
-          currentChartType = "bar";
-          currentDataMode = "simple";
-          selectChartType("bar");
-          switchTab("simple");
-
-          // 重置颜色
-          var defaultColors = [
-            "#00f5d4",
-            "#f72585",
-            "#fbbf24",
-            "#10b981",
-            "#a855f7",
-            "#3b82f6",
-            "#f43f5e",
-            "#8b5cf6"
-          ];
+        if (state.title !== undefined) document.getElementById("chartTitle").value = state.title;
+        if (state.xAxis !== undefined) document.getElementById("xAxisLabel").value = state.xAxis;
+        if (state.yAxis !== undefined) document.getElementById("yAxisLabel").value = state.yAxis;
+        if (state.legend) document.getElementById("legendPosition").value = state.legend;
+        if (state.animation !== undefined)
+          document.getElementById("showAnimation").checked = state.animation;
+        if (state.grid !== undefined) document.getElementById("showGrid").checked = state.grid;
+        if (state.fill !== undefined) document.getElementById("fillArea").checked = state.fill;
+        if (state.colors && Array.isArray(state.colors)) {
           var colorInputs = document.querySelectorAll(".chart-color");
-          defaultColors.forEach(function (color, i) {
+          state.colors.forEach(function (color, i) {
             if (colorInputs[i]) colorInputs[i].value = color;
           });
+        }
+      }
 
-          // 销毁图表
-          if (chartInstance) {
-            chartInstance.destroy();
-            chartInstance = null;
-          }
-          document.getElementById("chartPlaceholder").style.display = "flex";
-          document.getElementById("chartCanvas").style.display = "none";
+      // 保存状态到 localStorage
+      function saveState() {
+        localStorage.setItem("chart-maker-state", JSON.stringify(getState()));
+      }
 
-          // 清除 localStorage
-          localStorage.removeItem("chart-maker-state");
+      // 从 localStorage 加载状态
+      function loadState() {
+        var saved = localStorage.getItem("chart-maker-state");
+        if (!saved) return false;
 
-          // 清除 URL hash
-          history.replaceState(null, "", window.location.pathname);
+        try {
+          var state = JSON.parse(saved);
+          applyState(state);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
 
-          showToast("已清空");
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("dataInput").value = "";
+        document.getElementById("chartTitle").value = "数据统计";
+        document.getElementById("xAxisLabel").value = "";
+        document.getElementById("yAxisLabel").value = "";
+        document.getElementById("legendPosition").value = "top";
+        document.getElementById("showAnimation").checked = true;
+        document.getElementById("showGrid").checked = true;
+        document.getElementById("fillArea").checked = false;
+
+        currentChartType = "bar";
+        currentDataMode = "simple";
+        selectChartType("bar");
+        switchTab("simple");
+
+        // 重置颜色
+        var defaultColors = [
+          "#00f5d4",
+          "#f72585",
+          "#fbbf24",
+          "#10b981",
+          "#a855f7",
+          "#3b82f6",
+          "#f43f5e",
+          "#8b5cf6"
+        ];
+        var colorInputs = document.querySelectorAll(".chart-color");
+        defaultColors.forEach(function (color, i) {
+          if (colorInputs[i]) colorInputs[i].value = color;
+        });
+
+        // 销毁图表
+        if (chartInstance) {
+          chartInstance.destroy();
+          chartInstance = null;
+        }
+        document.getElementById("chartPlaceholder").style.display = "flex";
+        document.getElementById("chartCanvas").style.display = "none";
+
+        // 清除 localStorage
+        localStorage.removeItem("chart-maker-state");
+
+        // 清除 URL hash
+        history.replaceState(null, "", window.location.pathname);
+
+        showToast("已清空");
+      }
+
+      // 显示提示
+      function showToast(msg, isError) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        if (isError) {
+          toast.classList.add("error");
+        } else {
+          toast.classList.remove("error");
+        }
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // 初始化
+      (function init() {
+        // 初始化UI状态
+        selectChartType("bar");
+
+        // 优先从URL加载，否则从localStorage加载
+        var loadedFromUrl = loadFromUrl();
+        if (!loadedFromUrl) {
+          loadState();
         }
 
-        // 显示提示
-        function showToast(msg, isError) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          if (isError) {
-            toast.classList.add("error");
-          } else {
-            toast.classList.remove("error");
-          }
-          toast.classList.add("show");
+        // 如果有数据，自动生成图表
+        var dataInput = document.getElementById("dataInput").value;
+        if (dataInput.trim()) {
           setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
+            generateChart();
+          }, 100);
         }
 
-        // 初始化
-        (function init() {
-          // 初始化UI状态
-          selectChartType("bar");
-
-          // 优先从URL加载，否则从localStorage加载
-          var loadedFromUrl = loadFromUrl();
-          if (!loadedFromUrl) {
-            loadState();
+        // 监听输入变化保存状态
+        var inputs = [
+          "dataInput",
+          "chartTitle",
+          "xAxisLabel",
+          "yAxisLabel",
+          "legendPosition",
+          "showAnimation",
+          "showGrid",
+          "fillArea"
+        ];
+        inputs.forEach(function (id) {
+          var el = document.getElementById(id);
+          if (el) {
+            el.addEventListener("input", saveState);
+            el.addEventListener("change", saveState);
           }
+        });
 
-          // 如果有数据，自动生成图表
-          var dataInput = document.getElementById("dataInput").value;
-          if (dataInput.trim()) {
-            setTimeout(function () {
-              generateChart();
-            }, 100);
+        // 监听颜色变化
+        document.querySelectorAll(".chart-color").forEach(function (input) {
+          input.addEventListener("change", saveState);
+        });
+
+        // 快捷键
+        document.addEventListener("keydown", function (e) {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            e.preventDefault();
+            generateChart();
           }
+        });
+      })();
+    </script>
 
-          // 监听输入变化保存状态
-          var inputs = [
-            "dataInput",
-            "chartTitle",
-            "xAxisLabel",
-            "yAxisLabel",
-            "legendPosition",
-            "showAnimation",
-            "showGrid",
-            "fillArea"
-          ];
-          inputs.forEach(function (id) {
-            var el = document.getElementById(id);
-            if (el) {
-              el.addEventListener("input", saveState);
-              el.addEventListener("change", saveState);
-            }
-          });
-
-          // 监听颜色变化
-          document.querySelectorAll(".chart-color").forEach(function (input) {
-            input.addEventListener("change", saveState);
-          });
-
-          // 快捷键
-          document.addEventListener("keydown", function (e) {
-            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-              e.preventDefault();
-              generateChart();
-            }
-          });
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/correlation-analyzer.html
+++ b/tools/data/correlation-analyzer.html
@@ -6,17 +6,29 @@
     <title>Correlation Analyzer - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="correlation analyzer" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="Correlation Analyzer - WebUtils" />
-    <meta property="og:description" content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Correlation Analyzer - WebUtils" />
-    <meta name="twitter:description" content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Correlation Analyzer，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Correlation Analyzer",
-      "item": "https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Correlation Analyzer",
+            "item": "https://tools.realtime-ai.chat/tools/data/correlation-analyzer.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Correlation Analyzer - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Correlation Analyzer - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,395 +103,401 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .input-group {
-    margin-bottom: 16px;
-  }
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-    min-height: 150px;
-    resize: vertical;
-  }
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-top: 16px;
-  }
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .result-box {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    margin-bottom: 16px;
-  }
-  .result-value {
-    font-family: var(--font-mono);
-    font-size: 2.5rem;
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 8px;
-  }
-  .result-label {
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-    text-align: center;
-  }
-  .interpretation {
-    padding: 12px 16px;
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    text-align: center;
-    margin-top: 12px;
-  }
-  .interpretation.strong-positive {
-    background: rgba(16, 185, 129, 0.15);
-    color: var(--accent-green);
-    border: 1px solid var(--accent-green);
-  }
-  .interpretation.moderate-positive {
-    background: rgba(0, 245, 212, 0.15);
-    color: var(--color-accent-cyan);
-    border: 1px solid var(--color-accent-cyan);
-  }
-  .interpretation.weak {
-    background: rgba(251, 191, 36, 0.15);
-    color: var(--accent-yellow);
-    border: 1px solid var(--accent-yellow);
-  }
-  .interpretation.moderate-negative {
-    background: rgba(168, 85, 247, 0.15);
-    color: var(--color-accent-purple);
-    border: 1px solid var(--color-accent-purple);
-  }
-  .interpretation.strong-negative {
-    background: rgba(244, 63, 94, 0.15);
-    color: var(--accent-red);
-    border: 1px solid var(--accent-red);
-  }
-  .chart-container {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    position: relative;
-  }
-  #scatterCanvas {
-    width: 100%;
-    height: 300px;
-    display: block;
-  }
-  .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-    margin-top: 16px;
-  }
-  .stat-item {
-    background: var(--bg-input);
-    padding: 12px;
-    border-radius: var(--radius-sm);
-    text-align: center;
-  }
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
-  .stat-label {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .btn {
-      width: 100%;
-    }
-    .stats-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .input-group {
+        margin-bottom: 16px;
+      }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+        min-height: 150px;
+        resize: vertical;
+      }
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .result-box {
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        margin-bottom: 16px;
+      }
+      .result-value {
+        font-family: var(--font-mono);
+        font-size: 2.5rem;
+        font-weight: 700;
+        text-align: center;
+        margin-bottom: 8px;
+      }
+      .result-label {
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+        text-align: center;
+      }
+      .interpretation {
+        padding: 12px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        text-align: center;
+        margin-top: 12px;
+      }
+      .interpretation.strong-positive {
+        background: rgba(16, 185, 129, 0.15);
+        color: var(--accent-green);
+        border: 1px solid var(--accent-green);
+      }
+      .interpretation.moderate-positive {
+        background: rgba(0, 245, 212, 0.15);
+        color: var(--color-accent-cyan);
+        border: 1px solid var(--color-accent-cyan);
+      }
+      .interpretation.weak {
+        background: rgba(251, 191, 36, 0.15);
+        color: var(--accent-yellow);
+        border: 1px solid var(--accent-yellow);
+      }
+      .interpretation.moderate-negative {
+        background: rgba(168, 85, 247, 0.15);
+        color: var(--color-accent-purple);
+        border: 1px solid var(--color-accent-purple);
+      }
+      .interpretation.strong-negative {
+        background: rgba(244, 63, 94, 0.15);
+        color: var(--accent-red);
+        border: 1px solid var(--accent-red);
+      }
+      .chart-container {
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        position: relative;
+      }
+      #scatterCanvas {
+        width: 100%;
+        height: 300px;
+        display: block;
+      }
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .stat-item {
+        background: var(--bg-input);
+        padding: 12px;
+        border-radius: var(--radius-sm);
+        text-align: center;
+      }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
+      .stat-label {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .btn {
+          width: 100%;
+        }
+        .stats-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">相关性分析</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        相关性分析
-      </h1>
-      <p>计算皮尔逊相关系数，可视化散点图</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">相关性分析</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              相关性分析
+            </h1>
+            <p>计算皮尔逊相关系数，可视化散点图</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <div class="input-panel">
-        <div class="section-title">数据输入</div>
-        <div class="input-group">
-          <label class="input-label">X 值（每行一个数字）</label>
-          <textarea id="xValues" placeholder="1
+        <main class="main-content">
+          <div class="tool-layout">
+            <div class="input-panel">
+              <div class="section-title">数据输入</div>
+              <div class="input-group">
+                <label class="input-label">X 值（每行一个数字）</label>
+                <textarea
+                  id="xValues"
+                  placeholder="1
 2
 3
 4
@@ -485,11 +506,14 @@
 7
 8
 9
-10"></textarea>
-        </div>
-        <div class="input-group">
-          <label class="input-label">Y 值（每行一个数字）</label>
-          <textarea id="yValues" placeholder="2.1
+10"
+                ></textarea>
+              </div>
+              <div class="input-group">
+                <label class="input-label">Y 值（每行一个数字）</label>
+                <textarea
+                  id="yValues"
+                  placeholder="2.1
 4.2
 5.8
 8.1
@@ -498,442 +522,443 @@
 14.2
 16.0
 18.1
-20.2"></textarea>
-          <div class="input-hint">提示：X 和 Y 的数据点数量必须相同</div>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="analyze()">📈 分析</button>
-          <button class="btn btn-secondary" onclick="loadSample()">📝 示例</button>
-          <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        </div>
-      </div>
+20.2"
+                ></textarea>
+                <div class="input-hint">提示：X 和 Y 的数据点数量必须相同</div>
+              </div>
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="analyze()">📈 分析</button>
+                <button class="btn btn-secondary" onclick="loadSample()">📝 示例</button>
+                <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+              </div>
+            </div>
 
-      <div class="output-panel">
-        <div class="section-title">分析结果</div>
-        <div class="result-box">
-          <div class="result-value" id="rValue">--</div>
-          <div class="result-label">皮尔逊相关系数 (r)</div>
-          <div class="interpretation" id="interpretation" style="display: none"></div>
-        </div>
+            <div class="output-panel">
+              <div class="section-title">分析结果</div>
+              <div class="result-box">
+                <div class="result-value" id="rValue">--</div>
+                <div class="result-label">皮尔逊相关系数 (r)</div>
+                <div class="interpretation" id="interpretation" style="display: none"></div>
+              </div>
 
-        <div class="chart-container">
-          <canvas id="scatterCanvas"></canvas>
-        </div>
+              <div class="chart-container">
+                <canvas id="scatterCanvas"></canvas>
+              </div>
 
-        <div class="stats-grid">
-          <div class="stat-item">
-            <div class="stat-value" id="r2Value">--</div>
-            <div class="stat-label">R² 决定系数</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value" id="nValue">--</div>
-            <div class="stat-label">数据点数</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value" id="xMean">--</div>
-            <div class="stat-label">X 均值</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value" id="yMean">--</div>
-            <div class="stat-label">Y 均值</div>
-          </div>
-        </div>
+              <div class="stats-grid">
+                <div class="stat-item">
+                  <div class="stat-value" id="r2Value">--</div>
+                  <div class="stat-label">R² 决定系数</div>
+                </div>
+                <div class="stat-item">
+                  <div class="stat-value" id="nValue">--</div>
+                  <div class="stat-label">数据点数</div>
+                </div>
+                <div class="stat-item">
+                  <div class="stat-value" id="xMean">--</div>
+                  <div class="stat-label">X 均值</div>
+                </div>
+                <div class="stat-item">
+                  <div class="stat-value" id="yMean">--</div>
+                  <div class="stat-label">Y 均值</div>
+                </div>
+              </div>
 
-        <div class="btn-row">
-          <button class="btn btn-secondary" onclick="copyResults()">📋 复制结果</button>
-          <button class="btn btn-secondary" onclick="shareAnalysis()">🔗 分享</button>
-        </div>
+              <div class="btn-row">
+                <button class="btn btn-secondary" onclick="copyResults()">📋 复制结果</button>
+                <button class="btn btn-secondary" onclick="shareAnalysis()">🔗 分享</button>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script>
-  const LS_KEY = "correlation-analyzer-data";
+      const LS_KEY = "correlation-analyzer-data";
 
-  function toggleTheme() {
-    const body = document.body;
-    const isDark = body.getAttribute("data-theme") !== "light";
-    body.setAttribute("data-theme", isDark ? "light" : "dark");
-    localStorage.setItem("theme", isDark ? "light" : "dark");
-    if (window.lastData) {
-      drawScatterPlot(window.lastData.x, window.lastData.y, window.lastData.r);
-    }
-  }
-
-  (function () {
-    const saved = localStorage.getItem("theme");
-    if (saved === "light") {
-      document.body.setAttribute("data-theme", "light");
-    }
-  })();
-
-  function parseValues(text) {
-    return text
-      .trim()
-      .split("\n")
-      .map(function (line) {
-        return line.trim();
-      })
-      .filter(function (line) {
-        return line !== "";
-      })
-      .map(function (line) {
-        return parseFloat(line);
-      })
-      .filter(function (num) {
-        return !isNaN(num);
-      });
-  }
-
-  function calculatePearson(x, y) {
-    const n = x.length;
-    if (n !== y.length || n < 2) return null;
-
-    const sumX = x.reduce(function (a, b) {
-      return a + b;
-    }, 0);
-    const sumY = y.reduce(function (a, b) {
-      return a + b;
-    }, 0);
-    const sumXY = x.reduce(function (total, xi, i) {
-      return total + xi * y[i];
-    }, 0);
-    const sumX2 = x.reduce(function (total, xi) {
-      return total + xi * xi;
-    }, 0);
-    const sumY2 = y.reduce(function (total, yi) {
-      return total + yi * yi;
-    }, 0);
-
-    const numerator = n * sumXY - sumX * sumY;
-    const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
-
-    if (denominator === 0) return 0;
-    return numerator / denominator;
-  }
-
-  function getInterpretation(r) {
-    const absR = Math.abs(r);
-    if (absR >= 0.8) {
-      return {
-        text: r > 0 ? "强正相关" : "强负相关",
-        class: r > 0 ? "strong-positive" : "strong-negative"
-      };
-    } else if (absR >= 0.5) {
-      return {
-        text: r > 0 ? "中等正相关" : "中等负相关",
-        class: r > 0 ? "moderate-positive" : "moderate-negative"
-      };
-    } else if (absR >= 0.3) {
-      return {
-        text: r > 0 ? "弱正相关" : "弱负相关",
-        class: "weak"
-      };
-    } else {
-      return {
-        text: "无明显相关性",
-        class: "weak"
-      };
-    }
-  }
-
-  function drawScatterPlot(xData, yData, r) {
-    const canvas = document.getElementById("scatterCanvas");
-    const ctx = canvas.getContext("2d");
-    const isLight = document.body.getAttribute("data-theme") === "light";
-
-    const dpr = window.devicePixelRatio || 1;
-    const rect = canvas.getBoundingClientRect();
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    ctx.scale(dpr, dpr);
-
-    const width = rect.width;
-    const height = rect.height;
-    const padding = 40;
-
-    ctx.fillStyle = isLight ? "#fff" : "#12121a";
-    ctx.fillRect(0, 0, width, height);
-
-    const xMin = Math.min.apply(null, xData);
-    const xMax = Math.max.apply(null, xData);
-    const yMin = Math.min.apply(null, yData);
-    const yMax = Math.max.apply(null, yData);
-
-    const xRange = xMax - xMin || 1;
-    const yRange = yMax - yMin || 1;
-
-    function scaleX(x) {
-      return padding + ((x - xMin) / xRange) * (width - 2 * padding);
-    }
-    function scaleY(y) {
-      return height - padding - ((y - yMin) / yRange) * (height - 2 * padding);
-    }
-
-    ctx.strokeStyle = isLight ? "#e5e5e5" : "#2a2a3a";
-    ctx.lineWidth = 1;
-
-    for (var i = 0; i <= 5; i++) {
-      var y = padding + (i / 5) * (height - 2 * padding);
-      ctx.beginPath();
-      ctx.moveTo(padding, y);
-      ctx.lineTo(width - padding, y);
-      ctx.stroke();
-    }
-
-    for (var j = 0; j <= 5; j++) {
-      var x = padding + (j / 5) * (width - 2 * padding);
-      ctx.beginPath();
-      ctx.moveTo(x, padding);
-      ctx.lineTo(x, height - padding);
-      ctx.stroke();
-    }
-
-    ctx.fillStyle = isLight ? "#666" : "#8888a0";
-    ctx.font = "11px JetBrains Mono";
-    ctx.textAlign = "center";
-
-    for (var k = 0; k <= 5; k++) {
-      var xVal = xMin + (k / 5) * xRange;
-      var xPos = scaleX(xVal);
-      ctx.fillText(xVal.toFixed(1), xPos, height - padding + 15);
-    }
-
-    ctx.textAlign = "right";
-    for (var m = 0; m <= 5; m++) {
-      var yVal = yMin + (m / 5) * yRange;
-      var yPos = scaleY(yVal);
-      ctx.fillText(yVal.toFixed(1), padding - 5, yPos + 4);
-    }
-
-    ctx.fillStyle = "#00f5d4";
-    for (var n = 0; n < xData.length; n++) {
-      var px = scaleX(xData[n]);
-      var py = scaleY(yData[n]);
-      ctx.beginPath();
-      ctx.arc(px, py, 5, 0, Math.PI * 2);
-      ctx.fill();
-    }
-
-    if (xData.length >= 2) {
-      var xMean =
-        xData.reduce(function (a, b) {
-          return a + b;
-        }, 0) / xData.length;
-      var yMeanVal =
-        yData.reduce(function (a, b) {
-          return a + b;
-        }, 0) / yData.length;
-
-      var num = 0,
-        den = 0;
-      for (var p = 0; p < xData.length; p++) {
-        num += (xData[p] - xMean) * (yData[p] - yMeanVal);
-        den += (xData[p] - xMean) * (xData[p] - xMean);
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        if (window.lastData) {
+          drawScatterPlot(window.lastData.x, window.lastData.y, window.lastData.r);
+        }
       }
-      var slope = den !== 0 ? num / den : 0;
-      var intercept = yMeanVal - slope * xMean;
 
-      var y1 = slope * xMin + intercept;
-      var y2 = slope * xMax + intercept;
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
 
-      ctx.strokeStyle = "#f72585";
-      ctx.lineWidth = 2;
-      ctx.setLineDash([5, 5]);
-      ctx.beginPath();
-      ctx.moveTo(scaleX(xMin), scaleY(y1));
-      ctx.lineTo(scaleX(xMax), scaleY(y2));
-      ctx.stroke();
-      ctx.setLineDash([]);
-    }
+      function parseValues(text) {
+        return text
+          .trim()
+          .split("\n")
+          .map(function (line) {
+            return line.trim();
+          })
+          .filter(function (line) {
+            return line !== "";
+          })
+          .map(function (line) {
+            return parseFloat(line);
+          })
+          .filter(function (num) {
+            return !isNaN(num);
+          });
+      }
 
-    window.lastData = { x: xData, y: yData, r: r };
-  }
+      function calculatePearson(x, y) {
+        const n = x.length;
+        if (n !== y.length || n < 2) return null;
 
-  function analyze() {
-    var xText = document.getElementById("xValues").value;
-    var yText = document.getElementById("yValues").value;
+        const sumX = x.reduce(function (a, b) {
+          return a + b;
+        }, 0);
+        const sumY = y.reduce(function (a, b) {
+          return a + b;
+        }, 0);
+        const sumXY = x.reduce(function (total, xi, i) {
+          return total + xi * y[i];
+        }, 0);
+        const sumX2 = x.reduce(function (total, xi) {
+          return total + xi * xi;
+        }, 0);
+        const sumY2 = y.reduce(function (total, yi) {
+          return total + yi * yi;
+        }, 0);
 
-    var xData = parseValues(xText);
-    var yData = parseValues(yText);
+        const numerator = n * sumXY - sumX * sumY;
+        const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
 
-    if (xData.length < 2 || yData.length < 2) {
-      showToast("请至少输入 2 个数据点", "error");
-      return;
-    }
+        if (denominator === 0) return 0;
+        return numerator / denominator;
+      }
 
-    if (xData.length !== yData.length) {
-      showToast("X 和 Y 的数据点数量不一致", "error");
-      return;
-    }
+      function getInterpretation(r) {
+        const absR = Math.abs(r);
+        if (absR >= 0.8) {
+          return {
+            text: r > 0 ? "强正相关" : "强负相关",
+            class: r > 0 ? "strong-positive" : "strong-negative"
+          };
+        } else if (absR >= 0.5) {
+          return {
+            text: r > 0 ? "中等正相关" : "中等负相关",
+            class: r > 0 ? "moderate-positive" : "moderate-negative"
+          };
+        } else if (absR >= 0.3) {
+          return {
+            text: r > 0 ? "弱正相关" : "弱负相关",
+            class: "weak"
+          };
+        } else {
+          return {
+            text: "无明显相关性",
+            class: "weak"
+          };
+        }
+      }
 
-    var r = calculatePearson(xData, yData);
-    var r2 = r * r;
-    var xMean =
-      xData.reduce(function (a, b) {
-        return a + b;
-      }, 0) / xData.length;
-    var yMean =
-      yData.reduce(function (a, b) {
-        return a + b;
-      }, 0) / yData.length;
+      function drawScatterPlot(xData, yData, r) {
+        const canvas = document.getElementById("scatterCanvas");
+        const ctx = canvas.getContext("2d");
+        const isLight = document.body.getAttribute("data-theme") === "light";
 
-    var interp = getInterpretation(r);
+        const dpr = window.devicePixelRatio || 1;
+        const rect = canvas.getBoundingClientRect();
+        canvas.width = rect.width * dpr;
+        canvas.height = rect.height * dpr;
+        ctx.scale(dpr, dpr);
 
-    document.getElementById("rValue").textContent = r.toFixed(4);
-    document.getElementById("rValue").style.color = r >= 0 ? "#10b981" : "#f43f5e";
+        const width = rect.width;
+        const height = rect.height;
+        const padding = 40;
 
-    var interpEl = document.getElementById("interpretation");
-    interpEl.textContent = interp.text;
-    interpEl.className = "interpretation " + interp.class;
-    interpEl.style.display = "block";
+        ctx.fillStyle = isLight ? "#fff" : "#12121a";
+        ctx.fillRect(0, 0, width, height);
 
-    document.getElementById("r2Value").textContent = r2.toFixed(4);
-    document.getElementById("nValue").textContent = xData.length;
-    document.getElementById("xMean").textContent = xMean.toFixed(2);
-    document.getElementById("yMean").textContent = yMean.toFixed(2);
+        const xMin = Math.min.apply(null, xData);
+        const xMax = Math.max.apply(null, xData);
+        const yMin = Math.min.apply(null, yData);
+        const yMax = Math.max.apply(null, yData);
 
-    drawScatterPlot(xData, yData, r);
-    saveToStorage();
-    showToast("分析完成");
-  }
+        const xRange = xMax - xMin || 1;
+        const yRange = yMax - yMin || 1;
 
-  function copyResults() {
-    var r = document.getElementById("rValue").textContent;
-    var r2 = document.getElementById("r2Value").textContent;
-    var n = document.getElementById("nValue").textContent;
-    var interp = document.getElementById("interpretation").textContent;
+        function scaleX(x) {
+          return padding + ((x - xMin) / xRange) * (width - 2 * padding);
+        }
+        function scaleY(y) {
+          return height - padding - ((y - yMin) / yRange) * (height - 2 * padding);
+        }
 
-    if (r === "--") {
-      showToast("请先进行分析", "error");
-      return;
-    }
+        ctx.strokeStyle = isLight ? "#e5e5e5" : "#2a2a3a";
+        ctx.lineWidth = 1;
 
-    var text = "相关性分析结果\n";
-    text += "================\n";
-    text += "皮尔逊相关系数 (r): " + r + "\n";
-    text += "决定系数 (R²): " + r2 + "\n";
-    text += "数据点数: " + n + "\n";
-    text += "解释: " + interp + "\n";
+        for (var i = 0; i <= 5; i++) {
+          var y = padding + (i / 5) * (height - 2 * padding);
+          ctx.beginPath();
+          ctx.moveTo(padding, y);
+          ctx.lineTo(width - padding, y);
+          ctx.stroke();
+        }
 
-    navigator.clipboard
-      .writeText(text)
-      .then(function () {
-        showToast("结果已复制");
-      })
-      .catch(function () {
-        showToast("复制失败", "error");
+        for (var j = 0; j <= 5; j++) {
+          var x = padding + (j / 5) * (width - 2 * padding);
+          ctx.beginPath();
+          ctx.moveTo(x, padding);
+          ctx.lineTo(x, height - padding);
+          ctx.stroke();
+        }
+
+        ctx.fillStyle = isLight ? "#666" : "#8888a0";
+        ctx.font = "11px JetBrains Mono";
+        ctx.textAlign = "center";
+
+        for (var k = 0; k <= 5; k++) {
+          var xVal = xMin + (k / 5) * xRange;
+          var xPos = scaleX(xVal);
+          ctx.fillText(xVal.toFixed(1), xPos, height - padding + 15);
+        }
+
+        ctx.textAlign = "right";
+        for (var m = 0; m <= 5; m++) {
+          var yVal = yMin + (m / 5) * yRange;
+          var yPos = scaleY(yVal);
+          ctx.fillText(yVal.toFixed(1), padding - 5, yPos + 4);
+        }
+
+        ctx.fillStyle = "#00f5d4";
+        for (var n = 0; n < xData.length; n++) {
+          var px = scaleX(xData[n]);
+          var py = scaleY(yData[n]);
+          ctx.beginPath();
+          ctx.arc(px, py, 5, 0, Math.PI * 2);
+          ctx.fill();
+        }
+
+        if (xData.length >= 2) {
+          var xMean =
+            xData.reduce(function (a, b) {
+              return a + b;
+            }, 0) / xData.length;
+          var yMeanVal =
+            yData.reduce(function (a, b) {
+              return a + b;
+            }, 0) / yData.length;
+
+          var num = 0,
+            den = 0;
+          for (var p = 0; p < xData.length; p++) {
+            num += (xData[p] - xMean) * (yData[p] - yMeanVal);
+            den += (xData[p] - xMean) * (xData[p] - xMean);
+          }
+          var slope = den !== 0 ? num / den : 0;
+          var intercept = yMeanVal - slope * xMean;
+
+          var y1 = slope * xMin + intercept;
+          var y2 = slope * xMax + intercept;
+
+          ctx.strokeStyle = "#f72585";
+          ctx.lineWidth = 2;
+          ctx.setLineDash([5, 5]);
+          ctx.beginPath();
+          ctx.moveTo(scaleX(xMin), scaleY(y1));
+          ctx.lineTo(scaleX(xMax), scaleY(y2));
+          ctx.stroke();
+          ctx.setLineDash([]);
+        }
+
+        window.lastData = { x: xData, y: yData, r: r };
+      }
+
+      function analyze() {
+        var xText = document.getElementById("xValues").value;
+        var yText = document.getElementById("yValues").value;
+
+        var xData = parseValues(xText);
+        var yData = parseValues(yText);
+
+        if (xData.length < 2 || yData.length < 2) {
+          showToast("请至少输入 2 个数据点", "error");
+          return;
+        }
+
+        if (xData.length !== yData.length) {
+          showToast("X 和 Y 的数据点数量不一致", "error");
+          return;
+        }
+
+        var r = calculatePearson(xData, yData);
+        var r2 = r * r;
+        var xMean =
+          xData.reduce(function (a, b) {
+            return a + b;
+          }, 0) / xData.length;
+        var yMean =
+          yData.reduce(function (a, b) {
+            return a + b;
+          }, 0) / yData.length;
+
+        var interp = getInterpretation(r);
+
+        document.getElementById("rValue").textContent = r.toFixed(4);
+        document.getElementById("rValue").style.color = r >= 0 ? "#10b981" : "#f43f5e";
+
+        var interpEl = document.getElementById("interpretation");
+        interpEl.textContent = interp.text;
+        interpEl.className = "interpretation " + interp.class;
+        interpEl.style.display = "block";
+
+        document.getElementById("r2Value").textContent = r2.toFixed(4);
+        document.getElementById("nValue").textContent = xData.length;
+        document.getElementById("xMean").textContent = xMean.toFixed(2);
+        document.getElementById("yMean").textContent = yMean.toFixed(2);
+
+        drawScatterPlot(xData, yData, r);
+        saveToStorage();
+        showToast("分析完成");
+      }
+
+      function copyResults() {
+        var r = document.getElementById("rValue").textContent;
+        var r2 = document.getElementById("r2Value").textContent;
+        var n = document.getElementById("nValue").textContent;
+        var interp = document.getElementById("interpretation").textContent;
+
+        if (r === "--") {
+          showToast("请先进行分析", "error");
+          return;
+        }
+
+        var text = "相关性分析结果\n";
+        text += "================\n";
+        text += "皮尔逊相关系数 (r): " + r + "\n";
+        text += "决定系数 (R²): " + r2 + "\n";
+        text += "数据点数: " + n + "\n";
+        text += "解释: " + interp + "\n";
+
+        navigator.clipboard
+          .writeText(text)
+          .then(function () {
+            showToast("结果已复制");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      function shareAnalysis() {
+        var data = {
+          x: document.getElementById("xValues").value,
+          y: document.getElementById("yValues").value
+        };
+
+        var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+        var url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(function () {
+            showToast("分享链接已复制");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      function loadSample() {
+        document.getElementById("xValues").value = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10";
+        document.getElementById("yValues").value =
+          "2.1\n4.2\n5.8\n8.1\n10.3\n11.9\n14.2\n16.0\n18.1\n20.2";
+        analyze();
+      }
+
+      function clearAll() {
+        document.getElementById("xValues").value = "";
+        document.getElementById("yValues").value = "";
+        document.getElementById("rValue").textContent = "--";
+        document.getElementById("rValue").style.color = "";
+        document.getElementById("r2Value").textContent = "--";
+        document.getElementById("nValue").textContent = "--";
+        document.getElementById("xMean").textContent = "--";
+        document.getElementById("yMean").textContent = "--";
+        document.getElementById("interpretation").style.display = "none";
+
+        var canvas = document.getElementById("scatterCanvas");
+        var ctx = canvas.getContext("2d");
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+        showToast("已清空");
+      }
+
+      function saveToStorage() {
+        var data = {
+          x: document.getElementById("xValues").value,
+          y: document.getElementById("yValues").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      function loadFromStorage() {
+        if (window.location.hash) return;
+
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+          if (data.x) document.getElementById("xValues").value = data.x;
+          if (data.y) document.getElementById("yValues").value = data.y;
+        } catch (e) {
+          // ignore
+        }
+      }
+
+      function loadFromUrl() {
+        var hash = window.location.hash.slice(1);
+        if (!hash) return;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          if (data.x) document.getElementById("xValues").value = data.x;
+          if (data.y) document.getElementById("yValues").value = data.y;
+          setTimeout(analyze, 100);
+        } catch (e) {
+          // ignore
+        }
+      }
+
+      function showToast(msg, type) {
+        type = type || "success";
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      document.addEventListener("DOMContentLoaded", function () {
+        loadFromStorage();
+        loadFromUrl();
+
+        document.querySelectorAll("textarea").forEach(function (el) {
+          el.addEventListener("input", saveToStorage);
+        });
       });
-  }
+    </script>
 
-  function shareAnalysis() {
-    var data = {
-      x: document.getElementById("xValues").value,
-      y: document.getElementById("yValues").value
-    };
-
-    var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-    var url = window.location.href.split("#")[0] + "#" + encoded;
-
-    navigator.clipboard
-      .writeText(url)
-      .then(function () {
-        showToast("分享链接已复制");
-      })
-      .catch(function () {
-        showToast("复制失败", "error");
-      });
-  }
-
-  function loadSample() {
-    document.getElementById("xValues").value = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10";
-    document.getElementById("yValues").value =
-      "2.1\n4.2\n5.8\n8.1\n10.3\n11.9\n14.2\n16.0\n18.1\n20.2";
-    analyze();
-  }
-
-  function clearAll() {
-    document.getElementById("xValues").value = "";
-    document.getElementById("yValues").value = "";
-    document.getElementById("rValue").textContent = "--";
-    document.getElementById("rValue").style.color = "";
-    document.getElementById("r2Value").textContent = "--";
-    document.getElementById("nValue").textContent = "--";
-    document.getElementById("xMean").textContent = "--";
-    document.getElementById("yMean").textContent = "--";
-    document.getElementById("interpretation").style.display = "none";
-
-    var canvas = document.getElementById("scatterCanvas");
-    var ctx = canvas.getContext("2d");
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    localStorage.removeItem(LS_KEY);
-    window.location.hash = "";
-    showToast("已清空");
-  }
-
-  function saveToStorage() {
-    var data = {
-      x: document.getElementById("xValues").value,
-      y: document.getElementById("yValues").value
-    };
-    localStorage.setItem(LS_KEY, JSON.stringify(data));
-  }
-
-  function loadFromStorage() {
-    if (window.location.hash) return;
-
-    var saved = localStorage.getItem(LS_KEY);
-    if (!saved) return;
-
-    try {
-      var data = JSON.parse(saved);
-      if (data.x) document.getElementById("xValues").value = data.x;
-      if (data.y) document.getElementById("yValues").value = data.y;
-    } catch (e) {
-      // ignore
-    }
-  }
-
-  function loadFromUrl() {
-    var hash = window.location.hash.slice(1);
-    if (!hash) return;
-
-    try {
-      var data = JSON.parse(decodeURIComponent(atob(hash)));
-      if (data.x) document.getElementById("xValues").value = data.x;
-      if (data.y) document.getElementById("yValues").value = data.y;
-      setTimeout(analyze, 100);
-    } catch (e) {
-      // ignore
-    }
-  }
-
-  function showToast(msg, type) {
-    type = type || "success";
-    var toast = document.getElementById("toast");
-    toast.textContent = msg;
-    toast.className = "toast" + (type === "error" ? " error" : "");
-    toast.classList.add("show");
-    setTimeout(function () {
-      toast.classList.remove("show");
-    }, 2000);
-  }
-
-  document.addEventListener("DOMContentLoaded", function () {
-    loadFromStorage();
-    loadFromUrl();
-
-    document.querySelectorAll("textarea").forEach(function (el) {
-      el.addEventListener("input", saveToStorage);
-    });
-  });
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/csv-viewer.html
+++ b/tools/data/csv-viewer.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Csv Viewer - WebUtils" />
-    <meta property="og:description" content="Csv Viewer，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Csv Viewer，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/csv-viewer.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Csv Viewer - WebUtils" />
-    <meta name="twitter:description" content="Csv Viewer，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Csv Viewer，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Csv Viewer",
-      "item": "https://tools.realtime-ai.chat/tools/data/csv-viewer.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Csv Viewer",
+            "item": "https://tools.realtime-ai.chat/tools/data/csv-viewer.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Csv Viewer - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Csv Viewer - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,647 +94,653 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--text-muted);
-    user-select: none;
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+      }
 
-  .panel {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    margin-bottom: 24px;
-  }
-  .panel-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--text-muted);
+        user-select: none;
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  textarea {
-    width: 100%;
-    min-height: 150px;
-    padding: 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    resize: vertical;
-  }
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      .panel {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        margin-bottom: 24px;
+      }
+      .panel-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    overflow-x: auto;
-    display: block;
-  }
-  thead {
-    background: var(--bg-input);
-    position: sticky;
-    top: 0;
-  }
-  th,
-  td {
-    padding: 12px;
-    text-align: left;
-    border: 1px solid var(--border-subtle);
-  }
-  th {
-    color: var(--color-text-secondary);
-    font-weight: 600;
-  }
-  td {
-    color: var(--color-text-primary);
-  }
-  tbody tr:hover {
-    background: var(--color-bg-surface);
-  }
+      textarea {
+        width: 100%;
+        min-height: 150px;
+        padding: 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        resize: vertical;
+      }
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(0, 245, 212, 0.3);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        overflow-x: auto;
+        display: block;
+      }
+      thead {
+        background: var(--bg-input);
+        position: sticky;
+        top: 0;
+      }
+      th,
+      td {
+        padding: 12px;
+        text-align: left;
+        border: 1px solid var(--border-subtle);
+      }
+      th {
+        color: var(--color-text-secondary);
+        font-weight: 600;
+      }
+      td {
+        color: var(--color-text-primary);
+      }
+      tbody tr:hover {
+        background: var(--color-bg-surface);
+      }
 
-  .stats {
-    display: flex;
-    gap: 16px;
-    margin-top: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-  .stat-item {
-    padding: 8px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .stat-label {
-    color: var(--color-text-secondary);
-  }
-  .stat-value {
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-    margin-left: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px rgba(0, 245, 212, 0.3);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: #fff;
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-</style>
+      .stats {
+        display: flex;
+        gap: 16px;
+        margin-top: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+      .stat-item {
+        padding: 8px 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .stat-label {
+        color: var(--color-text-secondary);
+      }
+      .stat-value {
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+        margin-left: 8px;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: #fff;
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">CSV 查看器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        CSV 查看器
-      </h1>
-      <p>在线 CSV 文件查看和编辑工具</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">CSV 查看器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              CSV 查看器
+            </h1>
+            <p>在线 CSV 文件查看和编辑工具</p>
+          </div>
+        </header>
 
-  <main>
-    <div class="panel">
-      <div class="panel-title">输入 CSV 数据</div>
-      <textarea id="csvInput" placeholder="粘贴 CSV 数据或手动输入，例如：
+        <main>
+          <div class="panel">
+            <div class="panel-title">输入 CSV 数据</div>
+            <textarea
+              id="csvInput"
+              placeholder="粘贴 CSV 数据或手动输入，例如：
 姓名,年龄,城市
 张三,25,北京
-李四,30,上海"></textarea>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-primary" onclick="parseCSV()">📊 解析 CSV</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        <button class="btn btn-secondary" onclick="downloadCSV()">📥 下载 CSV</button>
-      </div>
-      <div class="stats" id="stats" style="display: none">
-        <div class="stat-item">
-          <span class="stat-label">行数:</span>
-          <span class="stat-value" id="rowCount">0</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">列数:</span>
-          <span class="stat-value" id="colCount">0</span>
-        </div>
+李四,30,上海"
+            ></textarea>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-primary" onclick="parseCSV()">📊 解析 CSV</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+              <button class="btn btn-secondary" onclick="downloadCSV()">📥 下载 CSV</button>
+            </div>
+            <div class="stats" id="stats" style="display: none">
+              <div class="stat-item">
+                <span class="stat-label">行数:</span>
+                <span class="stat-value" id="rowCount">0</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-label">列数:</span>
+                <span class="stat-value" id="colCount">0</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel-title">数据表格</div>
+            <div id="tableContainer" style="max-height: 500px; overflow: auto"></div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="panel">
-      <div class="panel-title">数据表格</div>
-      <div id="tableContainer" style="max-height: 500px; overflow: auto"></div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "CSV 查看器",
-              "item": "https://tools.realtime-ai.chat/tools/data/csv-viewer.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "CSV 查看器",
+            "item": "https://tools.realtime-ai.chat/tools/data/csv-viewer.html"
+          }
+        ]
+      }
     </script>
     <script>
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") document.body.setAttribute("data-theme", "light");
+      })();
 
-  function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      function parseCSV() {
+        const input = document.getElementById("csvInput").value.trim();
+        if (!input) {
+          showToast("请输入 CSV 数据");
+          return;
         }
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") document.body.setAttribute("data-theme", "light");
-        })();
 
-        function parseCSV() {
-          const input = document.getElementById("csvInput").value.trim();
-          if (!input) {
-            showToast("请输入 CSV 数据");
-            return;
-          }
+        const lines = input.split("\n").filter((line) => line.trim());
+        if (lines.length === 0) {
+          showToast("没有有效数据");
+          return;
+        }
 
-          const lines = input.split("\n").filter((line) => line.trim());
-          if (lines.length === 0) {
-            showToast("没有有效数据");
-            return;
-          }
+        const rows = lines.map((line) => line.split(",").map((cell) => cell.trim()));
+        const headers = rows[0];
+        const data = rows.slice(1);
 
-          const rows = lines.map((line) => line.split(",").map((cell) => cell.trim()));
-          const headers = rows[0];
-          const data = rows.slice(1);
+        // 使用 DOM API 防止 XSS
+        const container = document.getElementById("tableContainer");
+        container.textContent = "";
+        const table = document.createElement("table");
+        const thead = document.createElement("thead");
+        const headerRow = document.createElement("tr");
+        headers.forEach((h) => {
+          const th = document.createElement("th");
+          th.textContent = h;
+          headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
 
-          // 使用 DOM API 防止 XSS
-          const container = document.getElementById("tableContainer");
-          container.textContent = "";
-          const table = document.createElement("table");
-          const thead = document.createElement("thead");
-          const headerRow = document.createElement("tr");
-          headers.forEach((h) => {
-            const th = document.createElement("th");
-            th.textContent = h;
-            headerRow.appendChild(th);
+        const tbody = document.createElement("tbody");
+        data.forEach((row) => {
+          const tr = document.createElement("tr");
+          row.forEach((cell) => {
+            const td = document.createElement("td");
+            td.textContent = cell;
+            tr.appendChild(td);
           });
-          thead.appendChild(headerRow);
-          table.appendChild(thead);
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        container.appendChild(table);
 
-          const tbody = document.createElement("tbody");
-          data.forEach((row) => {
-            const tr = document.createElement("tr");
-            row.forEach((cell) => {
-              const td = document.createElement("td");
-              td.textContent = cell;
-              tr.appendChild(td);
-            });
-            tbody.appendChild(tr);
-          });
-          table.appendChild(tbody);
-          container.appendChild(table);
+        document.getElementById("stats").style.display = "flex";
+        document.getElementById("rowCount").textContent = data.length;
+        document.getElementById("colCount").textContent = headers.length;
+        showToast("解析成功");
+      }
 
-          document.getElementById("stats").style.display = "flex";
-          document.getElementById("rowCount").textContent = data.length;
-          document.getElementById("colCount").textContent = headers.length;
-          showToast("解析成功");
+      function clearAll() {
+        document.getElementById("csvInput").value = "";
+        document.getElementById("tableContainer").textContent = "";
+        document.getElementById("stats").style.display = "none";
+        showToast("已清空");
+      }
+
+      function downloadCSV() {
+        const input = document.getElementById("csvInput").value;
+        if (!input) {
+          showToast("没有数据可下载");
+          return;
         }
+        const blob = new Blob([input], { type: "text/csv" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "data.csv";
+        a.click();
+        URL.revokeObjectURL(url);
+        showToast("下载成功");
+      }
 
-        function clearAll() {
-          document.getElementById("csvInput").value = "";
-          document.getElementById("tableContainer").textContent = "";
-          document.getElementById("stats").style.display = "none";
-          showToast("已清空");
-        }
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+    </script>
 
-        function downloadCSV() {
-          const input = document.getElementById("csvInput").value;
-          if (!input) {
-            showToast("没有数据可下载");
-            return;
-          }
-          const blob = new Blob([input], { type: "text/csv" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "data.csv";
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast("下载成功");
-        }
-
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/data-exporter.html
+++ b/tools/data/data-exporter.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Data Exporter - WebUtils" />
-    <meta property="og:description" content="Data Exporter，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Data Exporter，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/data-exporter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/data-exporter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Data Exporter - WebUtils" />
-    <meta name="twitter:description" content="Data Exporter，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Data Exporter，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Data Exporter",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-exporter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Data Exporter",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-exporter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Data Exporter - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Data Exporter - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,742 +97,767 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .input-group {
-    margin-bottom: 16px;
-  }
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
-  textarea,
-  select {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-  textarea {
-    min-height: 250px;
-    resize: vertical;
-  }
-  textarea:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  .format-tabs {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
-  .format-tab {
-    padding: 8px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .format-tab:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .format-tab.active {
-    background: var(--color-accent-cyan);
-    border-color: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .btn-success {
-    background: var(--accent-green);
-    color: white;
-  }
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(16, 185, 129, 0.3);
-  }
-  .format-badge {
-    display: inline-block;
-    padding: 4px 8px;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-    border-radius: var(--radius-sm);
-    margin-left: 8px;
-  }
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .btn {
-      width: 100%;
-    }
-    .format-tabs {
-      flex-direction: column;
-    }
-    .format-tab {
-      text-align: center;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .input-group {
+        margin-bottom: 16px;
+      }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
+      textarea,
+      select {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+      textarea {
+        min-height: 250px;
+        resize: vertical;
+      }
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      .format-tabs {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
+      .format-tab {
+        padding: 8px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .format-tab:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .format-tab.active {
+        background: var(--color-accent-cyan);
+        border-color: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .btn-success {
+        background: var(--accent-green);
+        color: white;
+      }
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px rgba(16, 185, 129, 0.3);
+      }
+      .format-badge {
+        display: inline-block;
+        padding: 4px 8px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+        border-radius: var(--radius-sm);
+        margin-left: 8px;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .btn {
+          width: 100%;
+        }
+        .format-tabs {
+          flex-direction: column;
+        }
+        .format-tab {
+          text-align: center;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据导出</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📤</span>
-        数据导出
-      </h1>
-      <p>将数据导出为多种格式</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据导出</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📤</span>
+              数据导出
+            </h1>
+            <p>将数据导出为多种格式</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <div class="input-panel">
-        <div class="section-title">数据输入</div>
-        <div class="input-group">
-          <label class="input-label">输入格式</label>
-          <select id="inputFormat" onchange="detectFormat()">
-            <option value="auto">自动检测</option>
-            <option value="json">JSON</option>
-            <option value="csv">CSV</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">输入数据</label>
-          <textarea id="inputData" placeholder="JSON 示例：
+        <main class="main-content">
+          <div class="tool-layout">
+            <div class="input-panel">
+              <div class="section-title">数据输入</div>
+              <div class="input-group">
+                <label class="input-label">输入格式</label>
+                <select id="inputFormat" onchange="detectFormat()">
+                  <option value="auto">自动检测</option>
+                  <option value="json">JSON</option>
+                  <option value="csv">CSV</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">输入数据</label>
+                <textarea
+                  id="inputData"
+                  placeholder='JSON 示例：
 [
-  {&quot;name&quot;: &quot;Alice&quot;, &quot;age&quot;: 30, &quot;city&quot;: &quot;Beijing&quot;},
-  {&quot;name&quot;: &quot;Bob&quot;, &quot;age&quot;: 25, &quot;city&quot;: &quot;Shanghai&quot;}
+  {"name": "Alice", "age": 30, "city": "Beijing"},
+  {"name": "Bob", "age": 25, "city": "Shanghai"}
 ]
 
 CSV 示例：
 name,age,city
 Alice,30,Beijing
-Bob,25,Shanghai"></textarea>
-          <div class="input-hint" id="formatHint">自动检测输入格式</div>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="convert()">🔄 转换</button>
-          <button class="btn btn-secondary" onclick="loadSampleJSON()">📝 JSON示例</button>
-          <button class="btn btn-secondary" onclick="loadSampleCSV()">📝 CSV示例</button>
-          <button class="btn btn-secondary" onclick="clearAll()">✕ 清空</button>
-        </div>
-      </div>
+Bob,25,Shanghai'
+                ></textarea>
+                <div class="input-hint" id="formatHint">自动检测输入格式</div>
+              </div>
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="convert()">🔄 转换</button>
+                <button class="btn btn-secondary" onclick="loadSampleJSON()">📝 JSON示例</button>
+                <button class="btn btn-secondary" onclick="loadSampleCSV()">📝 CSV示例</button>
+                <button class="btn btn-secondary" onclick="clearAll()">✕ 清空</button>
+              </div>
+            </div>
 
-      <div class="output-panel">
-        <div class="section-title">
-          导出格式
-          <span class="format-badge" id="currentFormat">CSV</span>
-        </div>
-        <div class="format-tabs">
-          <button class="format-tab active" data-format="csv" onclick="selectFormat('csv')">
-            CSV
-          </button>
-          <button class="format-tab" data-format="tsv" onclick="selectFormat('tsv')">TSV</button>
-          <button class="format-tab" data-format="json" onclick="selectFormat('json')">JSON</button>
-          <button class="format-tab" data-format="html" onclick="selectFormat('html')">HTML</button>
-          <button class="format-tab" data-format="markdown" onclick="selectFormat('markdown')">
-            Markdown
-          </button>
-        </div>
-        <div class="input-group">
-          <label class="input-label">输出结果</label>
-          <textarea id="outputData" readonly="" placeholder="转换后的数据将显示在这里"></textarea>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-secondary" onclick="copyOutput()">📋 复制</button>
-          <button class="btn btn-success" onclick="downloadOutput()">📥 下载</button>
-        </div>
+            <div class="output-panel">
+              <div class="section-title">
+                导出格式
+                <span class="format-badge" id="currentFormat">CSV</span>
+              </div>
+              <div class="format-tabs">
+                <button class="format-tab active" data-format="csv" onclick="selectFormat('csv')">
+                  CSV
+                </button>
+                <button class="format-tab" data-format="tsv" onclick="selectFormat('tsv')">
+                  TSV
+                </button>
+                <button class="format-tab" data-format="json" onclick="selectFormat('json')">
+                  JSON
+                </button>
+                <button class="format-tab" data-format="html" onclick="selectFormat('html')">
+                  HTML
+                </button>
+                <button
+                  class="format-tab"
+                  data-format="markdown"
+                  onclick="selectFormat('markdown')"
+                >
+                  Markdown
+                </button>
+              </div>
+              <div class="input-group">
+                <label class="input-label">输出结果</label>
+                <textarea
+                  id="outputData"
+                  readonly=""
+                  placeholder="转换后的数据将显示在这里"
+                ></textarea>
+              </div>
+              <div class="btn-row">
+                <button class="btn btn-secondary" onclick="copyOutput()">📋 复制</button>
+                <button class="btn btn-success" onclick="downloadOutput()">📥 下载</button>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script>
-  var LS_KEY = "data-exporter-data";
-  var currentOutputFormat = "csv";
-  var parsedData = null;
+      var LS_KEY = "data-exporter-data";
+      var currentOutputFormat = "csv";
+      var parsedData = null;
 
-  function toggleTheme() {
-    var body = document.body;
-    var isDark = body.getAttribute("data-theme") !== "light";
-    body.setAttribute("data-theme", isDark ? "light" : "dark");
-    localStorage.setItem("theme", isDark ? "light" : "dark");
-  }
-
-  (function () {
-    var saved = localStorage.getItem("theme");
-    if (saved === "light") {
-      document.body.setAttribute("data-theme", "light");
-    }
-  })();
-
-  function detectFormat() {
-    var format = document.getElementById("inputFormat").value;
-    var hint = document.getElementById("formatHint");
-    if (format === "auto") {
-      hint.textContent = "自动检测输入格式";
-    } else if (format === "json") {
-      hint.textContent = "输入 JSON 数组格式数据";
-    } else {
-      hint.textContent = "输入 CSV 格式数据（第一行为表头）";
-    }
-  }
-
-  function parseInput(text) {
-    var format = document.getElementById("inputFormat").value;
-    text = text.trim();
-
-    if (!text) return null;
-
-    if (format === "auto") {
-      if (text.charAt(0) === "[" || text.charAt(0) === "{") {
-        format = "json";
-      } else {
-        format = "csv";
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
       }
-    }
 
-    if (format === "json") {
-      try {
-        var data = JSON.parse(text);
-        if (!Array.isArray(data)) {
-          data = [data];
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
-        return data;
-      } catch (e) {
-        showToast("JSON 解析失败: " + e.message, "error");
-        return null;
+      })();
+
+      function detectFormat() {
+        var format = document.getElementById("inputFormat").value;
+        var hint = document.getElementById("formatHint");
+        if (format === "auto") {
+          hint.textContent = "自动检测输入格式";
+        } else if (format === "json") {
+          hint.textContent = "输入 JSON 数组格式数据";
+        } else {
+          hint.textContent = "输入 CSV 格式数据（第一行为表头）";
+        }
       }
-    } else {
-      var lines = text.split("\n").filter(function (l) {
-        return l.trim();
-      });
-      if (lines.length < 1) return null;
 
-      var headers = lines[0].split(",").map(function (h) {
-        return h.trim();
-      });
-      var rows = [];
+      function parseInput(text) {
+        var format = document.getElementById("inputFormat").value;
+        text = text.trim();
 
-      for (var i = 1; i < lines.length; i++) {
-        var values = lines[i].split(",").map(function (v) {
-          return v.trim();
+        if (!text) return null;
+
+        if (format === "auto") {
+          if (text.charAt(0) === "[" || text.charAt(0) === "{") {
+            format = "json";
+          } else {
+            format = "csv";
+          }
+        }
+
+        if (format === "json") {
+          try {
+            var data = JSON.parse(text);
+            if (!Array.isArray(data)) {
+              data = [data];
+            }
+            return data;
+          } catch (e) {
+            showToast("JSON 解析失败: " + e.message, "error");
+            return null;
+          }
+        } else {
+          var lines = text.split("\n").filter(function (l) {
+            return l.trim();
+          });
+          if (lines.length < 1) return null;
+
+          var headers = lines[0].split(",").map(function (h) {
+            return h.trim();
+          });
+          var rows = [];
+
+          for (var i = 1; i < lines.length; i++) {
+            var values = lines[i].split(",").map(function (v) {
+              return v.trim();
+            });
+            var row = {};
+            for (var j = 0; j < headers.length; j++) {
+              row[headers[j]] = values[j] || "";
+            }
+            rows.push(row);
+          }
+
+          return rows;
+        }
+      }
+
+      function selectFormat(format) {
+        currentOutputFormat = format;
+
+        document.querySelectorAll(".format-tab").forEach(function (tab) {
+          tab.classList.remove("active");
+          if (tab.getAttribute("data-format") === format) {
+            tab.classList.add("active");
+          }
         });
-        var row = {};
-        for (var j = 0; j < headers.length; j++) {
-          row[headers[j]] = values[j] || "";
+
+        document.getElementById("currentFormat").textContent = format.toUpperCase();
+
+        if (parsedData) {
+          renderOutput();
         }
-        rows.push(row);
       }
 
-      return rows;
-    }
-  }
+      function convert() {
+        var input = document.getElementById("inputData").value;
+        parsedData = parseInput(input);
 
-  function selectFormat(format) {
-    currentOutputFormat = format;
-
-    document.querySelectorAll(".format-tab").forEach(function (tab) {
-      tab.classList.remove("active");
-      if (tab.getAttribute("data-format") === format) {
-        tab.classList.add("active");
-      }
-    });
-
-    document.getElementById("currentFormat").textContent = format.toUpperCase();
-
-    if (parsedData) {
-      renderOutput();
-    }
-  }
-
-  function convert() {
-    var input = document.getElementById("inputData").value;
-    parsedData = parseInput(input);
-
-    if (!parsedData || parsedData.length === 0) {
-      showToast("无法解析输入数据", "error");
-      return;
-    }
-
-    renderOutput();
-    saveToStorage();
-    showToast("转换成功");
-  }
-
-  function renderOutput() {
-    if (!parsedData || parsedData.length === 0) {
-      document.getElementById("outputData").value = "";
-      return;
-    }
-
-    var output = "";
-    var headers = Object.keys(parsedData[0]);
-
-    switch (currentOutputFormat) {
-      case "csv":
-        output = toCSV(parsedData, headers, ",");
-        break;
-      case "tsv":
-        output = toCSV(parsedData, headers, "\t");
-        break;
-      case "json":
-        output = JSON.stringify(parsedData, null, 2);
-        break;
-      case "html":
-        output = toHTML(parsedData, headers);
-        break;
-      case "markdown":
-        output = toMarkdown(parsedData, headers);
-        break;
-    }
-
-    document.getElementById("outputData").value = output;
-  }
-
-  function toCSV(data, headers, delimiter) {
-    var lines = [headers.join(delimiter)];
-    data.forEach(function (row) {
-      var values = headers.map(function (h) {
-        var val = String(row[h] || "");
-        if (val.indexOf(delimiter) !== -1 || val.indexOf('"') !== -1 || val.indexOf("\n") !== -1) {
-          val = '"' + val.replace(/"/g, '""') + '"';
+        if (!parsedData || parsedData.length === 0) {
+          showToast("无法解析输入数据", "error");
+          return;
         }
-        return val;
-      });
-      lines.push(values.join(delimiter));
-    });
-    return lines.join("\n");
-  }
 
-  function toHTML(data, headers) {
-    var lines = ['<table border="1" cellpadding="8" cellspacing="0">'];
-    lines.push("  <thead>");
-    lines.push("    <tr>");
-    headers.forEach(function (h) {
-      lines.push("      <th>" + escapeHtml(h) + "</th>");
-    });
-    lines.push("    </tr>");
-    lines.push("  </thead>");
-    lines.push("  <tbody>");
-    data.forEach(function (row) {
-      lines.push("    <tr>");
-      headers.forEach(function (h) {
-        lines.push("      <td>" + escapeHtml(String(row[h] || "")) + "</td>");
-      });
-      lines.push("    </tr>");
-    });
-    lines.push("  </tbody>");
-    lines.push("</table>");
-    return lines.join("\n");
-  }
+        renderOutput();
+        saveToStorage();
+        showToast("转换成功");
+      }
 
-  function toMarkdown(data, headers) {
-    var lines = [];
-    lines.push("| " + headers.join(" | ") + " |");
-    lines.push(
-      "| " +
-        headers
-          .map(function () {
-            return "---";
+      function renderOutput() {
+        if (!parsedData || parsedData.length === 0) {
+          document.getElementById("outputData").value = "";
+          return;
+        }
+
+        var output = "";
+        var headers = Object.keys(parsedData[0]);
+
+        switch (currentOutputFormat) {
+          case "csv":
+            output = toCSV(parsedData, headers, ",");
+            break;
+          case "tsv":
+            output = toCSV(parsedData, headers, "\t");
+            break;
+          case "json":
+            output = JSON.stringify(parsedData, null, 2);
+            break;
+          case "html":
+            output = toHTML(parsedData, headers);
+            break;
+          case "markdown":
+            output = toMarkdown(parsedData, headers);
+            break;
+        }
+
+        document.getElementById("outputData").value = output;
+      }
+
+      function toCSV(data, headers, delimiter) {
+        var lines = [headers.join(delimiter)];
+        data.forEach(function (row) {
+          var values = headers.map(function (h) {
+            var val = String(row[h] || "");
+            if (
+              val.indexOf(delimiter) !== -1 ||
+              val.indexOf('"') !== -1 ||
+              val.indexOf("\n") !== -1
+            ) {
+              val = '"' + val.replace(/"/g, '""') + '"';
+            }
+            return val;
+          });
+          lines.push(values.join(delimiter));
+        });
+        return lines.join("\n");
+      }
+
+      function toHTML(data, headers) {
+        var lines = ['<table border="1" cellpadding="8" cellspacing="0">'];
+        lines.push("  <thead>");
+        lines.push("    <tr>");
+        headers.forEach(function (h) {
+          lines.push("      <th>" + escapeHtml(h) + "</th>");
+        });
+        lines.push("    </tr>");
+        lines.push("  </thead>");
+        lines.push("  <tbody>");
+        data.forEach(function (row) {
+          lines.push("    <tr>");
+          headers.forEach(function (h) {
+            lines.push("      <td>" + escapeHtml(String(row[h] || "")) + "</td>");
+          });
+          lines.push("    </tr>");
+        });
+        lines.push("  </tbody>");
+        lines.push("</table>");
+        return lines.join("\n");
+      }
+
+      function toMarkdown(data, headers) {
+        var lines = [];
+        lines.push("| " + headers.join(" | ") + " |");
+        lines.push(
+          "| " +
+            headers
+              .map(function () {
+                return "---";
+              })
+              .join(" | ") +
+            " |"
+        );
+        data.forEach(function (row) {
+          var values = headers.map(function (h) {
+            return String(row[h] || "").replace(/\|/g, "\\|");
+          });
+          lines.push("| " + values.join(" | ") + " |");
+        });
+        return lines.join("\n");
+      }
+
+      function escapeHtml(text) {
+        var div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
+
+      function copyOutput() {
+        var output = document.getElementById("outputData").value;
+        if (!output) {
+          showToast("无内容可复制", "error");
+          return;
+        }
+        navigator.clipboard
+          .writeText(output)
+          .then(function () {
+            showToast("已复制");
           })
-          .join(" | ") +
-        " |"
-    );
-    data.forEach(function (row) {
-      var values = headers.map(function (h) {
-        return String(row[h] || "").replace(/\|/g, "\\|");
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      function downloadOutput() {
+        var output = document.getElementById("outputData").value;
+        if (!output) {
+          showToast("无内容可下载", "error");
+          return;
+        }
+
+        var ext = {
+          csv: "csv",
+          tsv: "tsv",
+          json: "json",
+          html: "html",
+          markdown: "md"
+        }[currentOutputFormat];
+
+        var mime = {
+          csv: "text/csv",
+          tsv: "text/tab-separated-values",
+          json: "application/json",
+          html: "text/html",
+          markdown: "text/markdown"
+        }[currentOutputFormat];
+
+        var blob = new Blob([output], { type: mime + ";charset=utf-8" });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement("a");
+        a.href = url;
+        a.download = "data." + ext;
+        a.click();
+        URL.revokeObjectURL(url);
+
+        showToast("已下载");
+      }
+
+      function loadSampleJSON() {
+        document.getElementById("inputData").value =
+          '[\n  {"name": "Alice", "age": 30, "city": "Beijing"},\n  {"name": "Bob", "age": 25, "city": "Shanghai"},\n  {"name": "Charlie", "age": 35, "city": "Shenzhen"}\n]';
+        document.getElementById("inputFormat").value = "json";
+        detectFormat();
+        convert();
+      }
+
+      function loadSampleCSV() {
+        document.getElementById("inputData").value =
+          "name,age,city\nAlice,30,Beijing\nBob,25,Shanghai\nCharlie,35,Shenzhen";
+        document.getElementById("inputFormat").value = "csv";
+        detectFormat();
+        convert();
+      }
+
+      function clearAll() {
+        document.getElementById("inputData").value = "";
+        document.getElementById("outputData").value = "";
+        document.getElementById("inputFormat").value = "auto";
+        parsedData = null;
+        detectFormat();
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
+
+      function saveToStorage() {
+        var data = {
+          input: document.getElementById("inputData").value,
+          format: document.getElementById("inputFormat").value,
+          outputFormat: currentOutputFormat
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+          if (data.input) document.getElementById("inputData").value = data.input;
+          if (data.format) document.getElementById("inputFormat").value = data.format;
+          if (data.outputFormat) selectFormat(data.outputFormat);
+          detectFormat();
+        } catch (e) {
+          // ignore
+        }
+      }
+
+      function showToast(msg, type) {
+        type = type || "success";
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      document.addEventListener("DOMContentLoaded", function () {
+        loadFromStorage();
+
+        document.getElementById("inputData").addEventListener("input", saveToStorage);
+        document.getElementById("inputFormat").addEventListener("change", saveToStorage);
       });
-      lines.push("| " + values.join(" | ") + " |");
-    });
-    return lines.join("\n");
-  }
+    </script>
 
-  function escapeHtml(text) {
-    var div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
-  function copyOutput() {
-    var output = document.getElementById("outputData").value;
-    if (!output) {
-      showToast("无内容可复制", "error");
-      return;
-    }
-    navigator.clipboard
-      .writeText(output)
-      .then(function () {
-        showToast("已复制");
-      })
-      .catch(function () {
-        showToast("复制失败", "error");
-      });
-  }
-
-  function downloadOutput() {
-    var output = document.getElementById("outputData").value;
-    if (!output) {
-      showToast("无内容可下载", "error");
-      return;
-    }
-
-    var ext = {
-      csv: "csv",
-      tsv: "tsv",
-      json: "json",
-      html: "html",
-      markdown: "md"
-    }[currentOutputFormat];
-
-    var mime = {
-      csv: "text/csv",
-      tsv: "text/tab-separated-values",
-      json: "application/json",
-      html: "text/html",
-      markdown: "text/markdown"
-    }[currentOutputFormat];
-
-    var blob = new Blob([output], { type: mime + ";charset=utf-8" });
-    var url = URL.createObjectURL(blob);
-    var a = document.createElement("a");
-    a.href = url;
-    a.download = "data." + ext;
-    a.click();
-    URL.revokeObjectURL(url);
-
-    showToast("已下载");
-  }
-
-  function loadSampleJSON() {
-    document.getElementById("inputData").value =
-      '[\n  {"name": "Alice", "age": 30, "city": "Beijing"},\n  {"name": "Bob", "age": 25, "city": "Shanghai"},\n  {"name": "Charlie", "age": 35, "city": "Shenzhen"}\n]';
-    document.getElementById("inputFormat").value = "json";
-    detectFormat();
-    convert();
-  }
-
-  function loadSampleCSV() {
-    document.getElementById("inputData").value =
-      "name,age,city\nAlice,30,Beijing\nBob,25,Shanghai\nCharlie,35,Shenzhen";
-    document.getElementById("inputFormat").value = "csv";
-    detectFormat();
-    convert();
-  }
-
-  function clearAll() {
-    document.getElementById("inputData").value = "";
-    document.getElementById("outputData").value = "";
-    document.getElementById("inputFormat").value = "auto";
-    parsedData = null;
-    detectFormat();
-    localStorage.removeItem(LS_KEY);
-    showToast("已清空");
-  }
-
-  function saveToStorage() {
-    var data = {
-      input: document.getElementById("inputData").value,
-      format: document.getElementById("inputFormat").value,
-      outputFormat: currentOutputFormat
-    };
-    localStorage.setItem(LS_KEY, JSON.stringify(data));
-  }
-
-  function loadFromStorage() {
-    var saved = localStorage.getItem(LS_KEY);
-    if (!saved) return;
-
-    try {
-      var data = JSON.parse(saved);
-      if (data.input) document.getElementById("inputData").value = data.input;
-      if (data.format) document.getElementById("inputFormat").value = data.format;
-      if (data.outputFormat) selectFormat(data.outputFormat);
-      detectFormat();
-    } catch (e) {
-      // ignore
-    }
-  }
-
-  function showToast(msg, type) {
-    type = type || "success";
-    var toast = document.getElementById("toast");
-    toast.textContent = msg;
-    toast.className = "toast" + (type === "error" ? " error" : "");
-    toast.classList.add("show");
-    setTimeout(function () {
-      toast.classList.remove("show");
-    }, 2000);
-  }
-
-  document.addEventListener("DOMContentLoaded", function () {
-    loadFromStorage();
-
-    document.getElementById("inputData").addEventListener("input", saveToStorage);
-    document.getElementById("inputFormat").addEventListener("change", saveToStorage);
-  });
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/data-filter.html
+++ b/tools/data/data-filter.html
@@ -6,7 +6,10 @@
     <title>数据筛选器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合" />
+    <meta
+      name="description"
+      content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合"
+    />
     <meta name="keywords" content="data filter 筛选 过滤 CSV regex contains 正则 匹配" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,7 +17,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="数据筛选器 - WebUtils" />
-    <meta property="og:description" content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合" />
+    <meta
+      property="og:description"
+      content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/data-filter.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="数据筛选器 - WebUtils" />
-    <meta name="twitter:description" content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合" />
+    <meta
+      name="twitter:description"
+      content="强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "数据筛选器",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-filter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据筛选器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-filter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "数据筛选器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "数据筛选器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1500 +97,1510 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --bg-hover: #22222e;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #3b82f6;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --glow-red: rgb(244, 63, 94, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f0f0f0;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
-
-  .row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-  }
-
-  .row > * {
-    flex: 1;
-    min-width: 200px;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-danger {
-    background: var(--accent-red);
-    color: #fff;
-  }
-
-  .btn-danger:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-red);
-  }
-
-  .btn-small {
-    flex: 0;
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-  }
-
-  /* Filter conditions */
-  .conditions-container {
-    margin-bottom: 16px;
-  }
-
-  .condition-item {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    padding: 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: 12px;
-    flex-wrap: wrap;
-  }
-
-  .condition-item select,
-  .condition-item input {
-    flex: 1;
-    min-width: 100px;
-  }
-
-  .condition-item .pattern-input {
-    flex: 2;
-    min-width: 200px;
-  }
-
-  .condition-item .column-select {
-    flex: 0.8;
-    min-width: 80px;
-  }
-
-  .remove-condition {
-    background: var(--accent-red);
-    color: #fff;
-    border: none;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    cursor: pointer;
-    font-size: 1.2rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s;
-    flex-shrink: 0;
-  }
-
-  .remove-condition:hover {
-    transform: scale(1.1);
-  }
-
-  .logic-operator {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-
-  .logic-btn {
-    padding: 8px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    border: 2px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .logic-btn.active {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.1);
-  }
-
-  .logic-btn:hover:not(.active) {
-    border-color: var(--color-text-secondary);
-  }
-
-  /* Options row */
-  .options-row {
-    display: flex;
-    gap: 24px;
-    flex-wrap: wrap;
-    margin-bottom: 16px;
-  }
-
-  .option-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .option-item input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--color-accent-cyan);
-    cursor: pointer;
-  }
-
-  .option-item label {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-  }
-
-  /* Statistics */
-  .stats-bar {
-    display: flex;
-    gap: 24px;
-    flex-wrap: wrap;
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: 16px;
-  }
-
-  .stat-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--color-accent-cyan);
-  }
-
-  .stat-value.matched {
-    color: var(--accent-green);
-  }
-
-  .stat-value.unmatched {
-    color: var(--accent-red);
-  }
-
-  .stat-label {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-  }
-
-  /* Result panels */
-  .result-panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
-
-  .result-panel {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .result-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 8px;
-  }
-
-  .result-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .result-title.matched {
-    color: var(--accent-green);
-  }
-
-  .result-title.unmatched {
-    color: var(--accent-red);
-  }
-
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-primary);
-    min-height: 200px;
-    max-height: 400px;
-    overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-
-  .result-box.matched-box {
-    border-color: rgba(16, 185, 129, 0.3);
-  }
-
-  .result-box.unmatched-box {
-    border-color: rgba(244, 63, 94, 0.3);
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  .toast.error {
-    background: var(--accent-red);
-  }
-
-  /* CSV mode indicator */
-  .mode-indicator {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 600;
-    border-radius: var(--radius-sm);
-    margin-left: auto;
-  }
-
-  .mode-indicator.csv-mode {
-    background: rgba(59, 130, 246, 0.2);
-    color: var(--accent-blue);
-    border: 1px solid var(--accent-blue);
-  }
-
-  .mode-indicator.text-mode {
-    background: rgba(168, 85, 247, 0.2);
-    color: var(--color-accent-purple);
-    border: 1px solid var(--color-accent-purple);
-  }
-
-  @media (max-width: 900px) {
-    .result-panels {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .condition-item {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .condition-item select,
-    .condition-item input {
-      width: 100%;
-    }
-
-    .remove-condition {
-      align-self: flex-end;
-    }
-
-    .stats-bar {
-      justify-content: space-around;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --bg-hover: #22222e;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #3b82f6;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --glow-red: rgb(244, 63, 94, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f0f0f0;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
+
+      .row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .row > * {
+        flex: 1;
+        min-width: 200px;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-danger {
+        background: var(--accent-red);
+        color: #fff;
+      }
+
+      .btn-danger:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-red);
+      }
+
+      .btn-small {
+        flex: 0;
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+      }
+
+      /* Filter conditions */
+      .conditions-container {
+        margin-bottom: 16px;
+      }
+
+      .condition-item {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        padding: 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+      }
+
+      .condition-item select,
+      .condition-item input {
+        flex: 1;
+        min-width: 100px;
+      }
+
+      .condition-item .pattern-input {
+        flex: 2;
+        min-width: 200px;
+      }
+
+      .condition-item .column-select {
+        flex: 0.8;
+        min-width: 80px;
+      }
+
+      .remove-condition {
+        background: var(--accent-red);
+        color: #fff;
+        border: none;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        cursor: pointer;
+        font-size: 1.2rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s;
+        flex-shrink: 0;
+      }
+
+      .remove-condition:hover {
+        transform: scale(1.1);
+      }
+
+      .logic-operator {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .logic-btn {
+        padding: 8px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        border: 2px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .logic-btn.active {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.1);
+      }
+
+      .logic-btn:hover:not(.active) {
+        border-color: var(--color-text-secondary);
+      }
+
+      /* Options row */
+      .options-row {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        margin-bottom: 16px;
+      }
+
+      .option-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .option-item input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--color-accent-cyan);
+        cursor: pointer;
+      }
+
+      .option-item label {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
+
+      /* Statistics */
+      .stats-bar {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: 16px;
+      }
+
+      .stat-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--color-accent-cyan);
+      }
+
+      .stat-value.matched {
+        color: var(--accent-green);
+      }
+
+      .stat-value.unmatched {
+        color: var(--accent-red);
+      }
+
+      .stat-label {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+      }
+
+      /* Result panels */
+      .result-panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .result-panel {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .result-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+      }
+
+      .result-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .result-title.matched {
+        color: var(--accent-green);
+      }
+
+      .result-title.unmatched {
+        color: var(--accent-red);
+      }
+
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-primary);
+        min-height: 200px;
+        max-height: 400px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+
+      .result-box.matched-box {
+        border-color: rgba(16, 185, 129, 0.3);
+      }
+
+      .result-box.unmatched-box {
+        border-color: rgba(244, 63, 94, 0.3);
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      .toast.error {
+        background: var(--accent-red);
+      }
+
+      /* CSV mode indicator */
+      .mode-indicator {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 600;
+        border-radius: var(--radius-sm);
+        margin-left: auto;
+      }
+
+      .mode-indicator.csv-mode {
+        background: rgba(59, 130, 246, 0.2);
+        color: var(--accent-blue);
+        border: 1px solid var(--accent-blue);
+      }
+
+      .mode-indicator.text-mode {
+        background: rgba(168, 85, 247, 0.2);
+        color: var(--color-accent-purple);
+        border: 1px solid var(--color-accent-purple);
+      }
+
+      @media (max-width: 900px) {
+        .result-panels {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .condition-item {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .condition-item select,
+        .condition-item input {
+          width: 100%;
+        }
+
+        .remove-condition {
+          align-self: flex-end;
+        }
+
+        .stats-bar {
+          justify-content: space-around;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据筛选器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔍</span>
-        数据筛选器
-      </h1>
-      <p>强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据筛选器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔍</span>
+              数据筛选器
+            </h1>
+            <p>强大的数据筛选工具，支持CSV/文本筛选，多种匹配模式，多条件组合</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Input Section -->
-    <div class="tool-section">
-      <div class="section-title">
-        数据输入
-        <span id="modeIndicator" class="mode-indicator text-mode">文本模式</span>
-      </div>
-      <div class="input-group">
-        <label class="input-label">输入数据（支持纯文本或 CSV 格式）</label>
-        <textarea id="inputData" placeholder="粘贴您的数据...
+        <main class="main-content">
+          <!-- Input Section -->
+          <div class="tool-section">
+            <div class="section-title">
+              数据输入
+              <span id="modeIndicator" class="mode-indicator text-mode">文本模式</span>
+            </div>
+            <div class="input-group">
+              <label class="input-label">输入数据（支持纯文本或 CSV 格式）</label>
+              <textarea
+                id="inputData"
+                placeholder="粘贴您的数据...
 
 文本模式: 每行一条数据
-CSV模式: 自动检测逗号/制表符分隔的数据"></textarea>
-      </div>
-      <div class="row">
-        <div class="input-group">
-          <label class="input-label">CSV 分隔符</label>
-          <select id="delimiter">
-            <option value="auto">自动检测</option>
-            <option value=",">逗号 (,)</option>
-            <option value="	">制表符 (Tab)</option>
-            <option value=";">分号 (;)</option>
-            <option value="|">竖线 (|)</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">首行是否为标题</label>
-          <select id="hasHeader">
-            <option value="auto">自动检测</option>
-            <option value="yes">是</option>
-            <option value="no">否</option>
-          </select>
-        </div>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-secondary" onclick="pasteFromClipboard()">📋 粘贴</button>
-        <button class="btn btn-secondary" onclick="parseData()">🔄 解析数据</button>
-      </div>
-    </div>
-
-    <!-- Filter Conditions Section -->
-    <div class="tool-section">
-      <div class="section-title">筛选条件</div>
-
-      <div class="logic-operator">
-        <span class="input-label" style="margin-bottom: 0">条件组合方式:</span>
-        <button class="logic-btn active" data-logic="and" onclick="setLogic('and')">
-          AND (全部满足)
-        </button>
-        <button class="logic-btn" data-logic="or" onclick="setLogic('or')">OR (任一满足)</button>
-      </div>
-
-      <div id="conditionsContainer" class="conditions-container">
-        <!-- Conditions will be added here -->
-      </div>
-
-      <button class="btn btn-secondary btn-small" onclick="addCondition()">+ 添加条件</button>
-
-      <div class="options-row" style="margin-top: 16px">
-        <div class="option-item">
-          <input type="checkbox" id="caseSensitive">
-          <label for="caseSensitive">区分大小写</label>
-        </div>
-        <div class="option-item">
-          <input type="checkbox" id="trimWhitespace" checked="">
-          <label for="trimWhitespace">忽略首尾空格</label>
-        </div>
-        <div class="option-item">
-          <input type="checkbox" id="skipEmpty" checked="">
-          <label for="skipEmpty">跳过空行</label>
-        </div>
-      </div>
-    </div>
-
-    <!-- Action Buttons -->
-    <div class="tool-section">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="applyFilter()">🔍 执行筛选</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空全部</button>
-        <button class="btn btn-secondary" onclick="shareState()">🔗 分享</button>
-      </div>
-    </div>
-
-    <!-- Statistics -->
-    <div class="tool-section">
-      <div class="section-title">筛选统计</div>
-      <div class="stats-bar">
-        <div class="stat-item">
-          <span class="stat-value" id="statTotal">0</span>
-          <span class="stat-label">总行数</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value matched" id="statMatched">0</span>
-          <span class="stat-label">匹配</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value unmatched" id="statUnmatched">0</span>
-          <span class="stat-label">不匹配</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value" id="statPercent">0%</span>
-          <span class="stat-label">匹配率</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Results -->
-    <div class="tool-section">
-      <div class="section-title">筛选结果</div>
-      <div class="result-panels">
-        <div class="result-panel">
-          <div class="result-header">
-            <span class="result-title matched">✓ 匹配数据</span>
-            <button class="btn btn-secondary btn-small" onclick="copyResult('matched')">
-              复制
-            </button>
+CSV模式: 自动检测逗号/制表符分隔的数据"
+              ></textarea>
+            </div>
+            <div class="row">
+              <div class="input-group">
+                <label class="input-label">CSV 分隔符</label>
+                <select id="delimiter">
+                  <option value="auto">自动检测</option>
+                  <option value=",">逗号 (,)</option>
+                  <option value="	">制表符 (Tab)</option>
+                  <option value=";">分号 (;)</option>
+                  <option value="|">竖线 (|)</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">首行是否为标题</label>
+                <select id="hasHeader">
+                  <option value="auto">自动检测</option>
+                  <option value="yes">是</option>
+                  <option value="no">否</option>
+                </select>
+              </div>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-secondary" onclick="pasteFromClipboard()">📋 粘贴</button>
+              <button class="btn btn-secondary" onclick="parseData()">🔄 解析数据</button>
+            </div>
           </div>
-          <div class="result-box matched-box" id="matchedResult">匹配的数据将显示在这里...</div>
-        </div>
-        <div class="result-panel">
-          <div class="result-header">
-            <span class="result-title unmatched">✗ 不匹配数据</span>
-            <button class="btn btn-secondary btn-small" onclick="copyResult('unmatched')">
-              复制
-            </button>
+
+          <!-- Filter Conditions Section -->
+          <div class="tool-section">
+            <div class="section-title">筛选条件</div>
+
+            <div class="logic-operator">
+              <span class="input-label" style="margin-bottom: 0">条件组合方式:</span>
+              <button class="logic-btn active" data-logic="and" onclick="setLogic('and')">
+                AND (全部满足)
+              </button>
+              <button class="logic-btn" data-logic="or" onclick="setLogic('or')">
+                OR (任一满足)
+              </button>
+            </div>
+
+            <div id="conditionsContainer" class="conditions-container">
+              <!-- Conditions will be added here -->
+            </div>
+
+            <button class="btn btn-secondary btn-small" onclick="addCondition()">+ 添加条件</button>
+
+            <div class="options-row" style="margin-top: 16px">
+              <div class="option-item">
+                <input type="checkbox" id="caseSensitive" />
+                <label for="caseSensitive">区分大小写</label>
+              </div>
+              <div class="option-item">
+                <input type="checkbox" id="trimWhitespace" checked="" />
+                <label for="trimWhitespace">忽略首尾空格</label>
+              </div>
+              <div class="option-item">
+                <input type="checkbox" id="skipEmpty" checked="" />
+                <label for="skipEmpty">跳过空行</label>
+              </div>
+            </div>
           </div>
-          <div class="result-box unmatched-box" id="unmatchedResult">
-            不匹配的数据将显示在这里...
+
+          <!-- Action Buttons -->
+          <div class="tool-section">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="applyFilter()">🔍 执行筛选</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空全部</button>
+              <button class="btn btn-secondary" onclick="shareState()">🔗 分享</button>
+            </div>
           </div>
-        </div>
+
+          <!-- Statistics -->
+          <div class="tool-section">
+            <div class="section-title">筛选统计</div>
+            <div class="stats-bar">
+              <div class="stat-item">
+                <span class="stat-value" id="statTotal">0</span>
+                <span class="stat-label">总行数</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value matched" id="statMatched">0</span>
+                <span class="stat-label">匹配</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value unmatched" id="statUnmatched">0</span>
+                <span class="stat-label">不匹配</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value" id="statPercent">0%</span>
+                <span class="stat-label">匹配率</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Results -->
+          <div class="tool-section">
+            <div class="section-title">筛选结果</div>
+            <div class="result-panels">
+              <div class="result-panel">
+                <div class="result-header">
+                  <span class="result-title matched">✓ 匹配数据</span>
+                  <button class="btn btn-secondary btn-small" onclick="copyResult('matched')">
+                    复制
+                  </button>
+                </div>
+                <div class="result-box matched-box" id="matchedResult">
+                  匹配的数据将显示在这里...
+                </div>
+              </div>
+              <div class="result-panel">
+                <div class="result-header">
+                  <span class="result-title unmatched">✗ 不匹配数据</span>
+                  <button class="btn btn-secondary btn-small" onclick="copyResult('unmatched')">
+                    复制
+                  </button>
+                </div>
+                <div class="result-box unmatched-box" id="unmatchedResult">
+                  不匹配的数据将显示在这里...
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据筛选器",
-              "item": "https://tools.realtime-ai.chat/tools/data/data-filter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据筛选器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-filter.html"
+          }
+        ]
+      }
     </script>
     <script>
+      // State
+      const state = {
+        parsedData: [],
+        headers: [],
+        isCSV: false,
+        delimiter: ",",
+        hasHeader: false,
+        logic: "and",
+        conditions: []
+      };
 
-  // State
-        const state = {
-          parsedData: [],
-          headers: [],
-          isCSV: false,
-          delimiter: ",",
-          hasHeader: false,
-          logic: "and",
-          conditions: []
-        };
+      const LS_KEY = "data_filter_state_v1";
 
-        const LS_KEY = "data_filter_state_v1";
-
-        // Filter modes
-        const FILTER_MODES = {
-          contains: {
-            label: "包含",
-            fn: function (val, pat) {
-              return val.includes(pat);
-            }
-          },
-          not_contains: {
-            label: "不包含",
-            fn: function (val, pat) {
-              return !val.includes(pat);
-            }
-          },
-          starts_with: {
-            label: "开头是",
-            fn: function (val, pat) {
-              return val.startsWith(pat);
-            }
-          },
-          ends_with: {
-            label: "结尾是",
-            fn: function (val, pat) {
-              return val.endsWith(pat);
-            }
-          },
-          exact: {
-            label: "精确匹配",
-            fn: function (val, pat) {
-              return val === pat;
-            }
-          },
-          regex: {
-            label: "正则表达式",
-            fn: function (val, pat, flags) {
-              try {
-                var regex = new RegExp(pat, flags);
-                return regex.test(val);
-              } catch (e) {
-                return false;
-              }
+      // Filter modes
+      const FILTER_MODES = {
+        contains: {
+          label: "包含",
+          fn: function (val, pat) {
+            return val.includes(pat);
+          }
+        },
+        not_contains: {
+          label: "不包含",
+          fn: function (val, pat) {
+            return !val.includes(pat);
+          }
+        },
+        starts_with: {
+          label: "开头是",
+          fn: function (val, pat) {
+            return val.startsWith(pat);
+          }
+        },
+        ends_with: {
+          label: "结尾是",
+          fn: function (val, pat) {
+            return val.endsWith(pat);
+          }
+        },
+        exact: {
+          label: "精确匹配",
+          fn: function (val, pat) {
+            return val === pat;
+          }
+        },
+        regex: {
+          label: "正则表达式",
+          fn: function (val, pat, flags) {
+            try {
+              var regex = new RegExp(pat, flags);
+              return regex.test(val);
+            } catch (e) {
+              return false;
             }
           }
-        };
-
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
         }
+      };
 
-        // Load theme
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // Toast notification
+      function showToast(msg, isError) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (isError ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Paste from clipboard
+      function pasteFromClipboard() {
+        navigator.clipboard
+          .readText()
+          .then(function (text) {
+            document.getElementById("inputData").value = text;
+            parseData();
+            showToast("已粘贴");
+          })
+          .catch(function () {
+            showToast("无法访问剪贴板", true);
+          });
+      }
+
+      // Detect delimiter
+      function detectDelimiter(text) {
+        var firstLine = text.split("\n")[0];
+        var delimiters = [",", "\t", ";", "|"];
+        var counts = delimiters.map(function (d) {
+          var escaped = d === "|" ? "\\|" : d;
+          var matches = firstLine.match(new RegExp(escaped, "g"));
+          return { d: d, count: matches ? matches.length : 0 };
+        });
+        counts.sort(function (a, b) {
+          return b.count - a.count;
+        });
+        return counts[0].count > 0 ? counts[0].d : null;
+      }
+
+      // Detect if first row is header
+      function detectHeader(rows, delimiter) {
+        if (rows.length < 2) return false;
+        var firstRow = rows[0].split(delimiter);
+        var secondRow = rows[1].split(delimiter);
+
+        var firstRowNumeric = firstRow.filter(function (cell) {
+          return !isNaN(parseFloat(cell));
+        }).length;
+        var secondRowNumeric = secondRow.filter(function (cell) {
+          return !isNaN(parseFloat(cell));
+        }).length;
+
+        return firstRowNumeric < secondRowNumeric;
+      }
+
+      // Parse CSV line handling quoted fields
+      function parseCSVLine(line, delimiter) {
+        var result = [];
+        var current = "";
+        var inQuotes = false;
+
+        for (var i = 0; i < line.length; i++) {
+          var char = line[i];
+          if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+              current += '"';
+              i++;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (char === delimiter && !inQuotes) {
+            result.push(current);
+            current = "";
+          } else {
+            current += char;
           }
-        })();
+        }
+        result.push(current);
+        return result;
+      }
 
-        // Toast notification
-        function showToast(msg, isError) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (isError ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
+      // Parse data
+      function parseData() {
+        var input = document.getElementById("inputData").value;
+        var delimiterSelect = document.getElementById("delimiter").value;
+        var hasHeaderSelect = document.getElementById("hasHeader").value;
+
+        if (!input.trim()) {
+          showToast("请输入数据", true);
+          return;
         }
 
-        // Paste from clipboard
-        function pasteFromClipboard() {
-          navigator.clipboard
-            .readText()
-            .then(function (text) {
-              document.getElementById("inputData").value = text;
-              parseData();
-              showToast("已粘贴");
-            })
-            .catch(function () {
-              showToast("无法访问剪贴板", true);
-            });
-        }
+        var lines = input.split("\n").filter(function (line) {
+          return line.trim();
+        });
 
         // Detect delimiter
-        function detectDelimiter(text) {
-          var firstLine = text.split("\n")[0];
-          var delimiters = [",", "\t", ";", "|"];
-          var counts = delimiters.map(function (d) {
-            var escaped = d === "|" ? "\\|" : d;
-            var matches = firstLine.match(new RegExp(escaped, "g"));
-            return { d: d, count: matches ? matches.length : 0 };
-          });
-          counts.sort(function (a, b) {
-            return b.count - a.count;
-          });
-          return counts[0].count > 0 ? counts[0].d : null;
+        var delimiter;
+        if (delimiterSelect === "auto") {
+          delimiter = detectDelimiter(input);
+        } else {
+          delimiter = delimiterSelect;
         }
 
-        // Detect if first row is header
-        function detectHeader(rows, delimiter) {
-          if (rows.length < 2) return false;
-          var firstRow = rows[0].split(delimiter);
-          var secondRow = rows[1].split(delimiter);
+        // Check if CSV
+        state.isCSV = delimiter !== null;
+        state.delimiter = delimiter || ",";
 
-          var firstRowNumeric = firstRow.filter(function (cell) {
-            return !isNaN(parseFloat(cell));
-          }).length;
-          var secondRowNumeric = secondRow.filter(function (cell) {
-            return !isNaN(parseFloat(cell));
-          }).length;
-
-          return firstRowNumeric < secondRowNumeric;
-        }
-
-        // Parse CSV line handling quoted fields
-        function parseCSVLine(line, delimiter) {
-          var result = [];
-          var current = "";
-          var inQuotes = false;
-
-          for (var i = 0; i < line.length; i++) {
-            var char = line[i];
-            if (char === '"') {
-              if (inQuotes && line[i + 1] === '"') {
-                current += '"';
-                i++;
-              } else {
-                inQuotes = !inQuotes;
-              }
-            } else if (char === delimiter && !inQuotes) {
-              result.push(current);
-              current = "";
-            } else {
-              current += char;
-            }
-          }
-          result.push(current);
-          return result;
-        }
-
-        // Parse data
-        function parseData() {
-          var input = document.getElementById("inputData").value;
-          var delimiterSelect = document.getElementById("delimiter").value;
-          var hasHeaderSelect = document.getElementById("hasHeader").value;
-
-          if (!input.trim()) {
-            showToast("请输入数据", true);
-            return;
-          }
-
-          var lines = input.split("\n").filter(function (line) {
-            return line.trim();
+        if (state.isCSV) {
+          // Parse CSV
+          var rows = lines.map(function (line) {
+            return parseCSVLine(line, state.delimiter);
           });
 
-          // Detect delimiter
-          var delimiter;
-          if (delimiterSelect === "auto") {
-            delimiter = detectDelimiter(input);
+          // Detect or set header
+          if (hasHeaderSelect === "auto") {
+            state.hasHeader = detectHeader(lines, state.delimiter);
           } else {
-            delimiter = delimiterSelect;
+            state.hasHeader = hasHeaderSelect === "yes";
           }
 
-          // Check if CSV
-          state.isCSV = delimiter !== null;
-          state.delimiter = delimiter || ",";
-
-          if (state.isCSV) {
-            // Parse CSV
-            var rows = lines.map(function (line) {
-              return parseCSVLine(line, state.delimiter);
+          if (state.hasHeader && rows.length > 0) {
+            state.headers = rows[0].map(function (h, i) {
+              return h.trim() || "列" + (i + 1);
             });
-
-            // Detect or set header
-            if (hasHeaderSelect === "auto") {
-              state.hasHeader = detectHeader(lines, state.delimiter);
-            } else {
-              state.hasHeader = hasHeaderSelect === "yes";
-            }
-
-            if (state.hasHeader && rows.length > 0) {
-              state.headers = rows[0].map(function (h, i) {
-                return h.trim() || "列" + (i + 1);
-              });
-              state.parsedData = rows.slice(1);
-            } else {
-              var colCount = rows[0] ? rows[0].length : 0;
-              state.headers = [];
-              for (var i = 0; i < colCount; i++) {
-                state.headers.push("列" + (i + 1));
-              }
-              state.parsedData = rows;
-            }
-
-            updateModeIndicator(true);
+            state.parsedData = rows.slice(1);
           } else {
-            // Plain text mode
-            state.headers = ["内容"];
-            state.parsedData = lines.map(function (line) {
-              return [line];
-            });
-            updateModeIndicator(false);
-          }
-
-          // Update column selectors in conditions
-          updateColumnSelectors();
-
-          showToast("已解析 " + state.parsedData.length + " 行数据");
-          saveToStorage();
-        }
-
-        // Update mode indicator
-        function updateModeIndicator(isCSV) {
-          var indicator = document.getElementById("modeIndicator");
-          if (isCSV) {
-            indicator.className = "mode-indicator csv-mode";
-            indicator.textContent = "CSV模式 (" + state.headers.length + "列)";
-          } else {
-            indicator.className = "mode-indicator text-mode";
-            indicator.textContent = "文本模式";
-          }
-        }
-
-        // Update column selectors
-        function updateColumnSelectors() {
-          var selects = document.querySelectorAll(".column-select");
-          selects.forEach(function (select) {
-            var currentValue = select.value;
-            // Clear and rebuild options
-            while (select.firstChild) {
-              select.removeChild(select.firstChild);
+            var colCount = rows[0] ? rows[0].length : 0;
+            state.headers = [];
+            for (var i = 0; i < colCount; i++) {
+              state.headers.push("列" + (i + 1));
             }
-            var allOption = document.createElement("option");
-            allOption.value = "all";
-            allOption.textContent = "所有列";
-            select.appendChild(allOption);
+            state.parsedData = rows;
+          }
 
-            state.headers.forEach(function (header, i) {
-              var option = document.createElement("option");
-              option.value = i;
-              option.textContent = header;
-              select.appendChild(option);
-            });
-            select.value = currentValue;
+          updateModeIndicator(true);
+        } else {
+          // Plain text mode
+          state.headers = ["内容"];
+          state.parsedData = lines.map(function (line) {
+            return [line];
           });
+          updateModeIndicator(false);
         }
 
-        // Create a condition element
-        function createConditionElement(conditionData) {
-          var div = document.createElement("div");
-          div.className = "condition-item";
-          div.dataset.id = Date.now();
+        // Update column selectors in conditions
+        updateColumnSelectors();
 
-          // Column select
-          var columnSelect = document.createElement("select");
-          columnSelect.className = "column-select";
-          columnSelect.title = "选择列";
+        showToast("已解析 " + state.parsedData.length + " 行数据");
+        saveToStorage();
+      }
+
+      // Update mode indicator
+      function updateModeIndicator(isCSV) {
+        var indicator = document.getElementById("modeIndicator");
+        if (isCSV) {
+          indicator.className = "mode-indicator csv-mode";
+          indicator.textContent = "CSV模式 (" + state.headers.length + "列)";
+        } else {
+          indicator.className = "mode-indicator text-mode";
+          indicator.textContent = "文本模式";
+        }
+      }
+
+      // Update column selectors
+      function updateColumnSelectors() {
+        var selects = document.querySelectorAll(".column-select");
+        selects.forEach(function (select) {
+          var currentValue = select.value;
+          // Clear and rebuild options
+          while (select.firstChild) {
+            select.removeChild(select.firstChild);
+          }
           var allOption = document.createElement("option");
           allOption.value = "all";
           allOption.textContent = "所有列";
-          columnSelect.appendChild(allOption);
-          state.headers.forEach(function (h, i) {
-            var opt = document.createElement("option");
-            opt.value = i;
-            opt.textContent = h;
-            columnSelect.appendChild(opt);
+          select.appendChild(allOption);
+
+          state.headers.forEach(function (header, i) {
+            var option = document.createElement("option");
+            option.value = i;
+            option.textContent = header;
+            select.appendChild(option);
           });
+          select.value = currentValue;
+        });
+      }
 
-          // Mode select
-          var modeSelect = document.createElement("select");
-          modeSelect.className = "mode-select";
-          modeSelect.title = "匹配模式";
-          Object.keys(FILTER_MODES).forEach(function (key) {
-            var opt = document.createElement("option");
-            opt.value = key;
-            opt.textContent = FILTER_MODES[key].label;
-            modeSelect.appendChild(opt);
-          });
+      // Create a condition element
+      function createConditionElement(conditionData) {
+        var div = document.createElement("div");
+        div.className = "condition-item";
+        div.dataset.id = Date.now();
 
-          // Pattern input
-          var patternInput = document.createElement("input");
-          patternInput.type = "text";
-          patternInput.className = "pattern-input";
-          patternInput.placeholder = "匹配内容/正则表达式...";
+        // Column select
+        var columnSelect = document.createElement("select");
+        columnSelect.className = "column-select";
+        columnSelect.title = "选择列";
+        var allOption = document.createElement("option");
+        allOption.value = "all";
+        allOption.textContent = "所有列";
+        columnSelect.appendChild(allOption);
+        state.headers.forEach(function (h, i) {
+          var opt = document.createElement("option");
+          opt.value = i;
+          opt.textContent = h;
+          columnSelect.appendChild(opt);
+        });
 
-          // Remove button
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "remove-condition";
-          removeBtn.title = "删除条件";
-          removeBtn.textContent = "×";
-          removeBtn.onclick = function () {
-            div.remove();
-            saveToStorage();
-          };
+        // Mode select
+        var modeSelect = document.createElement("select");
+        modeSelect.className = "mode-select";
+        modeSelect.title = "匹配模式";
+        Object.keys(FILTER_MODES).forEach(function (key) {
+          var opt = document.createElement("option");
+          opt.value = key;
+          opt.textContent = FILTER_MODES[key].label;
+          modeSelect.appendChild(opt);
+        });
 
-          // Set values if provided
-          if (conditionData) {
-            columnSelect.value = conditionData.column || "all";
-            modeSelect.value = conditionData.mode || "contains";
-            patternInput.value = conditionData.pattern || "";
+        // Pattern input
+        var patternInput = document.createElement("input");
+        patternInput.type = "text";
+        patternInput.className = "pattern-input";
+        patternInput.placeholder = "匹配内容/正则表达式...";
+
+        // Remove button
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "remove-condition";
+        removeBtn.title = "删除条件";
+        removeBtn.textContent = "×";
+        removeBtn.onclick = function () {
+          div.remove();
+          saveToStorage();
+        };
+
+        // Set values if provided
+        if (conditionData) {
+          columnSelect.value = conditionData.column || "all";
+          modeSelect.value = conditionData.mode || "contains";
+          patternInput.value = conditionData.pattern || "";
+        }
+
+        // Auto-save on change
+        [columnSelect, modeSelect, patternInput].forEach(function (el) {
+          el.addEventListener("change", saveToStorage);
+          el.addEventListener("input", saveToStorage);
+        });
+
+        div.appendChild(columnSelect);
+        div.appendChild(modeSelect);
+        div.appendChild(patternInput);
+        div.appendChild(removeBtn);
+
+        return div;
+      }
+
+      // Add condition
+      function addCondition(conditionData) {
+        var container = document.getElementById("conditionsContainer");
+        var conditionEl = createConditionElement(conditionData);
+        container.appendChild(conditionEl);
+        saveToStorage();
+      }
+
+      // Set logic operator
+      function setLogic(logic) {
+        state.logic = logic;
+        var buttons = document.querySelectorAll(".logic-btn");
+        buttons.forEach(function (btn) {
+          if (btn.dataset.logic === logic) {
+            btn.classList.add("active");
+          } else {
+            btn.classList.remove("active");
           }
+        });
+        saveToStorage();
+      }
 
-          // Auto-save on change
-          [columnSelect, modeSelect, patternInput].forEach(function (el) {
-            el.addEventListener("change", saveToStorage);
-            el.addEventListener("input", saveToStorage);
-          });
+      // Get conditions from UI
+      function getConditions() {
+        var conditions = [];
+        var items = document.querySelectorAll(".condition-item");
+        items.forEach(function (item) {
+          var column = item.querySelector(".column-select").value;
+          var mode = item.querySelector(".mode-select").value;
+          var pattern = item.querySelector(".pattern-input").value;
+          if (pattern) {
+            conditions.push({ column: column, mode: mode, pattern: pattern });
+          }
+        });
+        return conditions;
+      }
 
-          div.appendChild(columnSelect);
-          div.appendChild(modeSelect);
-          div.appendChild(patternInput);
-          div.appendChild(removeBtn);
+      // Apply filter
+      function applyFilter() {
+        var conditions = getConditions();
 
-          return div;
+        if (conditions.length === 0) {
+          showToast("请添加至少一个筛选条件", true);
+          return;
         }
 
-        // Add condition
-        function addCondition(conditionData) {
-          var container = document.getElementById("conditionsContainer");
-          var conditionEl = createConditionElement(conditionData);
-          container.appendChild(conditionEl);
-          saveToStorage();
+        if (state.parsedData.length === 0) {
+          parseData();
+          if (state.parsedData.length === 0) {
+            showToast("请先输入并解析数据", true);
+            return;
+          }
         }
 
-        // Set logic operator
-        function setLogic(logic) {
-          state.logic = logic;
-          var buttons = document.querySelectorAll(".logic-btn");
-          buttons.forEach(function (btn) {
-            if (btn.dataset.logic === logic) {
-              btn.classList.add("active");
-            } else {
-              btn.classList.remove("active");
-            }
-          });
-          saveToStorage();
-        }
+        var caseSensitive = document.getElementById("caseSensitive").checked;
+        var trimWhitespace = document.getElementById("trimWhitespace").checked;
+        var skipEmpty = document.getElementById("skipEmpty").checked;
 
-        // Get conditions from UI
-        function getConditions() {
-          var conditions = [];
-          var items = document.querySelectorAll(".condition-item");
-          items.forEach(function (item) {
-            var column = item.querySelector(".column-select").value;
-            var mode = item.querySelector(".mode-select").value;
-            var pattern = item.querySelector(".pattern-input").value;
-            if (pattern) {
-              conditions.push({ column: column, mode: mode, pattern: pattern });
-            }
-          });
-          return conditions;
-        }
+        var matched = [];
+        var unmatched = [];
 
-        // Apply filter
-        function applyFilter() {
-          var conditions = getConditions();
-
-          if (conditions.length === 0) {
-            showToast("请添加至少一个筛选条件", true);
+        state.parsedData.forEach(function (row) {
+          // Skip empty rows if option is checked
+          if (
+            skipEmpty &&
+            row.every(function (cell) {
+              return !cell.trim();
+            })
+          ) {
             return;
           }
 
-          if (state.parsedData.length === 0) {
-            parseData();
-            if (state.parsedData.length === 0) {
-              showToast("请先输入并解析数据", true);
-              return;
-            }
-          }
+          var results = conditions.map(function (cond) {
+            var filterFn = FILTER_MODES[cond.mode].fn;
+            var pattern = cond.pattern;
+            var flags = caseSensitive ? "" : "i";
 
-          var caseSensitive = document.getElementById("caseSensitive").checked;
-          var trimWhitespace = document.getElementById("trimWhitespace").checked;
-          var skipEmpty = document.getElementById("skipEmpty").checked;
-
-          var matched = [];
-          var unmatched = [];
-
-          state.parsedData.forEach(function (row) {
-            // Skip empty rows if option is checked
-            if (
-              skipEmpty &&
-              row.every(function (cell) {
-                return !cell.trim();
-              })
-            ) {
-              return;
+            if (!caseSensitive && cond.mode !== "regex") {
+              pattern = pattern.toLowerCase();
             }
 
-            var results = conditions.map(function (cond) {
-              var filterFn = FILTER_MODES[cond.mode].fn;
-              var pattern = cond.pattern;
-              var flags = caseSensitive ? "" : "i";
+            // Get values to check
+            var valuesToCheck = [];
+            if (cond.column === "all") {
+              valuesToCheck = row;
+            } else {
+              var colIndex = parseInt(cond.column);
+              valuesToCheck = [row[colIndex] || ""];
+            }
 
-              if (!caseSensitive && cond.mode !== "regex") {
-                pattern = pattern.toLowerCase();
-              }
-
-              // Get values to check
-              var valuesToCheck = [];
-              if (cond.column === "all") {
-                valuesToCheck = row;
-              } else {
-                var colIndex = parseInt(cond.column);
-                valuesToCheck = [row[colIndex] || ""];
-              }
-
-              // Check if any value matches
-              return valuesToCheck.some(function (val) {
-                var value = val;
-                if (trimWhitespace) value = value.trim();
-                if (!caseSensitive && cond.mode !== "regex") value = value.toLowerCase();
-                return filterFn(value, pattern, flags);
-              });
+            // Check if any value matches
+            return valuesToCheck.some(function (val) {
+              var value = val;
+              if (trimWhitespace) value = value.trim();
+              if (!caseSensitive && cond.mode !== "regex") value = value.toLowerCase();
+              return filterFn(value, pattern, flags);
             });
-
-            // Apply logic (AND/OR)
-            var isMatch;
-            if (state.logic === "and") {
-              isMatch = results.every(function (r) {
-                return r;
-              });
-            } else {
-              isMatch = results.some(function (r) {
-                return r;
-              });
-            }
-
-            if (isMatch) {
-              matched.push(row);
-            } else {
-              unmatched.push(row);
-            }
           });
 
-          // Update statistics
-          updateStats(state.parsedData.length, matched.length, unmatched.length);
+          // Apply logic (AND/OR)
+          var isMatch;
+          if (state.logic === "and") {
+            isMatch = results.every(function (r) {
+              return r;
+            });
+          } else {
+            isMatch = results.some(function (r) {
+              return r;
+            });
+          }
 
-          // Display results
-          displayResults(matched, unmatched);
-
-          showToast("筛选完成: " + matched.length + " 条匹配");
-          saveToStorage();
-        }
+          if (isMatch) {
+            matched.push(row);
+          } else {
+            unmatched.push(row);
+          }
+        });
 
         // Update statistics
-        function updateStats(total, matchedCount, unmatchedCount) {
-          document.getElementById("statTotal").textContent = total;
-          document.getElementById("statMatched").textContent = matchedCount;
-          document.getElementById("statUnmatched").textContent = unmatchedCount;
-          document.getElementById("statPercent").textContent =
-            total > 0 ? Math.round((matchedCount / total) * 100) + "%" : "0%";
-        }
+        updateStats(state.parsedData.length, matched.length, unmatched.length);
 
         // Display results
-        function displayResults(matched, unmatched) {
-          var formatRow = function (row) {
-            if (state.isCSV) {
-              return row
-                .map(function (cell) {
-                  if (cell.includes(state.delimiter) || cell.includes('"') || cell.includes("\n")) {
-                    return '"' + cell.replace(/"/g, '""') + '"';
-                  }
-                  return cell;
-                })
-                .join(state.delimiter);
-            }
-            return row[0];
-          };
+        displayResults(matched, unmatched);
 
-          var matchedText;
-          if (matched.length > 0) {
-            var matchedLines = [];
-            if (state.isCSV && state.hasHeader) {
-              matchedLines.push(state.headers.join(state.delimiter));
-            }
-            matched.forEach(function (row) {
-              matchedLines.push(formatRow(row));
-            });
-            matchedText = matchedLines.join("\n");
-          } else {
-            matchedText = "无匹配数据";
+        showToast("筛选完成: " + matched.length + " 条匹配");
+        saveToStorage();
+      }
+
+      // Update statistics
+      function updateStats(total, matchedCount, unmatchedCount) {
+        document.getElementById("statTotal").textContent = total;
+        document.getElementById("statMatched").textContent = matchedCount;
+        document.getElementById("statUnmatched").textContent = unmatchedCount;
+        document.getElementById("statPercent").textContent =
+          total > 0 ? Math.round((matchedCount / total) * 100) + "%" : "0%";
+      }
+
+      // Display results
+      function displayResults(matched, unmatched) {
+        var formatRow = function (row) {
+          if (state.isCSV) {
+            return row
+              .map(function (cell) {
+                if (cell.includes(state.delimiter) || cell.includes('"') || cell.includes("\n")) {
+                  return '"' + cell.replace(/"/g, '""') + '"';
+                }
+                return cell;
+              })
+              .join(state.delimiter);
           }
+          return row[0];
+        };
 
-          var unmatchedText;
-          if (unmatched.length > 0) {
-            var unmatchedLines = [];
-            if (state.isCSV && state.hasHeader) {
-              unmatchedLines.push(state.headers.join(state.delimiter));
-            }
-            unmatched.forEach(function (row) {
-              unmatchedLines.push(formatRow(row));
-            });
-            unmatchedText = unmatchedLines.join("\n");
-          } else {
-            unmatchedText = "无不匹配数据";
+        var matchedText;
+        if (matched.length > 0) {
+          var matchedLines = [];
+          if (state.isCSV && state.hasHeader) {
+            matchedLines.push(state.headers.join(state.delimiter));
           }
-
-          document.getElementById("matchedResult").textContent = matchedText;
-          document.getElementById("unmatchedResult").textContent = unmatchedText;
-        }
-
-        // Copy result
-        function copyResult(type) {
-          var resultEl = document.getElementById(
-            type === "matched" ? "matchedResult" : "unmatchedResult"
-          );
-          var text = resultEl.textContent;
-
-          if (text === "无匹配数据" || text === "无不匹配数据" || text.indexOf("将显示在这里") >= 0) {
-            showToast("没有可复制的内容", true);
-            return;
-          }
-
-          navigator.clipboard.writeText(text).then(function () {
-            showToast("已复制到剪贴板");
+          matched.forEach(function (row) {
+            matchedLines.push(formatRow(row));
           });
+          matchedText = matchedLines.join("\n");
+        } else {
+          matchedText = "无匹配数据";
         }
 
-        // Clear all
-        function clearAll() {
-          document.getElementById("inputData").value = "";
-          var container = document.getElementById("conditionsContainer");
-          while (container.firstChild) {
-            container.removeChild(container.firstChild);
+        var unmatchedText;
+        if (unmatched.length > 0) {
+          var unmatchedLines = [];
+          if (state.isCSV && state.hasHeader) {
+            unmatchedLines.push(state.headers.join(state.delimiter));
           }
-          document.getElementById("matchedResult").textContent = "匹配的数据将显示在这里...";
-          document.getElementById("unmatchedResult").textContent = "不匹配的数据将显示在这里...";
-
-          state.parsedData = [];
-          state.headers = [];
-          state.isCSV = false;
-
-          updateStats(0, 0, 0);
-          updateModeIndicator(false);
-          addCondition();
-
-          localStorage.removeItem(LS_KEY);
-          history.replaceState(null, "", location.pathname);
-          showToast("已清空");
+          unmatched.forEach(function (row) {
+            unmatchedLines.push(formatRow(row));
+          });
+          unmatchedText = unmatchedLines.join("\n");
+        } else {
+          unmatchedText = "无不匹配数据";
         }
 
-        // Save to storage
-        function saveToStorage() {
-          var data = {
-            input: document.getElementById("inputData").value,
-            delimiter: document.getElementById("delimiter").value,
-            hasHeader: document.getElementById("hasHeader").value,
-            logic: state.logic,
-            caseSensitive: document.getElementById("caseSensitive").checked,
-            trimWhitespace: document.getElementById("trimWhitespace").checked,
-            skipEmpty: document.getElementById("skipEmpty").checked,
-            conditions: getConditions()
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
+        document.getElementById("matchedResult").textContent = matchedText;
+        document.getElementById("unmatchedResult").textContent = unmatchedText;
+      }
+
+      // Copy result
+      function copyResult(type) {
+        var resultEl = document.getElementById(
+          type === "matched" ? "matchedResult" : "unmatchedResult"
+        );
+        var text = resultEl.textContent;
+
+        if (text === "无匹配数据" || text === "无不匹配数据" || text.indexOf("将显示在这里") >= 0) {
+          showToast("没有可复制的内容", true);
+          return;
         }
 
-        // Load from storage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return false;
+        navigator.clipboard.writeText(text).then(function () {
+          showToast("已复制到剪贴板");
+        });
+      }
 
-          try {
-            var data = JSON.parse(saved);
-            document.getElementById("inputData").value = data.input || "";
-            document.getElementById("delimiter").value = data.delimiter || "auto";
-            document.getElementById("hasHeader").value = data.hasHeader || "auto";
-            document.getElementById("caseSensitive").checked = data.caseSensitive || false;
-            document.getElementById("trimWhitespace").checked =
-              data.trimWhitespace !== undefined ? data.trimWhitespace : true;
-            document.getElementById("skipEmpty").checked =
-              data.skipEmpty !== undefined ? data.skipEmpty : true;
+      // Clear all
+      function clearAll() {
+        document.getElementById("inputData").value = "";
+        var container = document.getElementById("conditionsContainer");
+        while (container.firstChild) {
+          container.removeChild(container.firstChild);
+        }
+        document.getElementById("matchedResult").textContent = "匹配的数据将显示在这里...";
+        document.getElementById("unmatchedResult").textContent = "不匹配的数据将显示在这里...";
 
-            if (data.logic) {
-              setLogic(data.logic);
-            }
+        state.parsedData = [];
+        state.headers = [];
+        state.isCSV = false;
 
-            if (data.input) {
-              parseData();
-            }
+        updateStats(0, 0, 0);
+        updateModeIndicator(false);
+        addCondition();
 
-            if (data.conditions && data.conditions.length > 0) {
-              data.conditions.forEach(function (cond) {
-                addCondition(cond);
-              });
-            } else {
-              addCondition();
-            }
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+        showToast("已清空");
+      }
 
-            return true;
-          } catch (e) {
-            return false;
+      // Save to storage
+      function saveToStorage() {
+        var data = {
+          input: document.getElementById("inputData").value,
+          delimiter: document.getElementById("delimiter").value,
+          hasHeader: document.getElementById("hasHeader").value,
+          logic: state.logic,
+          caseSensitive: document.getElementById("caseSensitive").checked,
+          trimWhitespace: document.getElementById("trimWhitespace").checked,
+          skipEmpty: document.getElementById("skipEmpty").checked,
+          conditions: getConditions()
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from storage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return false;
+
+        try {
+          var data = JSON.parse(saved);
+          document.getElementById("inputData").value = data.input || "";
+          document.getElementById("delimiter").value = data.delimiter || "auto";
+          document.getElementById("hasHeader").value = data.hasHeader || "auto";
+          document.getElementById("caseSensitive").checked = data.caseSensitive || false;
+          document.getElementById("trimWhitespace").checked =
+            data.trimWhitespace !== undefined ? data.trimWhitespace : true;
+          document.getElementById("skipEmpty").checked =
+            data.skipEmpty !== undefined ? data.skipEmpty : true;
+
+          if (data.logic) {
+            setLogic(data.logic);
           }
-        }
 
-        // Save to URL
-        function saveToUrl() {
-          var data = {
-            i: document.getElementById("inputData").value,
-            d: document.getElementById("delimiter").value,
-            h: document.getElementById("hasHeader").value,
-            l: state.logic,
-            cs: document.getElementById("caseSensitive").checked,
-            tw: document.getElementById("trimWhitespace").checked,
-            se: document.getElementById("skipEmpty").checked,
-            c: getConditions()
-          };
-
-          try {
-            var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-            if (encoded.length < 2000) {
-              history.replaceState(null, "", "#" + encoded);
-              return true;
-            }
-          } catch (e) {
-            // ignore
+          if (data.input) {
+            parseData();
           }
+
+          if (data.conditions && data.conditions.length > 0) {
+            data.conditions.forEach(function (cond) {
+              addCondition(cond);
+            });
+          } else {
+            addCondition();
+          }
+
+          return true;
+        } catch (e) {
           return false;
         }
+      }
 
-        // Load from URL
-        function loadFromUrl() {
-          var hash = location.hash.slice(1);
-          if (!hash) return false;
+      // Save to URL
+      function saveToUrl() {
+        var data = {
+          i: document.getElementById("inputData").value,
+          d: document.getElementById("delimiter").value,
+          h: document.getElementById("hasHeader").value,
+          l: state.logic,
+          cs: document.getElementById("caseSensitive").checked,
+          tw: document.getElementById("trimWhitespace").checked,
+          se: document.getElementById("skipEmpty").checked,
+          c: getConditions()
+        };
 
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
-            document.getElementById("inputData").value = data.i || "";
-            document.getElementById("delimiter").value = data.d || "auto";
-            document.getElementById("hasHeader").value = data.h || "auto";
-            document.getElementById("caseSensitive").checked = data.cs || false;
-            document.getElementById("trimWhitespace").checked =
-              data.tw !== undefined ? data.tw : true;
-            document.getElementById("skipEmpty").checked = data.se !== undefined ? data.se : true;
-
-            if (data.l) {
-              setLogic(data.l);
-            }
-
-            if (data.i) {
-              parseData();
-            }
-
-            if (data.c && data.c.length > 0) {
-              data.c.forEach(function (cond) {
-                addCondition(cond);
-              });
-            } else {
-              addCondition();
-            }
-
+        try {
+          var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+          if (encoded.length < 2000) {
+            history.replaceState(null, "", "#" + encoded);
             return true;
-          } catch (e) {
-            return false;
           }
+        } catch (e) {
+          // ignore
         }
+        return false;
+      }
 
-        // Share state
-        function shareState() {
-          if (saveToUrl()) {
-            navigator.clipboard
-              .writeText(location.href)
-              .then(function () {
-                showToast("链接已复制到剪贴板");
-              })
-              .catch(function () {
-                showToast("请手动复制地址栏链接");
-              });
+      // Load from URL
+      function loadFromUrl() {
+        var hash = location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          document.getElementById("inputData").value = data.i || "";
+          document.getElementById("delimiter").value = data.d || "auto";
+          document.getElementById("hasHeader").value = data.h || "auto";
+          document.getElementById("caseSensitive").checked = data.cs || false;
+          document.getElementById("trimWhitespace").checked =
+            data.tw !== undefined ? data.tw : true;
+          document.getElementById("skipEmpty").checked = data.se !== undefined ? data.se : true;
+
+          if (data.l) {
+            setLogic(data.l);
+          }
+
+          if (data.i) {
+            parseData();
+          }
+
+          if (data.c && data.c.length > 0) {
+            data.c.forEach(function (cond) {
+              addCondition(cond);
+            });
           } else {
-            showToast("数据过大，无法生成分享链接", true);
+            addCondition();
+          }
+
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // Share state
+      function shareState() {
+        if (saveToUrl()) {
+          navigator.clipboard
+            .writeText(location.href)
+            .then(function () {
+              showToast("链接已复制到剪贴板");
+            })
+            .catch(function () {
+              showToast("请手动复制地址栏链接");
+            });
+        } else {
+          showToast("数据过大，无法生成分享链接", true);
+        }
+      }
+
+      // Initialize
+      (function init() {
+        if (!loadFromUrl()) {
+          if (!loadFromStorage()) {
+            addCondition();
           }
         }
 
-        // Initialize
-        (function init() {
-          if (!loadFromUrl()) {
-            if (!loadFromStorage()) {
-              addCondition();
-            }
+        // Auto-save on input change
+        document.getElementById("inputData").addEventListener("input", saveToStorage);
+        document.getElementById("delimiter").addEventListener("change", saveToStorage);
+        document.getElementById("hasHeader").addEventListener("change", saveToStorage);
+        document.getElementById("caseSensitive").addEventListener("change", saveToStorage);
+        document.getElementById("trimWhitespace").addEventListener("change", saveToStorage);
+        document.getElementById("skipEmpty").addEventListener("change", saveToStorage);
+
+        // Keyboard shortcut
+        document.addEventListener("keydown", function (e) {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            e.preventDefault();
+            applyFilter();
           }
+        });
+      })();
+    </script>
 
-          // Auto-save on input change
-          document.getElementById("inputData").addEventListener("input", saveToStorage);
-          document.getElementById("delimiter").addEventListener("change", saveToStorage);
-          document.getElementById("hasHeader").addEventListener("change", saveToStorage);
-          document.getElementById("caseSensitive").addEventListener("change", saveToStorage);
-          document.getElementById("trimWhitespace").addEventListener("change", saveToStorage);
-          document.getElementById("skipEmpty").addEventListener("change", saveToStorage);
-
-          // Keyboard shortcut
-          document.addEventListener("keydown", function (e) {
-            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-              e.preventDefault();
-              applyFilter();
-            }
-          });
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/data-merger.html
+++ b/tools/data/data-merger.html
@@ -27,7 +27,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="数据合并器 - WebUtils" />
-    <meta name="twitter:description" content="合并多个数据集，支持追加、交错、去重、CSV列合并模式" />
+    <meta
+      name="twitter:description"
+      content="合并多个数据集，支持追加、交错、去重、CSV列合并模式"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "数据合并器",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-merger.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据合并器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-merger.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "数据合并器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "数据合并器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,810 +91,813 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .data-inputs {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
 
-  @media (max-width: 768px) {
-    .data-inputs {
-      grid-template-columns: 1fr;
-    }
-  }
+      .data-inputs {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
 
-  .options-row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-bottom: 16px;
-  }
+      @media (max-width: 768px) {
+        .data-inputs {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .option-group {
-    flex: 1;
-    min-width: 200px;
-  }
+      .options-row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 16px;
+      }
 
-  .radio-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
+      .option-group {
+        flex: 1;
+        min-width: 200px;
+      }
 
-  .radio-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .radio-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
 
-  .radio-item:hover {
-    border-color: var(--color-accent-cyan);
-  }
+      .radio-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .radio-item.active {
-    border-color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.1);
-  }
+      .radio-item:hover {
+        border-color: var(--color-accent-cyan);
+      }
 
-  .radio-item input {
-    display: none;
-  }
+      .radio-item.active {
+        border-color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.1);
+      }
 
-  .radio-item span {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-primary);
-  }
+      .radio-item input {
+        display: none;
+      }
 
-  .checkbox-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .radio-item span {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-primary);
+      }
 
-  .checkbox-item:hover {
-    border-color: var(--color-accent-cyan);
-  }
+      .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .checkbox-item input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    accent-color: var(--color-accent-cyan);
-  }
+      .checkbox-item:hover {
+        border-color: var(--color-accent-cyan);
+      }
 
-  .checkbox-item span {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-primary);
-  }
+      .checkbox-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .checkbox-item span {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-primary);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-accent-cyan);
-    min-height: 150px;
-    max-height: 400px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-accent-cyan);
+        min-height: 150px;
+        max-height: 400px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
 
-  .stat-item {
-    padding: 12px 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex: 1;
-    min-width: 120px;
-    text-align: center;
-  }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
 
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .stat-item {
+        padding: 12px 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex: 1;
+        min-width: 120px;
+        text-align: center;
+      }
 
-  .stat-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .stat-label {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据合并器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔗</span>
-        数据合并器
-      </h1>
-      <p>合并多个数据集，支持追加、交错、去重模式</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">数据输入</div>
-      <div class="data-inputs">
-        <div class="input-group">
-          <label class="input-label">数据集 A</label>
-          <textarea id="inputA" placeholder="输入第一个数据集（每行一条数据）..."></textarea>
-        </div>
-        <div class="input-group">
-          <label class="input-label">数据集 B</label>
-          <textarea id="inputB" placeholder="输入第二个数据集（每行一条数据）..."></textarea>
-        </div>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">合并选项</div>
-      <div class="options-row">
-        <div class="option-group">
-          <label class="input-label">合并模式</label>
-          <div class="radio-group" id="mergeMode">
-            <label class="radio-item active">
-              <input type="radio" name="mode" value="append" checked="">
-              <span>追加 (A+B)</span>
-            </label>
-            <label class="radio-item">
-              <input type="radio" name="mode" value="interleave">
-              <span>交错</span>
-            </label>
-            <label class="radio-item">
-              <input type="radio" name="mode" value="union">
-              <span>去重合并</span>
-            </label>
-            <label class="radio-item">
-              <input type="radio" name="mode" value="csv-column">
-              <span>CSV列合并</span>
-            </label>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据合并器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔗</span>
+              数据合并器
+            </h1>
+            <p>合并多个数据集，支持追加、交错、去重模式</p>
           </div>
-        </div>
-      </div>
-      <div class="options-row">
-        <div class="option-group">
-          <label class="checkbox-item">
-            <input type="checkbox" id="trimLines" checked="">
-            <span>去除首尾空白</span>
-          </label>
-        </div>
-        <div class="option-group">
-          <label class="checkbox-item">
-            <input type="checkbox" id="skipEmpty" checked="">
-            <span>跳过空行</span>
-          </label>
-        </div>
-        <div class="option-group" id="delimiterGroup" style="display: none">
-          <label class="input-label">CSV分隔符</label>
-          <input type="text" id="delimiter" value="," style="width: 80px">
-        </div>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="mergeData()">🔗 合并数据</button>
-        <button class="btn btn-secondary" onclick="swapInputs()">🔄 交换A/B</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+        </header>
+
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">数据输入</div>
+            <div class="data-inputs">
+              <div class="input-group">
+                <label class="input-label">数据集 A</label>
+                <textarea id="inputA" placeholder="输入第一个数据集（每行一条数据）..."></textarea>
+              </div>
+              <div class="input-group">
+                <label class="input-label">数据集 B</label>
+                <textarea id="inputB" placeholder="输入第二个数据集（每行一条数据）..."></textarea>
+              </div>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">合并选项</div>
+            <div class="options-row">
+              <div class="option-group">
+                <label class="input-label">合并模式</label>
+                <div class="radio-group" id="mergeMode">
+                  <label class="radio-item active">
+                    <input type="radio" name="mode" value="append" checked="" />
+                    <span>追加 (A+B)</span>
+                  </label>
+                  <label class="radio-item">
+                    <input type="radio" name="mode" value="interleave" />
+                    <span>交错</span>
+                  </label>
+                  <label class="radio-item">
+                    <input type="radio" name="mode" value="union" />
+                    <span>去重合并</span>
+                  </label>
+                  <label class="radio-item">
+                    <input type="radio" name="mode" value="csv-column" />
+                    <span>CSV列合并</span>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="options-row">
+              <div class="option-group">
+                <label class="checkbox-item">
+                  <input type="checkbox" id="trimLines" checked="" />
+                  <span>去除首尾空白</span>
+                </label>
+              </div>
+              <div class="option-group">
+                <label class="checkbox-item">
+                  <input type="checkbox" id="skipEmpty" checked="" />
+                  <span>跳过空行</span>
+                </label>
+              </div>
+              <div class="option-group" id="delimiterGroup" style="display: none">
+                <label class="input-label">CSV分隔符</label>
+                <input type="text" id="delimiter" value="," style="width: 80px" />
+              </div>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="mergeData()">🔗 合并数据</button>
+              <button class="btn btn-secondary" onclick="swapInputs()">🔄 交换A/B</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">合并结果</div>
+            <div class="stats-row">
+              <div class="stat-item">
+                <div class="stat-value" id="countA">0</div>
+                <div class="stat-label">数据集A行数</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-value" id="countB">0</div>
+                <div class="stat-label">数据集B行数</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-value" id="countResult">0</div>
+                <div class="stat-label">合并后行数</div>
+              </div>
+              <div class="stat-item" id="removedStat" style="display: none">
+                <div class="stat-value" id="countRemoved">0</div>
+                <div class="stat-label">去重移除</div>
+              </div>
+            </div>
+            <div class="result-box" id="result">合并结果将显示在这里...</div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
+              <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="tool-section">
-      <div class="section-title">合并结果</div>
-      <div class="stats-row">
-        <div class="stat-item">
-          <div class="stat-value" id="countA">0</div>
-          <div class="stat-label">数据集A行数</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="countB">0</div>
-          <div class="stat-label">数据集B行数</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="countResult">0</div>
-          <div class="stat-label">合并后行数</div>
-        </div>
-        <div class="stat-item" id="removedStat" style="display: none">
-          <div class="stat-value" id="countRemoved">0</div>
-          <div class="stat-label">去重移除</div>
-        </div>
-      </div>
-      <div class="result-box" id="result">合并结果将显示在这里...</div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
-        <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据合并器",
-              "item": "https://tools.realtime-ai.chat/tools/data/data-merger.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据合并器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-merger.html"
+          }
+        ]
+      }
     </script>
     <script>
+      const LS_KEY = "data-merger-state";
 
-  const LS_KEY = "data-merger-state";
+      // Elements
+      const inputA = document.getElementById("inputA");
+      const inputB = document.getElementById("inputB");
+      const resultEl = document.getElementById("result");
+      const trimLinesEl = document.getElementById("trimLines");
+      const skipEmptyEl = document.getElementById("skipEmpty");
+      const delimiterEl = document.getElementById("delimiter");
+      const delimiterGroup = document.getElementById("delimiterGroup");
 
-        // Elements
-        const inputA = document.getElementById("inputA");
-        const inputB = document.getElementById("inputB");
-        const resultEl = document.getElementById("result");
-        const trimLinesEl = document.getElementById("trimLines");
-        const skipEmptyEl = document.getElementById("skipEmpty");
-        const delimiterEl = document.getElementById("delimiter");
-        const delimiterGroup = document.getElementById("delimiterGroup");
-
-        // Radio group handling
-        document.querySelectorAll("#mergeMode .radio-item").forEach((item) => {
-          item.addEventListener("click", function () {
-            document.querySelectorAll("#mergeMode .radio-item").forEach((i) => {
-              i.classList.remove("active");
-            });
-            this.classList.add("active");
-            this.querySelector("input").checked = true;
-
-            // Show/hide delimiter option for CSV mode
-            const mode = this.querySelector("input").value;
-            delimiterGroup.style.display = mode === "csv-column" ? "block" : "none";
+      // Radio group handling
+      document.querySelectorAll("#mergeMode .radio-item").forEach((item) => {
+        item.addEventListener("click", function () {
+          document.querySelectorAll("#mergeMode .radio-item").forEach((i) => {
+            i.classList.remove("active");
           });
+          this.classList.add("active");
+          this.querySelector("input").checked = true;
+
+          // Show/hide delimiter option for CSV mode
+          const mode = this.querySelector("input").value;
+          delimiterGroup.style.display = mode === "csv-column" ? "block" : "none";
         });
+      });
 
-        // Get current merge mode
-        function getMergeMode() {
-          return document.querySelector('input[name="mode"]:checked').value;
+      // Get current merge mode
+      function getMergeMode() {
+        return document.querySelector('input[name="mode"]:checked').value;
+      }
+
+      // Parse lines from text
+      function parseLines(text) {
+        let lines = text.split("\n");
+        if (trimLinesEl.checked) {
+          lines = lines.map((l) => l.trim());
         }
-
-        // Parse lines from text
-        function parseLines(text) {
-          let lines = text.split("\n");
-          if (trimLinesEl.checked) {
-            lines = lines.map((l) => l.trim());
-          }
-          if (skipEmptyEl.checked) {
-            lines = lines.filter((l) => l !== "");
-          }
-          return lines;
+        if (skipEmptyEl.checked) {
+          lines = lines.filter((l) => l !== "");
         }
+        return lines;
+      }
 
-        // Merge data
-        function mergeData() {
-          const linesA = parseLines(inputA.value);
-          const linesB = parseLines(inputB.value);
-          const mode = getMergeMode();
+      // Merge data
+      function mergeData() {
+        const linesA = parseLines(inputA.value);
+        const linesB = parseLines(inputB.value);
+        const mode = getMergeMode();
 
-          let result = [];
-          let removed = 0;
+        let result = [];
+        let removed = 0;
 
-          switch (mode) {
-            case "append":
-              result = [...linesA, ...linesB];
-              break;
+        switch (mode) {
+          case "append":
+            result = [...linesA, ...linesB];
+            break;
 
-            case "interleave":
-              const maxLen = Math.max(linesA.length, linesB.length);
-              for (let i = 0; i < maxLen; i++) {
-                if (i < linesA.length) result.push(linesA[i]);
-                if (i < linesB.length) result.push(linesB[i]);
-              }
-              break;
-
-            case "union":
-              const totalBefore = linesA.length + linesB.length;
-              const uniqueSet = new Set([...linesA, ...linesB]);
-              result = [...uniqueSet];
-              removed = totalBefore - result.length;
-              break;
-
-            case "csv-column":
-              const delimiter = delimiterEl.value || ",";
-              const maxRows = Math.max(linesA.length, linesB.length);
-              for (let i = 0; i < maxRows; i++) {
-                const a = i < linesA.length ? linesA[i] : "";
-                const b = i < linesB.length ? linesB[i] : "";
-                result.push(a + delimiter + b);
-              }
-              break;
-          }
-
-          // Update stats
-          document.getElementById("countA").textContent = linesA.length;
-          document.getElementById("countB").textContent = linesB.length;
-          document.getElementById("countResult").textContent = result.length;
-
-          const removedStat = document.getElementById("removedStat");
-          if (mode === "union") {
-            removedStat.style.display = "block";
-            document.getElementById("countRemoved").textContent = removed;
-          } else {
-            removedStat.style.display = "none";
-          }
-
-          resultEl.textContent = result.length > 0 ? result.join("\n") : "（无数据）";
-          saveState();
-          showToast("合并完成");
-        }
-
-        // Swap inputs
-        function swapInputs() {
-          const tempA = inputA.value;
-          inputA.value = inputB.value;
-          inputB.value = tempA;
-          saveState();
-          showToast("已交换数据集");
-        }
-
-        // Copy result
-        function copyResult() {
-          const text = resultEl.textContent;
-          if (!text || text === "合并结果将显示在这里..." || text === "（无数据）") {
-            showToast("没有可复制的内容");
-            return;
-          }
-          navigator.clipboard.writeText(text).then(() => {
-            showToast("已复制到剪贴板");
-          });
-        }
-
-        // Download result
-        function downloadResult() {
-          const text = resultEl.textContent;
-          if (!text || text === "合并结果将显示在这里..." || text === "（无数据）") {
-            showToast("没有可下载的内容");
-            return;
-          }
-          const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "merged-data.txt";
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast("下载已开始");
-        }
-
-        // Clear all
-        function clearAll() {
-          inputA.value = "";
-          inputB.value = "";
-          resultEl.textContent = "合并结果将显示在这里...";
-          document.getElementById("countA").textContent = "0";
-          document.getElementById("countB").textContent = "0";
-          document.getElementById("countResult").textContent = "0";
-          document.getElementById("removedStat").style.display = "none";
-          localStorage.removeItem(LS_KEY);
-          showToast("已清空");
-        }
-
-        // Save state
-        function saveState() {
-          const state = {
-            inputA: inputA.value,
-            inputB: inputB.value,
-            mode: getMergeMode(),
-            trimLines: trimLinesEl.checked,
-            skipEmpty: skipEmptyEl.checked,
-            delimiter: delimiterEl.value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
-        }
-
-        // Load state
-        function loadState() {
-          try {
-            const saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              const state = JSON.parse(saved);
-              inputA.value = state.inputA || "";
-              inputB.value = state.inputB || "";
-              trimLinesEl.checked = state.trimLines !== false;
-              skipEmptyEl.checked = state.skipEmpty !== false;
-              delimiterEl.value = state.delimiter || ",";
-
-              if (state.mode) {
-                document.querySelectorAll("#mergeMode .radio-item").forEach((item) => {
-                  const radio = item.querySelector("input");
-                  if (radio.value === state.mode) {
-                    item.classList.add("active");
-                    radio.checked = true;
-                    if (state.mode === "csv-column") {
-                      delimiterGroup.style.display = "block";
-                    }
-                  } else {
-                    item.classList.remove("active");
-                  }
-                });
-              }
+          case "interleave":
+            const maxLen = Math.max(linesA.length, linesB.length);
+            for (let i = 0; i < maxLen; i++) {
+              if (i < linesA.length) result.push(linesA[i]);
+              if (i < linesB.length) result.push(linesB[i]);
             }
-          } catch {
-            // ignore
+            break;
+
+          case "union":
+            const totalBefore = linesA.length + linesB.length;
+            const uniqueSet = new Set([...linesA, ...linesB]);
+            result = [...uniqueSet];
+            removed = totalBefore - result.length;
+            break;
+
+          case "csv-column":
+            const delimiter = delimiterEl.value || ",";
+            const maxRows = Math.max(linesA.length, linesB.length);
+            for (let i = 0; i < maxRows; i++) {
+              const a = i < linesA.length ? linesA[i] : "";
+              const b = i < linesB.length ? linesB[i] : "";
+              result.push(a + delimiter + b);
+            }
+            break;
+        }
+
+        // Update stats
+        document.getElementById("countA").textContent = linesA.length;
+        document.getElementById("countB").textContent = linesB.length;
+        document.getElementById("countResult").textContent = result.length;
+
+        const removedStat = document.getElementById("removedStat");
+        if (mode === "union") {
+          removedStat.style.display = "block";
+          document.getElementById("countRemoved").textContent = removed;
+        } else {
+          removedStat.style.display = "none";
+        }
+
+        resultEl.textContent = result.length > 0 ? result.join("\n") : "（无数据）";
+        saveState();
+        showToast("合并完成");
+      }
+
+      // Swap inputs
+      function swapInputs() {
+        const tempA = inputA.value;
+        inputA.value = inputB.value;
+        inputB.value = tempA;
+        saveState();
+        showToast("已交换数据集");
+      }
+
+      // Copy result
+      function copyResult() {
+        const text = resultEl.textContent;
+        if (!text || text === "合并结果将显示在这里..." || text === "（无数据）") {
+          showToast("没有可复制的内容");
+          return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+          showToast("已复制到剪贴板");
+        });
+      }
+
+      // Download result
+      function downloadResult() {
+        const text = resultEl.textContent;
+        if (!text || text === "合并结果将显示在这里..." || text === "（无数据）") {
+          showToast("没有可下载的内容");
+          return;
+        }
+        const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "merged-data.txt";
+        a.click();
+        URL.revokeObjectURL(url);
+        showToast("下载已开始");
+      }
+
+      // Clear all
+      function clearAll() {
+        inputA.value = "";
+        inputB.value = "";
+        resultEl.textContent = "合并结果将显示在这里...";
+        document.getElementById("countA").textContent = "0";
+        document.getElementById("countB").textContent = "0";
+        document.getElementById("countResult").textContent = "0";
+        document.getElementById("removedStat").style.display = "none";
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
+
+      // Save state
+      function saveState() {
+        const state = {
+          inputA: inputA.value,
+          inputB: inputB.value,
+          mode: getMergeMode(),
+          trimLines: trimLinesEl.checked,
+          skipEmpty: skipEmptyEl.checked,
+          delimiter: delimiterEl.value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
+
+      // Load state
+      function loadState() {
+        try {
+          const saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            const state = JSON.parse(saved);
+            inputA.value = state.inputA || "";
+            inputB.value = state.inputB || "";
+            trimLinesEl.checked = state.trimLines !== false;
+            skipEmptyEl.checked = state.skipEmpty !== false;
+            delimiterEl.value = state.delimiter || ",";
+
+            if (state.mode) {
+              document.querySelectorAll("#mergeMode .radio-item").forEach((item) => {
+                const radio = item.querySelector("input");
+                if (radio.value === state.mode) {
+                  item.classList.add("active");
+                  radio.checked = true;
+                  if (state.mode === "csv-column") {
+                    delimiterGroup.style.display = "block";
+                  }
+                } else {
+                  item.classList.remove("active");
+                }
+              });
+            }
           }
+        } catch {
+          // ignore
         }
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Theme toggle
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Show toast
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // Init theme
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // Show toast
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
+      // Auto-save on input
+      inputA.addEventListener("input", saveState);
+      inputB.addEventListener("input", saveState);
 
-        // Init theme
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+      // Load state on init
+      loadState();
+    </script>
 
-        // Auto-save on input
-        inputA.addEventListener("input", saveState);
-        inputB.addEventListener("input", saveState);
-
-        // Load state on init
-        loadState();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/data-sampler.html
+++ b/tools/data/data-sampler.html
@@ -27,7 +27,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="数据采样器 - WebUtils" />
-    <meta name="twitter:description" content="从数据集中采样，支持随机、前N条、后N条、每N条等模式" />
+    <meta
+      name="twitter:description"
+      content="从数据集中采样，支持随机、前N条、后N条、每N条等模式"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "数据采样器",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-sampler.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据采样器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-sampler.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "数据采样器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "数据采样器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,842 +91,848 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .options-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-    margin-bottom: 16px;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  .option-card {
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-  }
+      .options-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin-bottom: 16px;
+      }
 
-  .option-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-accent-cyan);
-    margin-bottom: 12px;
-    font-weight: 600;
-  }
+      .option-card {
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+      }
 
-  .mode-selector {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 16px;
-  }
+      .option-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-accent-cyan);
+        margin-bottom: 12px;
+        font-weight: 600;
+      }
 
-  .mode-btn {
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .mode-selector {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
 
-  .mode-btn:hover {
-    border-color: var(--color-accent-cyan);
-  }
+      .mode-btn {
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .mode-btn.active {
-    background: rgba(0, 245, 212, 0.1);
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .mode-btn:hover {
+        border-color: var(--color-accent-cyan);
+      }
 
-  .size-input-row {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-  }
+      .mode-btn.active {
+        background: rgba(0, 245, 212, 0.1);
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .size-input-row input {
-    width: 100px;
-  }
+      .size-input-row {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
 
-  .size-input-row select {
-    width: 120px;
-  }
+      .size-input-row input {
+        width: 100px;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .size-input-row select {
+        width: 120px;
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-accent-cyan);
-    min-height: 180px;
-    max-height: 400px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-accent-cyan);
+        min-height: 180px;
+        max-height: 400px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
 
-  .stat-item {
-    padding: 12px 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex: 1;
-    min-width: 100px;
-    text-align: center;
-  }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
 
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .stat-item {
+        padding: 12px 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex: 1;
+        min-width: 100px;
+        text-align: center;
+      }
 
-  .stat-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .stat-label {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .hidden {
-    display: none !important;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .hidden {
+        display: none !important;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .size-input-row {
-      flex-wrap: wrap;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .size-input-row {
+          flex-wrap: wrap;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据采样器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🎲</span>
-        数据采样器
-      </h1>
-      <p>从数据集中采样，支持随机、前N条、后N条、每N条模式</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据采样器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🎲</span>
+              数据采样器
+            </h1>
+            <p>从数据集中采样，支持随机、前N条、后N条、每N条模式</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">数据输入</div>
-      <div class="input-group">
-        <label class="input-label">输入数据（每行一条）</label>
-        <textarea id="input" placeholder="输入数据集，每行一条...
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">数据输入</div>
+            <div class="input-group">
+              <label class="input-label">输入数据（每行一条）</label>
+              <textarea
+                id="input"
+                placeholder="输入数据集，每行一条...
 示例:
 Item 1
 Item 2
 Item 3
 Item 4
-Item 5"></textarea>
+Item 5"
+              ></textarea>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">采样设置</div>
+            <div class="mode-selector">
+              <button class="mode-btn active" data-mode="random">🎲 随机采样</button>
+              <button class="mode-btn" data-mode="first">⬆️ 前 N 条</button>
+              <button class="mode-btn" data-mode="last">⬇️ 后 N 条</button>
+              <button class="mode-btn" data-mode="every">🔢 每 N 条</button>
+              <button class="mode-btn" data-mode="range">📍 指定范围</button>
+            </div>
+
+            <div class="options-grid">
+              <div class="option-card" id="sizeOption">
+                <div class="option-title">采样数量</div>
+                <div class="size-input-row">
+                  <input type="number" id="sampleSize" value="10" min="1" />
+                  <select id="sizeType">
+                    <option value="count">条</option>
+                    <option value="percent">%</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="option-card hidden" id="everyOption">
+                <div class="option-title">间隔设置</div>
+                <div class="size-input-row">
+                  <span style="color: var(--color-text-secondary)">每</span>
+                  <input type="number" id="everyN" value="2" min="1" style="width: 60px" />
+                  <span style="color: var(--color-text-secondary)">条取 1 条</span>
+                </div>
+              </div>
+
+              <div class="option-card hidden" id="rangeOption">
+                <div class="option-title">范围设置</div>
+                <div class="size-input-row">
+                  <span style="color: var(--color-text-secondary)">从第</span>
+                  <input type="number" id="rangeStart" value="1" min="1" style="width: 60px" />
+                  <span style="color: var(--color-text-secondary)">到第</span>
+                  <input type="number" id="rangeEnd" value="10" min="1" style="width: 60px" />
+                  <span style="color: var(--color-text-secondary)">条</span>
+                </div>
+              </div>
+
+              <div class="option-card" id="seedOption">
+                <div class="option-title">随机种子（可选）</div>
+                <input type="number" id="seed" placeholder="留空则每次随机" />
+                <div style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 4px">
+                  相同种子可重现相同结果
+                </div>
+              </div>
+            </div>
+
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="sampleData()">🎲 采样</button>
+              <button class="btn btn-secondary" onclick="resample()">🔄 重新采样</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">采样结果</div>
+            <div class="stats-row">
+              <div class="stat-item">
+                <div class="stat-value" id="inputCount">0</div>
+                <div class="stat-label">输入总数</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-value" id="outputCount">0</div>
+                <div class="stat-label">采样数量</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-value" id="samplePercent">0%</div>
+                <div class="stat-label">采样比例</div>
+              </div>
+            </div>
+            <div class="result-box" id="result">采样结果将显示在这里...</div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
+              <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="tool-section">
-      <div class="section-title">采样设置</div>
-      <div class="mode-selector">
-        <button class="mode-btn active" data-mode="random">🎲 随机采样</button>
-        <button class="mode-btn" data-mode="first">⬆️ 前 N 条</button>
-        <button class="mode-btn" data-mode="last">⬇️ 后 N 条</button>
-        <button class="mode-btn" data-mode="every">🔢 每 N 条</button>
-        <button class="mode-btn" data-mode="range">📍 指定范围</button>
-      </div>
-
-      <div class="options-grid">
-        <div class="option-card" id="sizeOption">
-          <div class="option-title">采样数量</div>
-          <div class="size-input-row">
-            <input type="number" id="sampleSize" value="10" min="1">
-            <select id="sizeType">
-              <option value="count">条</option>
-              <option value="percent">%</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="option-card hidden" id="everyOption">
-          <div class="option-title">间隔设置</div>
-          <div class="size-input-row">
-            <span style="color: var(--color-text-secondary)">每</span>
-            <input type="number" id="everyN" value="2" min="1" style="width: 60px">
-            <span style="color: var(--color-text-secondary)">条取 1 条</span>
-          </div>
-        </div>
-
-        <div class="option-card hidden" id="rangeOption">
-          <div class="option-title">范围设置</div>
-          <div class="size-input-row">
-            <span style="color: var(--color-text-secondary)">从第</span>
-            <input type="number" id="rangeStart" value="1" min="1" style="width: 60px">
-            <span style="color: var(--color-text-secondary)">到第</span>
-            <input type="number" id="rangeEnd" value="10" min="1" style="width: 60px">
-            <span style="color: var(--color-text-secondary)">条</span>
-          </div>
-        </div>
-
-        <div class="option-card" id="seedOption">
-          <div class="option-title">随机种子（可选）</div>
-          <input type="number" id="seed" placeholder="留空则每次随机">
-          <div style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 4px">
-            相同种子可重现相同结果
-          </div>
-        </div>
-      </div>
-
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="sampleData()">🎲 采样</button>
-        <button class="btn btn-secondary" onclick="resample()">🔄 重新采样</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">采样结果</div>
-      <div class="stats-row">
-        <div class="stat-item">
-          <div class="stat-value" id="inputCount">0</div>
-          <div class="stat-label">输入总数</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="outputCount">0</div>
-          <div class="stat-label">采样数量</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="samplePercent">0%</div>
-          <div class="stat-label">采样比例</div>
-        </div>
-      </div>
-      <div class="result-box" id="result">采样结果将显示在这里...</div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
-        <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据采样器",
-              "item": "https://tools.realtime-ai.chat/tools/data/data-sampler.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据采样器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-sampler.html"
+          }
+        ]
+      }
     </script>
     <script>
+      const LS_KEY = "data-sampler-state";
+      let currentMode = "random";
+      let lastResult = [];
 
-  const LS_KEY = "data-sampler-state";
-        let currentMode = "random";
-        let lastResult = [];
+      // Elements
+      const inputEl = document.getElementById("input");
+      const resultEl = document.getElementById("result");
+      const sizeOption = document.getElementById("sizeOption");
+      const everyOption = document.getElementById("everyOption");
+      const rangeOption = document.getElementById("rangeOption");
+      const seedOption = document.getElementById("seedOption");
 
-        // Elements
-        const inputEl = document.getElementById("input");
-        const resultEl = document.getElementById("result");
-        const sizeOption = document.getElementById("sizeOption");
-        const everyOption = document.getElementById("everyOption");
-        const rangeOption = document.getElementById("rangeOption");
-        const seedOption = document.getElementById("seedOption");
-
-        // Mode selector
-        document.querySelectorAll(".mode-btn").forEach((btn) => {
-          btn.addEventListener("click", function () {
-            document.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
-            this.classList.add("active");
-            currentMode = this.dataset.mode;
-            updateOptionsVisibility();
-            saveState();
-          });
-        });
-
-        // Update options visibility based on mode
-        function updateOptionsVisibility() {
-          sizeOption.classList.toggle("hidden", currentMode === "every" || currentMode === "range");
-          everyOption.classList.toggle("hidden", currentMode !== "every");
-          rangeOption.classList.toggle("hidden", currentMode !== "range");
-          seedOption.classList.toggle("hidden", currentMode !== "random");
-        }
-
-        // Parse lines
-        function parseLines(text) {
-          return text
-            .split("\n")
-            .map((l) => l.trim())
-            .filter((l) => l !== "");
-        }
-
-        // Seeded random generator (mulberry32)
-        function seededRandom(seed) {
-          return function () {
-            let t = (seed += 0x6d2b79f5);
-            t = Math.imul(t ^ (t >>> 15), t | 1);
-            t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-          };
-        }
-
-        // Shuffle array with optional seed
-        function shuffleArray(arr, seed) {
-          const result = [...arr];
-          const random = seed !== null ? seededRandom(seed) : Math.random;
-          for (let i = result.length - 1; i > 0; i--) {
-            const j = Math.floor(random() * (i + 1));
-            [result[i], result[j]] = [result[j], result[i]];
-          }
-          return result;
-        }
-
-        // Sample data
-        function sampleData() {
-          const lines = parseLines(inputEl.value);
-          if (lines.length === 0) {
-            showToast("请输入数据");
-            return;
-          }
-
-          let result = [];
-
-          switch (currentMode) {
-            case "random": {
-              const sizeType = document.getElementById("sizeType").value;
-              let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
-              const seedInput = document.getElementById("seed").value;
-              const seed = seedInput ? parseInt(seedInput) : null;
-
-              if (sizeType === "percent") {
-                sampleSize = Math.ceil((sampleSize / 100) * lines.length);
-              }
-              sampleSize = Math.min(sampleSize, lines.length);
-
-              const shuffled = shuffleArray(lines, seed);
-              result = shuffled.slice(0, sampleSize);
-              break;
-            }
-
-            case "first": {
-              const sizeType = document.getElementById("sizeType").value;
-              let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
-
-              if (sizeType === "percent") {
-                sampleSize = Math.ceil((sampleSize / 100) * lines.length);
-              }
-              sampleSize = Math.min(sampleSize, lines.length);
-
-              result = lines.slice(0, sampleSize);
-              break;
-            }
-
-            case "last": {
-              const sizeType = document.getElementById("sizeType").value;
-              let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
-
-              if (sizeType === "percent") {
-                sampleSize = Math.ceil((sampleSize / 100) * lines.length);
-              }
-              sampleSize = Math.min(sampleSize, lines.length);
-
-              result = lines.slice(-sampleSize);
-              break;
-            }
-
-            case "every": {
-              const everyN = parseInt(document.getElementById("everyN").value) || 2;
-              for (let i = 0; i < lines.length; i += everyN) {
-                result.push(lines[i]);
-              }
-              break;
-            }
-
-            case "range": {
-              const start = parseInt(document.getElementById("rangeStart").value) || 1;
-              const end = parseInt(document.getElementById("rangeEnd").value) || 10;
-              const actualStart = Math.max(0, Math.min(start - 1, lines.length - 1));
-              const actualEnd = Math.min(end, lines.length);
-              result = lines.slice(actualStart, actualEnd);
-              break;
-            }
-          }
-
-          lastResult = result;
-
-          // Update stats
-          document.getElementById("inputCount").textContent = lines.length;
-          document.getElementById("outputCount").textContent = result.length;
-          document.getElementById("samplePercent").textContent =
-            lines.length > 0 ? ((result.length / lines.length) * 100).toFixed(1) + "%" : "0%";
-
-          resultEl.textContent = result.length > 0 ? result.join("\n") : "（无数据）";
+      // Mode selector
+      document.querySelectorAll(".mode-btn").forEach((btn) => {
+        btn.addEventListener("click", function () {
+          document.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+          this.classList.add("active");
+          currentMode = this.dataset.mode;
+          updateOptionsVisibility();
           saveState();
-          showToast("采样完成");
+        });
+      });
+
+      // Update options visibility based on mode
+      function updateOptionsVisibility() {
+        sizeOption.classList.toggle("hidden", currentMode === "every" || currentMode === "range");
+        everyOption.classList.toggle("hidden", currentMode !== "every");
+        rangeOption.classList.toggle("hidden", currentMode !== "range");
+        seedOption.classList.toggle("hidden", currentMode !== "random");
+      }
+
+      // Parse lines
+      function parseLines(text) {
+        return text
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l !== "");
+      }
+
+      // Seeded random generator (mulberry32)
+      function seededRandom(seed) {
+        return function () {
+          let t = (seed += 0x6d2b79f5);
+          t = Math.imul(t ^ (t >>> 15), t | 1);
+          t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+          return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
+      }
+
+      // Shuffle array with optional seed
+      function shuffleArray(arr, seed) {
+        const result = [...arr];
+        const random = seed !== null ? seededRandom(seed) : Math.random;
+        for (let i = result.length - 1; i > 0; i--) {
+          const j = Math.floor(random() * (i + 1));
+          [result[i], result[j]] = [result[j], result[i]];
+        }
+        return result;
+      }
+
+      // Sample data
+      function sampleData() {
+        const lines = parseLines(inputEl.value);
+        if (lines.length === 0) {
+          showToast("请输入数据");
+          return;
         }
 
-        // Resample (for random mode)
-        function resample() {
-          if (currentMode === "random") {
-            // Clear seed for new random
-            document.getElementById("seed").value = "";
-          }
-          sampleData();
-        }
+        let result = [];
 
-        // Copy result
-        function copyResult() {
-          if (lastResult.length === 0) {
-            showToast("没有可复制的内容");
-            return;
-          }
-          navigator.clipboard.writeText(lastResult.join("\n")).then(() => {
-            showToast("已复制到剪贴板");
-          });
-        }
+        switch (currentMode) {
+          case "random": {
+            const sizeType = document.getElementById("sizeType").value;
+            let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
+            const seedInput = document.getElementById("seed").value;
+            const seed = seedInput ? parseInt(seedInput) : null;
 
-        // Download result
-        function downloadResult() {
-          if (lastResult.length === 0) {
-            showToast("没有可下载的内容");
-            return;
-          }
-          const blob = new Blob([lastResult.join("\n")], {
-            type: "text/plain;charset=utf-8"
-          });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "sampled-data.txt";
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast("下载已开始");
-        }
-
-        // Clear all
-        function clearAll() {
-          inputEl.value = "";
-          resultEl.textContent = "采样结果将显示在这里...";
-          lastResult = [];
-          document.getElementById("inputCount").textContent = "0";
-          document.getElementById("outputCount").textContent = "0";
-          document.getElementById("samplePercent").textContent = "0%";
-          localStorage.removeItem(LS_KEY);
-          showToast("已清空");
-        }
-
-        // Save state
-        function saveState() {
-          const state = {
-            input: inputEl.value,
-            mode: currentMode,
-            sampleSize: document.getElementById("sampleSize").value,
-            sizeType: document.getElementById("sizeType").value,
-            everyN: document.getElementById("everyN").value,
-            rangeStart: document.getElementById("rangeStart").value,
-            rangeEnd: document.getElementById("rangeEnd").value,
-            seed: document.getElementById("seed").value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
-        }
-
-        // Load state
-        function loadState() {
-          try {
-            const saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              const state = JSON.parse(saved);
-              inputEl.value = state.input || "";
-
-              if (state.mode) {
-                currentMode = state.mode;
-                document.querySelectorAll(".mode-btn").forEach((btn) => {
-                  if (btn.dataset.mode === state.mode) {
-                    btn.classList.add("active");
-                  } else {
-                    btn.classList.remove("active");
-                  }
-                });
-                updateOptionsVisibility();
-              }
-
-              document.getElementById("sampleSize").value = state.sampleSize || "10";
-              document.getElementById("sizeType").value = state.sizeType || "count";
-              document.getElementById("everyN").value = state.everyN || "2";
-              document.getElementById("rangeStart").value = state.rangeStart || "1";
-              document.getElementById("rangeEnd").value = state.rangeEnd || "10";
-              document.getElementById("seed").value = state.seed || "";
+            if (sizeType === "percent") {
+              sampleSize = Math.ceil((sampleSize / 100) * lines.length);
             }
-          } catch {
-            // ignore
+            sampleSize = Math.min(sampleSize, lines.length);
+
+            const shuffled = shuffleArray(lines, seed);
+            result = shuffled.slice(0, sampleSize);
+            break;
+          }
+
+          case "first": {
+            const sizeType = document.getElementById("sizeType").value;
+            let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
+
+            if (sizeType === "percent") {
+              sampleSize = Math.ceil((sampleSize / 100) * lines.length);
+            }
+            sampleSize = Math.min(sampleSize, lines.length);
+
+            result = lines.slice(0, sampleSize);
+            break;
+          }
+
+          case "last": {
+            const sizeType = document.getElementById("sizeType").value;
+            let sampleSize = parseInt(document.getElementById("sampleSize").value) || 10;
+
+            if (sizeType === "percent") {
+              sampleSize = Math.ceil((sampleSize / 100) * lines.length);
+            }
+            sampleSize = Math.min(sampleSize, lines.length);
+
+            result = lines.slice(-sampleSize);
+            break;
+          }
+
+          case "every": {
+            const everyN = parseInt(document.getElementById("everyN").value) || 2;
+            for (let i = 0; i < lines.length; i += everyN) {
+              result.push(lines[i]);
+            }
+            break;
+          }
+
+          case "range": {
+            const start = parseInt(document.getElementById("rangeStart").value) || 1;
+            const end = parseInt(document.getElementById("rangeEnd").value) || 10;
+            const actualStart = Math.max(0, Math.min(start - 1, lines.length - 1));
+            const actualEnd = Math.min(end, lines.length);
+            result = lines.slice(actualStart, actualEnd);
+            break;
           }
         }
 
-        // Theme toggle
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
+        lastResult = result;
 
-        // Show toast
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
+        // Update stats
+        document.getElementById("inputCount").textContent = lines.length;
+        document.getElementById("outputCount").textContent = result.length;
+        document.getElementById("samplePercent").textContent =
+          lines.length > 0 ? ((result.length / lines.length) * 100).toFixed(1) + "%" : "0%";
 
-        // Init theme
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
+        resultEl.textContent = result.length > 0 ? result.join("\n") : "（无数据）";
+        saveState();
+        showToast("采样完成");
+      }
+
+      // Resample (for random mode)
+      function resample() {
+        if (currentMode === "random") {
+          // Clear seed for new random
+          document.getElementById("seed").value = "";
+        }
+        sampleData();
+      }
+
+      // Copy result
+      function copyResult() {
+        if (lastResult.length === 0) {
+          showToast("没有可复制的内容");
+          return;
+        }
+        navigator.clipboard.writeText(lastResult.join("\n")).then(() => {
+          showToast("已复制到剪贴板");
+        });
+      }
+
+      // Download result
+      function downloadResult() {
+        if (lastResult.length === 0) {
+          showToast("没有可下载的内容");
+          return;
+        }
+        const blob = new Blob([lastResult.join("\n")], {
+          type: "text/plain;charset=utf-8"
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "sampled-data.txt";
+        a.click();
+        URL.revokeObjectURL(url);
+        showToast("下载已开始");
+      }
+
+      // Clear all
+      function clearAll() {
+        inputEl.value = "";
+        resultEl.textContent = "采样结果将显示在这里...";
+        lastResult = [];
+        document.getElementById("inputCount").textContent = "0";
+        document.getElementById("outputCount").textContent = "0";
+        document.getElementById("samplePercent").textContent = "0%";
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
+
+      // Save state
+      function saveState() {
+        const state = {
+          input: inputEl.value,
+          mode: currentMode,
+          sampleSize: document.getElementById("sampleSize").value,
+          sizeType: document.getElementById("sizeType").value,
+          everyN: document.getElementById("everyN").value,
+          rangeStart: document.getElementById("rangeStart").value,
+          rangeEnd: document.getElementById("rangeEnd").value,
+          seed: document.getElementById("seed").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
+
+      // Load state
+      function loadState() {
+        try {
+          const saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            const state = JSON.parse(saved);
+            inputEl.value = state.input || "";
+
+            if (state.mode) {
+              currentMode = state.mode;
+              document.querySelectorAll(".mode-btn").forEach((btn) => {
+                if (btn.dataset.mode === state.mode) {
+                  btn.classList.add("active");
+                } else {
+                  btn.classList.remove("active");
+                }
+              });
+              updateOptionsVisibility();
+            }
+
+            document.getElementById("sampleSize").value = state.sampleSize || "10";
+            document.getElementById("sizeType").value = state.sizeType || "count";
+            document.getElementById("everyN").value = state.everyN || "2";
+            document.getElementById("rangeStart").value = state.rangeStart || "1";
+            document.getElementById("rangeEnd").value = state.rangeEnd || "10";
+            document.getElementById("seed").value = state.seed || "";
           }
-        })();
+        } catch {
+          // ignore
+        }
+      }
 
-        // Auto-save on input
-        inputEl.addEventListener("input", saveState);
+      // Theme toggle
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // Load state on init
-        loadState();
-        updateOptionsVisibility();
-</script>
-    
+      // Show toast
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // Init theme
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // Auto-save on input
+      inputEl.addEventListener("input", saveState);
+
+      // Load state on init
+      loadState();
+      updateOptionsVisibility();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/data-transformer.html
+++ b/tools/data/data-transformer.html
@@ -6,17 +6,29 @@
     <title>数据转换器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换" />
-    <meta name="keywords" content="data transform 转换 prefix suffix wrap template 前缀 后缀 包裹 模板 批量" />
+    <meta
+      name="description"
+      content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换"
+    />
+    <meta
+      name="keywords"
+      content="data transform 转换 prefix suffix wrap template 前缀 后缀 包裹 模板 批量"
+    />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://tools.realtime-ai.chat/tools/data/data-transformer.html" />
 
     <!-- Open Graph -->
     <meta property="og:title" content="数据转换器 - WebUtils" />
-    <meta property="og:description" content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换" />
+    <meta
+      property="og:description"
+      content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/data-transformer.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/data-transformer.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="数据转换器 - WebUtils" />
-    <meta name="twitter:description" content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换" />
+    <meta
+      name="twitter:description"
+      content="批量转换数据，支持前缀后缀、包裹、模板替换、数字格式化、大小写转换"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "数据转换器",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-transformer.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据转换器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-transformer.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "数据转换器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "数据转换器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,953 +103,964 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .transform-options {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
-    margin-bottom: 16px;
-  }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
 
-  .option-card {
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-  }
+      .transform-options {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 16px;
+        margin-bottom: 16px;
+      }
 
-  .option-card-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    margin-bottom: 12px;
-  }
+      .option-card {
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+      }
 
-  .option-row {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 12px;
-  }
+      .option-card-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        margin-bottom: 12px;
+      }
 
-  .option-row:last-child {
-    margin-bottom: 0;
-  }
+      .option-row {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
 
-  .option-row input[type="text"] {
-    flex: 1;
-  }
+      .option-row:last-child {
+        margin-bottom: 0;
+      }
 
-  .transform-type-select {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 16px;
-  }
+      .option-row input[type="text"] {
+        flex: 1;
+      }
 
-  .type-btn {
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .transform-type-select {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
 
-  .type-btn:hover {
-    border-color: var(--color-accent-cyan);
-  }
+      .type-btn {
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .type-btn.active {
-    background: rgba(0, 245, 212, 0.1);
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .type-btn:hover {
+        border-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .type-btn.active {
+        background: rgba(0, 245, 212, 0.1);
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-accent-cyan);
-    min-height: 150px;
-    max-height: 400px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-accent-cyan);
+        min-height: 150px;
+        max-height: 400px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
 
-  .stat-item {
-    padding: 12px 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex: 1;
-    min-width: 100px;
-    text-align: center;
-  }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
 
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .stat-item {
+        padding: 12px 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex: 1;
+        min-width: 100px;
+        text-align: center;
+      }
 
-  .stat-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .stat-label {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .hidden {
-    display: none !important;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .hidden {
+        display: none !important;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .transform-options {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .transform-options {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据转换器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔄</span>
-        数据转换器
-      </h1>
-      <p>批量转换数据，支持前缀后缀、包裹、模板替换等</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据转换器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔄</span>
+              数据转换器
+            </h1>
+            <p>批量转换数据，支持前缀后缀、包裹、模板替换等</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">数据输入</div>
-      <div class="input-group">
-        <label class="input-label">输入数据（每行一条）</label>
-        <textarea id="input" placeholder="输入要转换的数据，每行一条...
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">数据输入</div>
+            <div class="input-group">
+              <label class="input-label">输入数据（每行一条）</label>
+              <textarea
+                id="input"
+                placeholder="输入要转换的数据，每行一条...
 示例:
 apple
 banana
-cherry"></textarea>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">转换类型</div>
-      <div class="transform-type-select">
-        <button class="type-btn active" data-type="prefix-suffix">前缀/后缀</button>
-        <button class="type-btn" data-type="wrap">包裹</button>
-        <button class="type-btn" data-type="template">模板替换</button>
-        <button class="type-btn" data-type="number">数字格式化</button>
-        <button class="type-btn" data-type="case">大小写</button>
-        <button class="type-btn" data-type="replace">查找替换</button>
-      </div>
-
-      <!-- Prefix/Suffix Options -->
-      <div class="transform-options" id="opt-prefix-suffix">
-        <div class="option-card">
-          <div class="option-card-title">添加前缀</div>
-          <input type="text" id="prefix" placeholder="例如: &quot;item_&quot;">
-        </div>
-        <div class="option-card">
-          <div class="option-card-title">添加后缀</div>
-          <input type="text" id="suffix" placeholder="例如: &quot;.txt&quot;">
-        </div>
-      </div>
-
-      <!-- Wrap Options -->
-      <div class="transform-options hidden" id="opt-wrap">
-        <div class="option-card">
-          <div class="option-card-title">包裹字符</div>
-          <div class="option-row">
-            <input type="text" id="wrapLeft" placeholder="左边" value="&quot;">
-            <input type="text" id="wrapRight" placeholder="右边" value="&quot;">
+cherry"
+              ></textarea>
+            </div>
           </div>
-          <div class="input-hint">常用: 引号 "" '' | 括号 () [] {} | 标签 &lt;&gt;</div>
-        </div>
-        <div class="option-card">
-          <div class="option-card-title">行分隔符</div>
-          <input type="text" id="wrapSeparator" placeholder="例如: ," value=",">
-          <div class="input-hint">用于连接各行，生成数组等</div>
-        </div>
-      </div>
 
-      <!-- Template Options -->
-      <div class="transform-options hidden" id="opt-template">
-        <div class="option-card" style="grid-column: 1 / -1">
-          <div class="option-card-title">模板</div>
-          <input type="text" id="template" placeholder="使用 {value} 表示原值，{index} 表示序号（从1开始），{index0} 从0开始">
-          <div class="input-hint">
-            示例: &lt;li&gt;{index}. {value}&lt;/li&gt; → &lt;li&gt;1. apple&lt;/li&gt;
+          <div class="tool-section">
+            <div class="section-title">转换类型</div>
+            <div class="transform-type-select">
+              <button class="type-btn active" data-type="prefix-suffix">前缀/后缀</button>
+              <button class="type-btn" data-type="wrap">包裹</button>
+              <button class="type-btn" data-type="template">模板替换</button>
+              <button class="type-btn" data-type="number">数字格式化</button>
+              <button class="type-btn" data-type="case">大小写</button>
+              <button class="type-btn" data-type="replace">查找替换</button>
+            </div>
+
+            <!-- Prefix/Suffix Options -->
+            <div class="transform-options" id="opt-prefix-suffix">
+              <div class="option-card">
+                <div class="option-card-title">添加前缀</div>
+                <input type="text" id="prefix" placeholder='例如: "item_"' />
+              </div>
+              <div class="option-card">
+                <div class="option-card-title">添加后缀</div>
+                <input type="text" id="suffix" placeholder='例如: ".txt"' />
+              </div>
+            </div>
+
+            <!-- Wrap Options -->
+            <div class="transform-options hidden" id="opt-wrap">
+              <div class="option-card">
+                <div class="option-card-title">包裹字符</div>
+                <div class="option-row">
+                  <input type="text" id="wrapLeft" placeholder="左边" value='"' />
+                  <input type="text" id="wrapRight" placeholder="右边" value='"' />
+                </div>
+                <div class="input-hint">常用: 引号 "" '' | 括号 () [] {} | 标签 &lt;&gt;</div>
+              </div>
+              <div class="option-card">
+                <div class="option-card-title">行分隔符</div>
+                <input type="text" id="wrapSeparator" placeholder="例如: ," value="," />
+                <div class="input-hint">用于连接各行，生成数组等</div>
+              </div>
+            </div>
+
+            <!-- Template Options -->
+            <div class="transform-options hidden" id="opt-template">
+              <div class="option-card" style="grid-column: 1 / -1">
+                <div class="option-card-title">模板</div>
+                <input
+                  type="text"
+                  id="template"
+                  placeholder="使用 {value} 表示原值，{index} 表示序号（从1开始），{index0} 从0开始"
+                />
+                <div class="input-hint">
+                  示例: &lt;li&gt;{index}. {value}&lt;/li&gt; → &lt;li&gt;1. apple&lt;/li&gt;
+                </div>
+              </div>
+            </div>
+
+            <!-- Number Format Options -->
+            <div class="transform-options hidden" id="opt-number">
+              <div class="option-card">
+                <div class="option-card-title">数字格式</div>
+                <select id="numberFormat">
+                  <option value="thousands">千分位分隔 (1,234,567)</option>
+                  <option value="fixed2">保留2位小数</option>
+                  <option value="fixed4">保留4位小数</option>
+                  <option value="percent">转为百分比</option>
+                  <option value="scientific">科学计数法</option>
+                  <option value="currency-cny">人民币 (¥)</option>
+                  <option value="currency-usd">美元 ($)</option>
+                </select>
+              </div>
+              <div class="option-card">
+                <div class="option-card-title">非数字处理</div>
+                <select id="nonNumberAction">
+                  <option value="keep">保持原样</option>
+                  <option value="skip">跳过</option>
+                  <option value="zero">替换为0</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Case Options -->
+            <div class="transform-options hidden" id="opt-case">
+              <div class="option-card" style="grid-column: 1 / -1">
+                <div class="option-card-title">大小写转换</div>
+                <select id="caseType" style="width: 100%">
+                  <option value="upper">全部大写 (HELLO WORLD)</option>
+                  <option value="lower">全部小写 (hello world)</option>
+                  <option value="capitalize">首字母大写 (Hello World)</option>
+                  <option value="sentence">句首大写 (Hello world)</option>
+                  <option value="camel">驼峰命名 (helloWorld)</option>
+                  <option value="pascal">帕斯卡命名 (HelloWorld)</option>
+                  <option value="snake">蛇形命名 (hello_world)</option>
+                  <option value="kebab">短横线命名 (hello-world)</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Replace Options -->
+            <div class="transform-options hidden" id="opt-replace">
+              <div class="option-card">
+                <div class="option-card-title">查找</div>
+                <input type="text" id="replaceFind" placeholder="要查找的文本" />
+                <label
+                  style="
+                    margin-top: 8px;
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    font-size: 0.85rem;
+                    color: var(--color-text-secondary);
+                  "
+                >
+                  <input type="checkbox" id="replaceRegex" style="width: auto" />
+                  使用正则表达式
+                </label>
+              </div>
+              <div class="option-card">
+                <div class="option-card-title">替换为</div>
+                <input type="text" id="replaceWith" placeholder="替换后的文本" />
+              </div>
+            </div>
+
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="transformData()">🔄 转换</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            </div>
           </div>
-        </div>
-      </div>
 
-      <!-- Number Format Options -->
-      <div class="transform-options hidden" id="opt-number">
-        <div class="option-card">
-          <div class="option-card-title">数字格式</div>
-          <select id="numberFormat">
-            <option value="thousands">千分位分隔 (1,234,567)</option>
-            <option value="fixed2">保留2位小数</option>
-            <option value="fixed4">保留4位小数</option>
-            <option value="percent">转为百分比</option>
-            <option value="scientific">科学计数法</option>
-            <option value="currency-cny">人民币 (¥)</option>
-            <option value="currency-usd">美元 ($)</option>
-          </select>
-        </div>
-        <div class="option-card">
-          <div class="option-card-title">非数字处理</div>
-          <select id="nonNumberAction">
-            <option value="keep">保持原样</option>
-            <option value="skip">跳过</option>
-            <option value="zero">替换为0</option>
-          </select>
-        </div>
-      </div>
-
-      <!-- Case Options -->
-      <div class="transform-options hidden" id="opt-case">
-        <div class="option-card" style="grid-column: 1 / -1">
-          <div class="option-card-title">大小写转换</div>
-          <select id="caseType" style="width: 100%">
-            <option value="upper">全部大写 (HELLO WORLD)</option>
-            <option value="lower">全部小写 (hello world)</option>
-            <option value="capitalize">首字母大写 (Hello World)</option>
-            <option value="sentence">句首大写 (Hello world)</option>
-            <option value="camel">驼峰命名 (helloWorld)</option>
-            <option value="pascal">帕斯卡命名 (HelloWorld)</option>
-            <option value="snake">蛇形命名 (hello_world)</option>
-            <option value="kebab">短横线命名 (hello-world)</option>
-          </select>
-        </div>
-      </div>
-
-      <!-- Replace Options -->
-      <div class="transform-options hidden" id="opt-replace">
-        <div class="option-card">
-          <div class="option-card-title">查找</div>
-          <input type="text" id="replaceFind" placeholder="要查找的文本">
-          <label style="
-              margin-top: 8px;
-              display: flex;
-              align-items: center;
-              gap: 8px;
-              font-size: 0.85rem;
-              color: var(--color-text-secondary);
-            ">
-            <input type="checkbox" id="replaceRegex" style="width: auto">
-            使用正则表达式
-          </label>
-        </div>
-        <div class="option-card">
-          <div class="option-card-title">替换为</div>
-          <input type="text" id="replaceWith" placeholder="替换后的文本">
-        </div>
-      </div>
-
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="transformData()">🔄 转换</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+          <div class="tool-section">
+            <div class="section-title">转换结果</div>
+            <div class="stats-row">
+              <div class="stat-item">
+                <div class="stat-value" id="inputCount">0</div>
+                <div class="stat-label">输入行数</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-value" id="outputCount">0</div>
+                <div class="stat-label">输出行数</div>
+              </div>
+            </div>
+            <div class="result-box" id="result">转换结果将显示在这里...</div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
+              <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="tool-section">
-      <div class="section-title">转换结果</div>
-      <div class="stats-row">
-        <div class="stat-item">
-          <div class="stat-value" id="inputCount">0</div>
-          <div class="stat-label">输入行数</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="outputCount">0</div>
-          <div class="stat-label">输出行数</div>
-        </div>
-      </div>
-      <div class="result-box" id="result">转换结果将显示在这里...</div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-primary" onclick="copyResult()">📋 复制结果</button>
-        <button class="btn btn-secondary" onclick="downloadResult()">💾 下载</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据转换器",
-              "item": "https://tools.realtime-ai.chat/tools/data/data-transformer.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据转换器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-transformer.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      const LS_KEY = "data-transformer-state";
+      let currentType = "prefix-suffix";
 
-  const LS_KEY = "data-transformer-state";
-        let currentType = "prefix-suffix";
+      // Elements
+      const inputEl = document.getElementById("input");
+      const resultEl = document.getElementById("result");
 
-        // Elements
-        const inputEl = document.getElementById("input");
-        const resultEl = document.getElementById("result");
+      // Transform type selection
+      document.querySelectorAll(".type-btn").forEach((btn) => {
+        btn.addEventListener("click", function () {
+          document.querySelectorAll(".type-btn").forEach((b) => b.classList.remove("active"));
+          this.classList.add("active");
+          currentType = this.dataset.type;
 
-        // Transform type selection
-        document.querySelectorAll(".type-btn").forEach((btn) => {
-          btn.addEventListener("click", function () {
-            document.querySelectorAll(".type-btn").forEach((b) => b.classList.remove("active"));
-            this.classList.add("active");
-            currentType = this.dataset.type;
-
-            // Show/hide options
-            document.querySelectorAll(".transform-options").forEach((opt) => {
-              opt.classList.add("hidden");
-            });
-            document.getElementById("opt-" + currentType).classList.remove("hidden");
-            saveState();
+          // Show/hide options
+          document.querySelectorAll(".transform-options").forEach((opt) => {
+            opt.classList.add("hidden");
           });
+          document.getElementById("opt-" + currentType).classList.remove("hidden");
+          saveState();
         });
+      });
 
-        // Parse lines
-        function parseLines(text) {
-          return text
-            .split("\n")
-            .map((l) => l.trim())
-            .filter((l) => l !== "");
-        }
+      // Parse lines
+      function parseLines(text) {
+        return text
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l !== "");
+      }
 
-        // Transform functions
-        function transformPrefixSuffix(lines) {
-          const prefix = document.getElementById("prefix").value;
-          const suffix = document.getElementById("suffix").value;
-          return lines.map((line) => prefix + line + suffix);
-        }
+      // Transform functions
+      function transformPrefixSuffix(lines) {
+        const prefix = document.getElementById("prefix").value;
+        const suffix = document.getElementById("suffix").value;
+        return lines.map((line) => prefix + line + suffix);
+      }
 
-        function transformWrap(lines) {
-          const left = document.getElementById("wrapLeft").value;
-          const right = document.getElementById("wrapRight").value;
-          const sep = document.getElementById("wrapSeparator").value;
-          const wrapped = lines.map((line) => left + line + right);
-          return [wrapped.join(sep)];
-        }
+      function transformWrap(lines) {
+        const left = document.getElementById("wrapLeft").value;
+        const right = document.getElementById("wrapRight").value;
+        const sep = document.getElementById("wrapSeparator").value;
+        const wrapped = lines.map((line) => left + line + right);
+        return [wrapped.join(sep)];
+      }
 
-        function transformTemplate(lines) {
-          const template = document.getElementById("template").value;
-          if (!template) return lines;
-          return lines.map((line, i) =>
-            template
-              .replace(/{value}/g, line)
-              .replace(/{index}/g, i + 1)
-              .replace(/{index0}/g, i)
-          );
-        }
+      function transformTemplate(lines) {
+        const template = document.getElementById("template").value;
+        if (!template) return lines;
+        return lines.map((line, i) =>
+          template
+            .replace(/{value}/g, line)
+            .replace(/{index}/g, i + 1)
+            .replace(/{index0}/g, i)
+        );
+      }
 
-        function transformNumber(lines) {
-          const format = document.getElementById("numberFormat").value;
-          const nonNumAction = document.getElementById("nonNumberAction").value;
+      function transformNumber(lines) {
+        const format = document.getElementById("numberFormat").value;
+        const nonNumAction = document.getElementById("nonNumberAction").value;
 
-          return lines
-            .map((line) => {
-              const num = parseFloat(line);
-              if (isNaN(num)) {
-                if (nonNumAction === "skip") return null;
-                if (nonNumAction === "zero") return "0";
-                return line;
-              }
+        return lines
+          .map((line) => {
+            const num = parseFloat(line);
+            if (isNaN(num)) {
+              if (nonNumAction === "skip") return null;
+              if (nonNumAction === "zero") return "0";
+              return line;
+            }
 
-              switch (format) {
-                case "thousands":
-                  return num.toLocaleString("en-US");
-                case "fixed2":
-                  return num.toFixed(2);
-                case "fixed4":
-                  return num.toFixed(4);
-                case "percent":
-                  return (num * 100).toFixed(2) + "%";
-                case "scientific":
-                  return num.toExponential(2);
-                case "currency-cny":
-                  return "¥" + num.toLocaleString("zh-CN", { minimumFractionDigits: 2 });
-                case "currency-usd":
-                  return "$" + num.toLocaleString("en-US", { minimumFractionDigits: 2 });
-                default:
-                  return line;
-              }
-            })
-            .filter((l) => l !== null);
-        }
-
-        function transformCase(lines) {
-          const caseType = document.getElementById("caseType").value;
-
-          return lines.map((line) => {
-            switch (caseType) {
-              case "upper":
-                return line.toUpperCase();
-              case "lower":
-                return line.toLowerCase();
-              case "capitalize":
-                return line.replace(/\b\w/g, (c) => c.toUpperCase());
-              case "sentence":
-                return line.charAt(0).toUpperCase() + line.slice(1).toLowerCase();
-              case "camel":
-                return line.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, c) => c.toUpperCase());
-              case "pascal":
-                return line
-                  .toLowerCase()
-                  .replace(/(?:^|[^a-zA-Z0-9]+)(.)/g, (_, c) => c.toUpperCase());
-              case "snake":
-                return line
-                  .replace(/\s+/g, "_")
-                  .replace(/([a-z])([A-Z])/g, "$1_$2")
-                  .toLowerCase();
-              case "kebab":
-                return line
-                  .replace(/\s+/g, "-")
-                  .replace(/([a-z])([A-Z])/g, "$1-$2")
-                  .toLowerCase();
+            switch (format) {
+              case "thousands":
+                return num.toLocaleString("en-US");
+              case "fixed2":
+                return num.toFixed(2);
+              case "fixed4":
+                return num.toFixed(4);
+              case "percent":
+                return (num * 100).toFixed(2) + "%";
+              case "scientific":
+                return num.toExponential(2);
+              case "currency-cny":
+                return "¥" + num.toLocaleString("zh-CN", { minimumFractionDigits: 2 });
+              case "currency-usd":
+                return "$" + num.toLocaleString("en-US", { minimumFractionDigits: 2 });
               default:
                 return line;
             }
-          });
-        }
+          })
+          .filter((l) => l !== null);
+      }
 
-        function transformReplace(lines) {
-          const find = document.getElementById("replaceFind").value;
-          const replaceWith = document.getElementById("replaceWith").value;
-          const useRegex = document.getElementById("replaceRegex").checked;
+      function transformCase(lines) {
+        const caseType = document.getElementById("caseType").value;
 
-          if (!find) return lines;
-
-          return lines.map((line) => {
-            if (useRegex) {
-              try {
-                const regex = new RegExp(find, "g");
-                return line.replace(regex, replaceWith);
-              } catch {
-                return line;
-              }
-            }
-            return line.split(find).join(replaceWith);
-          });
-        }
-
-        // Main transform function
-        function transformData() {
-          const lines = parseLines(inputEl.value);
-          if (lines.length === 0) {
-            showToast("请输入数据");
-            return;
-          }
-
-          let result;
-          switch (currentType) {
-            case "prefix-suffix":
-              result = transformPrefixSuffix(lines);
-              break;
-            case "wrap":
-              result = transformWrap(lines);
-              break;
-            case "template":
-              result = transformTemplate(lines);
-              break;
-            case "number":
-              result = transformNumber(lines);
-              break;
-            case "case":
-              result = transformCase(lines);
-              break;
-            case "replace":
-              result = transformReplace(lines);
-              break;
+        return lines.map((line) => {
+          switch (caseType) {
+            case "upper":
+              return line.toUpperCase();
+            case "lower":
+              return line.toLowerCase();
+            case "capitalize":
+              return line.replace(/\b\w/g, (c) => c.toUpperCase());
+            case "sentence":
+              return line.charAt(0).toUpperCase() + line.slice(1).toLowerCase();
+            case "camel":
+              return line.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, c) => c.toUpperCase());
+            case "pascal":
+              return line
+                .toLowerCase()
+                .replace(/(?:^|[^a-zA-Z0-9]+)(.)/g, (_, c) => c.toUpperCase());
+            case "snake":
+              return line
+                .replace(/\s+/g, "_")
+                .replace(/([a-z])([A-Z])/g, "$1_$2")
+                .toLowerCase();
+            case "kebab":
+              return line
+                .replace(/\s+/g, "-")
+                .replace(/([a-z])([A-Z])/g, "$1-$2")
+                .toLowerCase();
             default:
-              result = lines;
+              return line;
           }
+        });
+      }
 
-          document.getElementById("inputCount").textContent = lines.length;
-          document.getElementById("outputCount").textContent = result.length;
-          resultEl.textContent = result.join("\n");
-          saveState();
-          showToast("转换完成");
-        }
+      function transformReplace(lines) {
+        const find = document.getElementById("replaceFind").value;
+        const replaceWith = document.getElementById("replaceWith").value;
+        const useRegex = document.getElementById("replaceRegex").checked;
 
-        // Copy result
-        function copyResult() {
-          const text = resultEl.textContent;
-          if (!text || text === "转换结果将显示在这里...") {
-            showToast("没有可复制的内容");
-            return;
-          }
-          navigator.clipboard.writeText(text).then(() => {
-            showToast("已复制到剪贴板");
-          });
-        }
+        if (!find) return lines;
 
-        // Download result
-        function downloadResult() {
-          const text = resultEl.textContent;
-          if (!text || text === "转换结果将显示在这里...") {
-            showToast("没有可下载的内容");
-            return;
-          }
-          const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "transformed-data.txt";
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast("下载已开始");
-        }
-
-        // Clear all
-        function clearAll() {
-          inputEl.value = "";
-          resultEl.textContent = "转换结果将显示在这里...";
-          document.getElementById("inputCount").textContent = "0";
-          document.getElementById("outputCount").textContent = "0";
-          localStorage.removeItem(LS_KEY);
-          showToast("已清空");
-        }
-
-        // Save state
-        function saveState() {
-          const state = {
-            input: inputEl.value,
-            type: currentType,
-            prefix: document.getElementById("prefix").value,
-            suffix: document.getElementById("suffix").value,
-            wrapLeft: document.getElementById("wrapLeft").value,
-            wrapRight: document.getElementById("wrapRight").value,
-            wrapSeparator: document.getElementById("wrapSeparator").value,
-            template: document.getElementById("template").value,
-            numberFormat: document.getElementById("numberFormat").value,
-            nonNumberAction: document.getElementById("nonNumberAction").value,
-            caseType: document.getElementById("caseType").value,
-            replaceFind: document.getElementById("replaceFind").value,
-            replaceWith: document.getElementById("replaceWith").value,
-            replaceRegex: document.getElementById("replaceRegex").checked
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
-        }
-
-        // Load state
-        function loadState() {
-          try {
-            const saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              const state = JSON.parse(saved);
-              inputEl.value = state.input || "";
-
-              if (state.type) {
-                currentType = state.type;
-                document.querySelectorAll(".type-btn").forEach((btn) => {
-                  if (btn.dataset.type === state.type) {
-                    btn.classList.add("active");
-                  } else {
-                    btn.classList.remove("active");
-                  }
-                });
-                document.querySelectorAll(".transform-options").forEach((opt) => {
-                  opt.classList.add("hidden");
-                });
-                document.getElementById("opt-" + currentType).classList.remove("hidden");
-              }
-
-              document.getElementById("prefix").value = state.prefix || "";
-              document.getElementById("suffix").value = state.suffix || "";
-              document.getElementById("wrapLeft").value = state.wrapLeft || '"';
-              document.getElementById("wrapRight").value = state.wrapRight || '"';
-              document.getElementById("wrapSeparator").value = state.wrapSeparator || ",";
-              document.getElementById("template").value = state.template || "";
-              document.getElementById("numberFormat").value = state.numberFormat || "thousands";
-              document.getElementById("nonNumberAction").value = state.nonNumberAction || "keep";
-              document.getElementById("caseType").value = state.caseType || "upper";
-              document.getElementById("replaceFind").value = state.replaceFind || "";
-              document.getElementById("replaceWith").value = state.replaceWith || "";
-              document.getElementById("replaceRegex").checked = state.replaceRegex || false;
+        return lines.map((line) => {
+          if (useRegex) {
+            try {
+              const regex = new RegExp(find, "g");
+              return line.replace(regex, replaceWith);
+            } catch {
+              return line;
             }
-          } catch {
-            // ignore
           }
+          return line.split(find).join(replaceWith);
+        });
+      }
+
+      // Main transform function
+      function transformData() {
+        const lines = parseLines(inputEl.value);
+        if (lines.length === 0) {
+          showToast("请输入数据");
+          return;
         }
 
-        // Theme toggle
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+        let result;
+        switch (currentType) {
+          case "prefix-suffix":
+            result = transformPrefixSuffix(lines);
+            break;
+          case "wrap":
+            result = transformWrap(lines);
+            break;
+          case "template":
+            result = transformTemplate(lines);
+            break;
+          case "number":
+            result = transformNumber(lines);
+            break;
+          case "case":
+            result = transformCase(lines);
+            break;
+          case "replace":
+            result = transformReplace(lines);
+            break;
+          default:
+            result = lines;
         }
 
-        // Show toast
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
+        document.getElementById("inputCount").textContent = lines.length;
+        document.getElementById("outputCount").textContent = result.length;
+        resultEl.textContent = result.join("\n");
+        saveState();
+        showToast("转换完成");
+      }
 
-        // Init theme
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
+      // Copy result
+      function copyResult() {
+        const text = resultEl.textContent;
+        if (!text || text === "转换结果将显示在这里...") {
+          showToast("没有可复制的内容");
+          return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+          showToast("已复制到剪贴板");
+        });
+      }
+
+      // Download result
+      function downloadResult() {
+        const text = resultEl.textContent;
+        if (!text || text === "转换结果将显示在这里...") {
+          showToast("没有可下载的内容");
+          return;
+        }
+        const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "transformed-data.txt";
+        a.click();
+        URL.revokeObjectURL(url);
+        showToast("下载已开始");
+      }
+
+      // Clear all
+      function clearAll() {
+        inputEl.value = "";
+        resultEl.textContent = "转换结果将显示在这里...";
+        document.getElementById("inputCount").textContent = "0";
+        document.getElementById("outputCount").textContent = "0";
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
+
+      // Save state
+      function saveState() {
+        const state = {
+          input: inputEl.value,
+          type: currentType,
+          prefix: document.getElementById("prefix").value,
+          suffix: document.getElementById("suffix").value,
+          wrapLeft: document.getElementById("wrapLeft").value,
+          wrapRight: document.getElementById("wrapRight").value,
+          wrapSeparator: document.getElementById("wrapSeparator").value,
+          template: document.getElementById("template").value,
+          numberFormat: document.getElementById("numberFormat").value,
+          nonNumberAction: document.getElementById("nonNumberAction").value,
+          caseType: document.getElementById("caseType").value,
+          replaceFind: document.getElementById("replaceFind").value,
+          replaceWith: document.getElementById("replaceWith").value,
+          replaceRegex: document.getElementById("replaceRegex").checked
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
+
+      // Load state
+      function loadState() {
+        try {
+          const saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            const state = JSON.parse(saved);
+            inputEl.value = state.input || "";
+
+            if (state.type) {
+              currentType = state.type;
+              document.querySelectorAll(".type-btn").forEach((btn) => {
+                if (btn.dataset.type === state.type) {
+                  btn.classList.add("active");
+                } else {
+                  btn.classList.remove("active");
+                }
+              });
+              document.querySelectorAll(".transform-options").forEach((opt) => {
+                opt.classList.add("hidden");
+              });
+              document.getElementById("opt-" + currentType).classList.remove("hidden");
+            }
+
+            document.getElementById("prefix").value = state.prefix || "";
+            document.getElementById("suffix").value = state.suffix || "";
+            document.getElementById("wrapLeft").value = state.wrapLeft || '"';
+            document.getElementById("wrapRight").value = state.wrapRight || '"';
+            document.getElementById("wrapSeparator").value = state.wrapSeparator || ",";
+            document.getElementById("template").value = state.template || "";
+            document.getElementById("numberFormat").value = state.numberFormat || "thousands";
+            document.getElementById("nonNumberAction").value = state.nonNumberAction || "keep";
+            document.getElementById("caseType").value = state.caseType || "upper";
+            document.getElementById("replaceFind").value = state.replaceFind || "";
+            document.getElementById("replaceWith").value = state.replaceWith || "";
+            document.getElementById("replaceRegex").checked = state.replaceRegex || false;
           }
-        })();
+        } catch {
+          // ignore
+        }
+      }
 
-        // Auto-save on input
-        inputEl.addEventListener("input", saveState);
+      // Theme toggle
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // Load state on init
-        loadState();
-</script>
-    
+      // Show toast
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // Init theme
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // Auto-save on input
+      inputEl.addEventListener("input", saveState);
+
+      // Load state on init
+      loadState();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/data-validator.html
+++ b/tools/data/data-validator.html
@@ -6,17 +6,29 @@
     <title>数据验证器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等" />
-    <meta name="keywords" content="data validate 验证 email URL date phone number 邮箱 手机号 IP UUID JSON" />
+    <meta
+      name="description"
+      content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等"
+    />
+    <meta
+      name="keywords"
+      content="data validate 验证 email URL date phone number 邮箱 手机号 IP UUID JSON"
+    />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://tools.realtime-ai.chat/tools/data/data-validator.html" />
 
     <!-- Open Graph -->
     <meta property="og:title" content="数据验证器 - WebUtils" />
-    <meta property="og:description" content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等" />
+    <meta
+      property="og:description"
+      content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/data-validator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/data-validator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="数据验证器 - WebUtils" />
-    <meta name="twitter:description" content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等" />
+    <meta
+      name="twitter:description"
+      content="验证数据格式，支持邮箱、URL、数字、日期、手机号、IP、UUID、JSON等"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "数据验证器",
-      "item": "https://tools.realtime-ai.chat/tools/data/data-validator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据验证器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-validator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "数据验证器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "数据验证器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,863 +103,876 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .type-selector {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 16px;
-  }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
 
-  .type-btn {
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .type-selector {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
 
-  .type-btn:hover {
-    border-color: var(--color-accent-cyan);
-  }
+      .type-btn {
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .type-btn.active {
-    background: rgba(0, 245, 212, 0.1);
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .type-btn:hover {
+        border-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .type-btn.active {
+        background: rgba(0, 245, 212, 0.1);
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .stat-item {
-    padding: 16px 20px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    flex: 1;
-    min-width: 120px;
-    text-align: center;
-  }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
 
-  .stat-item.valid {
-    border-color: var(--accent-green);
-    background: rgba(16, 185, 129, 0.1);
-  }
+      .stat-item {
+        padding: 16px 20px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        flex: 1;
+        min-width: 120px;
+        text-align: center;
+      }
 
-  .stat-item.invalid {
-    border-color: var(--accent-red);
-    background: rgba(244, 63, 94, 0.1);
-  }
+      .stat-item.valid {
+        border-color: var(--accent-green);
+        background: rgba(16, 185, 129, 0.1);
+      }
 
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 2rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .stat-item.invalid {
+        border-color: var(--accent-red);
+        background: rgba(244, 63, 94, 0.1);
+      }
 
-  .stat-item.valid .stat-value {
-    color: var(--accent-green);
-  }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 2rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .stat-item.invalid .stat-value {
-    color: var(--accent-red);
-  }
+      .stat-item.valid .stat-value {
+        color: var(--accent-green);
+      }
 
-  .stat-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .stat-item.invalid .stat-value {
+        color: var(--accent-red);
+      }
 
-  .stat-percent {
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-  }
+      .stat-label {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .results-container {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
+      .stat-percent {
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+      }
 
-  @media (max-width: 768px) {
-    .results-container {
-      grid-template-columns: 1fr;
-    }
-  }
+      .results-container {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
 
-  .result-panel {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-  }
+      @media (max-width: 768px) {
+        .results-container {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .result-panel.valid {
-    border-color: var(--accent-green);
-  }
+      .result-panel {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
 
-  .result-panel.invalid {
-    border-color: var(--accent-red);
-  }
+      .result-panel.valid {
+        border-color: var(--accent-green);
+      }
 
-  .result-header {
-    padding: 12px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    background: var(--color-bg-surface);
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
+      .result-panel.invalid {
+        border-color: var(--accent-red);
+      }
 
-  .result-panel.valid .result-header {
-    color: var(--accent-green);
-  }
+      .result-header {
+        padding: 12px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        background: var(--color-bg-surface);
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
 
-  .result-panel.invalid .result-header {
-    color: var(--accent-red);
-  }
+      .result-panel.valid .result-header {
+        color: var(--accent-green);
+      }
 
-  .result-content {
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    max-height: 300px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
+      .result-panel.invalid .result-header {
+        color: var(--accent-red);
+      }
 
-  .result-item {
-    padding: 6px 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .result-content {
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        max-height: 300px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
 
-  .result-item:last-child {
-    border-bottom: none;
-  }
+      .result-item {
+        padding: 6px 0;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .result-item.valid {
-    color: var(--accent-green);
-  }
+      .result-item:last-child {
+        border-bottom: none;
+      }
 
-  .result-item.invalid {
-    color: var(--accent-red);
-  }
+      .result-item.valid {
+        color: var(--accent-green);
+      }
 
-  .empty-state {
-    color: var(--color-text-muted);
-    text-align: center;
-    padding: 24px;
-  }
+      .result-item.invalid {
+        color: var(--accent-red);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .empty-state {
+        color: var(--color-text-muted);
+        text-align: center;
+        padding: 24px;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据验证器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">✓</span>
-        数据验证器
-      </h1>
-      <p>验证数据格式，支持数字、邮箱、URL、日期、手机号等</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据验证器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">✓</span>
+              数据验证器
+            </h1>
+            <p>验证数据格式，支持数字、邮箱、URL、日期、手机号等</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">数据输入</div>
-      <div class="input-group">
-        <label class="input-label">输入数据（每行一条）</label>
-        <textarea id="input" placeholder="输入要验证的数据，每行一条...
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">数据输入</div>
+            <div class="input-group">
+              <label class="input-label">输入数据（每行一条）</label>
+              <textarea
+                id="input"
+                placeholder="输入要验证的数据，每行一条...
 示例:
 test@example.com
 invalid-email
-hello@world.org"></textarea>
+hello@world.org"
+              ></textarea>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">验证类型</div>
+            <div class="type-selector">
+              <button class="type-btn active" data-type="email">📧 邮箱</button>
+              <button class="type-btn" data-type="url">🔗 URL</button>
+              <button class="type-btn" data-type="number">🔢 数字</button>
+              <button class="type-btn" data-type="integer">123 整数</button>
+              <button class="type-btn" data-type="phone-cn">📱 手机号(中国)</button>
+              <button class="type-btn" data-type="date">📅 日期</button>
+              <button class="type-btn" data-type="ipv4">🌐 IPv4</button>
+              <button class="type-btn" data-type="hex-color">🎨 十六进制颜色</button>
+              <button class="type-btn" data-type="uuid">🆔 UUID</button>
+              <button class="type-btn" data-type="json">📋 JSON</button>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="validateData()">✓ 验证</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">验证结果</div>
+            <div class="stats-row">
+              <div class="stat-item">
+                <div class="stat-value" id="totalCount">0</div>
+                <div class="stat-label">总数</div>
+              </div>
+              <div class="stat-item valid">
+                <div class="stat-value" id="validCount">0</div>
+                <div class="stat-label">有效</div>
+                <div class="stat-percent" id="validPercent">0%</div>
+              </div>
+              <div class="stat-item invalid">
+                <div class="stat-value" id="invalidCount">0</div>
+                <div class="stat-label">无效</div>
+                <div class="stat-percent" id="invalidPercent">0%</div>
+              </div>
+            </div>
+
+            <div class="results-container">
+              <div class="result-panel valid">
+                <div class="result-header">
+                  <span>✓ 有效数据</span>
+                  <button
+                    class="btn btn-secondary"
+                    style="flex: 0; min-width: auto; padding: 6px 12px"
+                    onclick="copyValid()"
+                  >
+                    复制
+                  </button>
+                </div>
+                <div class="result-content" id="validList">
+                  <div class="empty-state">验证后显示...</div>
+                </div>
+              </div>
+              <div class="result-panel invalid">
+                <div class="result-header">
+                  <span>✗ 无效数据</span>
+                  <button
+                    class="btn btn-secondary"
+                    style="flex: 0; min-width: auto; padding: 6px 12px"
+                    onclick="copyInvalid()"
+                  >
+                    复制
+                  </button>
+                </div>
+                <div class="result-content" id="invalidList">
+                  <div class="empty-state">验证后显示...</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="tool-section">
-      <div class="section-title">验证类型</div>
-      <div class="type-selector">
-        <button class="type-btn active" data-type="email">📧 邮箱</button>
-        <button class="type-btn" data-type="url">🔗 URL</button>
-        <button class="type-btn" data-type="number">🔢 数字</button>
-        <button class="type-btn" data-type="integer">123 整数</button>
-        <button class="type-btn" data-type="phone-cn">📱 手机号(中国)</button>
-        <button class="type-btn" data-type="date">📅 日期</button>
-        <button class="type-btn" data-type="ipv4">🌐 IPv4</button>
-        <button class="type-btn" data-type="hex-color">🎨 十六进制颜色</button>
-        <button class="type-btn" data-type="uuid">🆔 UUID</button>
-        <button class="type-btn" data-type="json">📋 JSON</button>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="validateData()">✓ 验证</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">验证结果</div>
-      <div class="stats-row">
-        <div class="stat-item">
-          <div class="stat-value" id="totalCount">0</div>
-          <div class="stat-label">总数</div>
-        </div>
-        <div class="stat-item valid">
-          <div class="stat-value" id="validCount">0</div>
-          <div class="stat-label">有效</div>
-          <div class="stat-percent" id="validPercent">0%</div>
-        </div>
-        <div class="stat-item invalid">
-          <div class="stat-value" id="invalidCount">0</div>
-          <div class="stat-label">无效</div>
-          <div class="stat-percent" id="invalidPercent">0%</div>
-        </div>
-      </div>
-
-      <div class="results-container">
-        <div class="result-panel valid">
-          <div class="result-header">
-            <span>✓ 有效数据</span>
-            <button class="btn btn-secondary" style="flex: 0; min-width: auto; padding: 6px 12px" onclick="copyValid()">
-              复制
-            </button>
-          </div>
-          <div class="result-content" id="validList">
-            <div class="empty-state">验证后显示...</div>
-          </div>
-        </div>
-        <div class="result-panel invalid">
-          <div class="result-header">
-            <span>✗ 无效数据</span>
-            <button class="btn btn-secondary" style="flex: 0; min-width: auto; padding: 6px 12px" onclick="copyInvalid()">
-              复制
-            </button>
-          </div>
-          <div class="result-content" id="invalidList">
-            <div class="empty-state">验证后显示...</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据验证器",
-              "item": "https://tools.realtime-ai.chat/tools/data/data-validator.html"
-            }
-          ]
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据验证器",
+            "item": "https://tools.realtime-ai.chat/tools/data/data-validator.html"
+          }
+        ]
+      }
+    </script>
+    <script>
+      const LS_KEY = "data-validator-state";
+      let currentType = "email";
+      let validItems = [];
+      let invalidItems = [];
+
+      // Elements
+      const inputEl = document.getElementById("input");
+
+      // Type selector
+      document.querySelectorAll(".type-btn").forEach((btn) => {
+        btn.addEventListener("click", function () {
+          document.querySelectorAll(".type-btn").forEach((b) => b.classList.remove("active"));
+          this.classList.add("active");
+          currentType = this.dataset.type;
+          saveState();
+        });
+      });
+
+      // Validators
+      const validators = {
+        email: (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+        url: (v) => {
+          try {
+            new URL(v);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        number: (v) => !isNaN(parseFloat(v)) && isFinite(v),
+        integer: (v) => /^-?\d+$/.test(v),
+        "phone-cn": (v) => /^1[3-9]\d{9}$/.test(v.replace(/\s+/g, "")),
+        date: (v) => {
+          // Supports: YYYY-MM-DD, YYYY/MM/DD, DD-MM-YYYY, DD/MM/YYYY
+          const patterns = [
+            /^\d{4}-\d{2}-\d{2}$/,
+            /^\d{4}\/\d{2}\/\d{2}$/,
+            /^\d{2}-\d{2}-\d{4}$/,
+            /^\d{2}\/\d{2}\/\d{4}$/
+          ];
+          if (!patterns.some((p) => p.test(v))) return false;
+          const date = new Date(v);
+          return !isNaN(date.getTime());
+        },
+        ipv4: (v) => {
+          const parts = v.split(".");
+          if (parts.length !== 4) return false;
+          return parts.every((p) => {
+            const num = parseInt(p, 10);
+            return !isNaN(num) && num >= 0 && num <= 255 && p === String(num);
+          });
+        },
+        "hex-color": (v) => /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(v),
+        uuid: (v) =>
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v),
+        json: (v) => {
+          try {
+            JSON.parse(v);
+            return true;
+          } catch {
+            return false;
+          }
+        }
+      };
+
+      // Parse lines
+      function parseLines(text) {
+        return text
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l !== "");
+      }
+
+      // Create result item element safely
+      function createResultItem(text, isValid) {
+        const div = document.createElement("div");
+        div.className = "result-item " + (isValid ? "valid" : "invalid");
+        div.textContent = text;
+        return div;
+      }
+
+      // Validate data
+      function validateData() {
+        const lines = parseLines(inputEl.value);
+        if (lines.length === 0) {
+          showToast("请输入数据");
+          return;
         }
 
-  </script>
-    <script>
+        const validator = validators[currentType];
+        validItems = [];
+        invalidItems = [];
 
-  const LS_KEY = "data-validator-state";
-        let currentType = "email";
-        let validItems = [];
-        let invalidItems = [];
-
-        // Elements
-        const inputEl = document.getElementById("input");
-
-        // Type selector
-        document.querySelectorAll(".type-btn").forEach((btn) => {
-          btn.addEventListener("click", function () {
-            document.querySelectorAll(".type-btn").forEach((b) => b.classList.remove("active"));
-            this.classList.add("active");
-            currentType = this.dataset.type;
-            saveState();
-          });
+        lines.forEach((line) => {
+          if (validator(line)) {
+            validItems.push(line);
+          } else {
+            invalidItems.push(line);
+          }
         });
 
-        // Validators
-        const validators = {
-          email: (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
-          url: (v) => {
-            try {
-              new URL(v);
-              return true;
-            } catch {
-              return false;
-            }
-          },
-          number: (v) => !isNaN(parseFloat(v)) && isFinite(v),
-          integer: (v) => /^-?\d+$/.test(v),
-          "phone-cn": (v) => /^1[3-9]\d{9}$/.test(v.replace(/\s+/g, "")),
-          date: (v) => {
-            // Supports: YYYY-MM-DD, YYYY/MM/DD, DD-MM-YYYY, DD/MM/YYYY
-            const patterns = [
-              /^\d{4}-\d{2}-\d{2}$/,
-              /^\d{4}\/\d{2}\/\d{2}$/,
-              /^\d{2}-\d{2}-\d{4}$/,
-              /^\d{2}\/\d{2}\/\d{4}$/
-            ];
-            if (!patterns.some((p) => p.test(v))) return false;
-            const date = new Date(v);
-            return !isNaN(date.getTime());
-          },
-          ipv4: (v) => {
-            const parts = v.split(".");
-            if (parts.length !== 4) return false;
-            return parts.every((p) => {
-              const num = parseInt(p, 10);
-              return !isNaN(num) && num >= 0 && num <= 255 && p === String(num);
-            });
-          },
-          "hex-color": (v) => /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(v),
-          uuid: (v) =>
-            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v),
-          json: (v) => {
-            try {
-              JSON.parse(v);
-              return true;
-            } catch {
-              return false;
-            }
-          }
+        // Update stats
+        const total = lines.length;
+        const validCount = validItems.length;
+        const invalidCount = invalidItems.length;
+
+        document.getElementById("totalCount").textContent = total;
+        document.getElementById("validCount").textContent = validCount;
+        document.getElementById("invalidCount").textContent = invalidCount;
+        document.getElementById("validPercent").textContent =
+          total > 0 ? ((validCount / total) * 100).toFixed(1) + "%" : "0%";
+        document.getElementById("invalidPercent").textContent =
+          total > 0 ? ((invalidCount / total) * 100).toFixed(1) + "%" : "0%";
+
+        // Update lists using safe DOM methods
+        const validList = document.getElementById("validList");
+        const invalidList = document.getElementById("invalidList");
+
+        // Clear existing content
+        validList.textContent = "";
+        invalidList.textContent = "";
+
+        if (validItems.length > 0) {
+          validItems.forEach((item) => {
+            validList.appendChild(createResultItem(item, true));
+          });
+        } else {
+          const emptyDiv = document.createElement("div");
+          emptyDiv.className = "empty-state";
+          emptyDiv.textContent = "无有效数据";
+          validList.appendChild(emptyDiv);
+        }
+
+        if (invalidItems.length > 0) {
+          invalidItems.forEach((item) => {
+            invalidList.appendChild(createResultItem(item, false));
+          });
+        } else {
+          const emptyDiv = document.createElement("div");
+          emptyDiv.className = "empty-state";
+          emptyDiv.textContent = "无无效数据";
+          invalidList.appendChild(emptyDiv);
+        }
+
+        saveState();
+        showToast("验证完成");
+      }
+
+      // Copy valid items
+      function copyValid() {
+        if (validItems.length === 0) {
+          showToast("没有可复制的有效数据");
+          return;
+        }
+        navigator.clipboard.writeText(validItems.join("\n")).then(() => {
+          showToast("有效数据已复制");
+        });
+      }
+
+      // Copy invalid items
+      function copyInvalid() {
+        if (invalidItems.length === 0) {
+          showToast("没有可复制的无效数据");
+          return;
+        }
+        navigator.clipboard.writeText(invalidItems.join("\n")).then(() => {
+          showToast("无效数据已复制");
+        });
+      }
+
+      // Clear all
+      function clearAll() {
+        inputEl.value = "";
+        validItems = [];
+        invalidItems = [];
+        document.getElementById("totalCount").textContent = "0";
+        document.getElementById("validCount").textContent = "0";
+        document.getElementById("invalidCount").textContent = "0";
+        document.getElementById("validPercent").textContent = "0%";
+        document.getElementById("invalidPercent").textContent = "0%";
+
+        const validList = document.getElementById("validList");
+        const invalidList = document.getElementById("invalidList");
+        validList.textContent = "";
+        invalidList.textContent = "";
+
+        const emptyValid = document.createElement("div");
+        emptyValid.className = "empty-state";
+        emptyValid.textContent = "验证后显示...";
+        validList.appendChild(emptyValid);
+
+        const emptyInvalid = document.createElement("div");
+        emptyInvalid.className = "empty-state";
+        emptyInvalid.textContent = "验证后显示...";
+        invalidList.appendChild(emptyInvalid);
+
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
+
+      // Save state
+      function saveState() {
+        const state = {
+          input: inputEl.value,
+          type: currentType
         };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
 
-        // Parse lines
-        function parseLines(text) {
-          return text
-            .split("\n")
-            .map((l) => l.trim())
-            .filter((l) => l !== "");
-        }
+      // Load state
+      function loadState() {
+        try {
+          const saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            const state = JSON.parse(saved);
+            inputEl.value = state.input || "";
 
-        // Create result item element safely
-        function createResultItem(text, isValid) {
-          const div = document.createElement("div");
-          div.className = "result-item " + (isValid ? "valid" : "invalid");
-          div.textContent = text;
-          return div;
-        }
-
-        // Validate data
-        function validateData() {
-          const lines = parseLines(inputEl.value);
-          if (lines.length === 0) {
-            showToast("请输入数据");
-            return;
-          }
-
-          const validator = validators[currentType];
-          validItems = [];
-          invalidItems = [];
-
-          lines.forEach((line) => {
-            if (validator(line)) {
-              validItems.push(line);
-            } else {
-              invalidItems.push(line);
+            if (state.type) {
+              currentType = state.type;
+              document.querySelectorAll(".type-btn").forEach((btn) => {
+                if (btn.dataset.type === state.type) {
+                  btn.classList.add("active");
+                } else {
+                  btn.classList.remove("active");
+                }
+              });
             }
-          });
-
-          // Update stats
-          const total = lines.length;
-          const validCount = validItems.length;
-          const invalidCount = invalidItems.length;
-
-          document.getElementById("totalCount").textContent = total;
-          document.getElementById("validCount").textContent = validCount;
-          document.getElementById("invalidCount").textContent = invalidCount;
-          document.getElementById("validPercent").textContent =
-            total > 0 ? ((validCount / total) * 100).toFixed(1) + "%" : "0%";
-          document.getElementById("invalidPercent").textContent =
-            total > 0 ? ((invalidCount / total) * 100).toFixed(1) + "%" : "0%";
-
-          // Update lists using safe DOM methods
-          const validList = document.getElementById("validList");
-          const invalidList = document.getElementById("invalidList");
-
-          // Clear existing content
-          validList.textContent = "";
-          invalidList.textContent = "";
-
-          if (validItems.length > 0) {
-            validItems.forEach((item) => {
-              validList.appendChild(createResultItem(item, true));
-            });
-          } else {
-            const emptyDiv = document.createElement("div");
-            emptyDiv.className = "empty-state";
-            emptyDiv.textContent = "无有效数据";
-            validList.appendChild(emptyDiv);
           }
-
-          if (invalidItems.length > 0) {
-            invalidItems.forEach((item) => {
-              invalidList.appendChild(createResultItem(item, false));
-            });
-          } else {
-            const emptyDiv = document.createElement("div");
-            emptyDiv.className = "empty-state";
-            emptyDiv.textContent = "无无效数据";
-            invalidList.appendChild(emptyDiv);
-          }
-
-          saveState();
-          showToast("验证完成");
+        } catch {
+          // ignore
         }
+      }
 
-        // Copy valid items
-        function copyValid() {
-          if (validItems.length === 0) {
-            showToast("没有可复制的有效数据");
-            return;
-          }
-          navigator.clipboard.writeText(validItems.join("\n")).then(() => {
-            showToast("有效数据已复制");
-          });
+      // Theme toggle
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Show toast
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // Init theme
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // Copy invalid items
-        function copyInvalid() {
-          if (invalidItems.length === 0) {
-            showToast("没有可复制的无效数据");
-            return;
-          }
-          navigator.clipboard.writeText(invalidItems.join("\n")).then(() => {
-            showToast("无效数据已复制");
-          });
-        }
+      // Auto-save on input
+      inputEl.addEventListener("input", saveState);
 
-        // Clear all
-        function clearAll() {
-          inputEl.value = "";
-          validItems = [];
-          invalidItems = [];
-          document.getElementById("totalCount").textContent = "0";
-          document.getElementById("validCount").textContent = "0";
-          document.getElementById("invalidCount").textContent = "0";
-          document.getElementById("validPercent").textContent = "0%";
-          document.getElementById("invalidPercent").textContent = "0%";
+      // Load state on init
+      loadState();
+    </script>
 
-          const validList = document.getElementById("validList");
-          const invalidList = document.getElementById("invalidList");
-          validList.textContent = "";
-          invalidList.textContent = "";
-
-          const emptyValid = document.createElement("div");
-          emptyValid.className = "empty-state";
-          emptyValid.textContent = "验证后显示...";
-          validList.appendChild(emptyValid);
-
-          const emptyInvalid = document.createElement("div");
-          emptyInvalid.className = "empty-state";
-          emptyInvalid.textContent = "验证后显示...";
-          invalidList.appendChild(emptyInvalid);
-
-          localStorage.removeItem(LS_KEY);
-          showToast("已清空");
-        }
-
-        // Save state
-        function saveState() {
-          const state = {
-            input: inputEl.value,
-            type: currentType
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
-        }
-
-        // Load state
-        function loadState() {
-          try {
-            const saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              const state = JSON.parse(saved);
-              inputEl.value = state.input || "";
-
-              if (state.type) {
-                currentType = state.type;
-                document.querySelectorAll(".type-btn").forEach((btn) => {
-                  if (btn.dataset.type === state.type) {
-                    btn.classList.add("active");
-                  } else {
-                    btn.classList.remove("active");
-                  }
-                });
-              }
-            }
-          } catch {
-            // ignore
-          }
-        }
-
-        // Theme toggle
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-
-        // Show toast
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
-
-        // Init theme
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // Auto-save on input
-        inputEl.addEventListener("input", saveState);
-
-        // Load state on init
-        loadState();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/excel-to-json.html
+++ b/tools/data/excel-to-json.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Excel To Json - WebUtils" />
-    <meta property="og:description" content="Excel To Json，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Excel To Json，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/excel-to-json.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Excel To Json - WebUtils" />
-    <meta name="twitter:description" content="Excel To Json，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Excel To Json，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Excel To Json",
-      "item": "https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Excel To Json",
+            "item": "https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Excel To Json - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Excel To Json - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,767 +97,777 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-  .tool-section {
-    margin-bottom: 24px;
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .input-group {
-    margin-bottom: 16px;
-  }
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
-  .options-row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-bottom: 16px;
-  }
-  .option-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .option-group label {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-  }
-  .option-group select {
-    width: auto;
-    min-width: 150px;
-  }
-  .checkbox-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .checkbox-group input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--color-accent-cyan);
-  }
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-accent-cyan);
-    min-height: 200px;
-    max-height: 400px;
-    overflow: auto;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-  }
-  .stats {
-    display: flex;
-    gap: 24px;
-    flex-wrap: wrap;
-    margin-top: 12px;
-    padding: 12px;
-    background: var(--color-bg-surface);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-  }
-  .stat-item {
-    display: flex;
-    gap: 6px;
-  }
-  .stat-label {
-    color: var(--color-text-muted);
-  }
-  .stat-value {
-    color: var(--color-accent-cyan);
-    font-weight: 500;
-  }
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  .file-upload {
-    border: 2px dashed var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.2s;
-    margin-bottom: 16px;
-  }
-  .file-upload:hover {
-    border-color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.05);
-  }
-  .file-upload input {
-    display: none;
-  }
-  .file-upload-text {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-  }
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .btn {
-      width: 100%;
-    }
-    .options-row {
-      flex-direction: column;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+      .tool-section {
+        margin-bottom: 24px;
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .input-group {
+        margin-bottom: 16px;
+      }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
+      .options-row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 16px;
+      }
+      .option-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .option-group label {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+      }
+      .option-group select {
+        width: auto;
+        min-width: 150px;
+      }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .checkbox-group input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--color-accent-cyan);
+      }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-accent-cyan);
+        min-height: 200px;
+        max-height: 400px;
+        overflow: auto;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+      .stats {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        margin-top: 12px;
+        padding: 12px;
+        background: var(--color-bg-surface);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+      }
+      .stat-item {
+        display: flex;
+        gap: 6px;
+      }
+      .stat-label {
+        color: var(--color-text-muted);
+      }
+      .stat-value {
+        color: var(--color-accent-cyan);
+        font-weight: 500;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .file-upload {
+        border: 2px dashed var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.2s;
+        margin-bottom: 16px;
+      }
+      .file-upload:hover {
+        border-color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.05);
+      }
+      .file-upload input {
+        display: none;
+      }
+      .file-upload-text {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .btn {
+          width: 100%;
+        }
+        .options-row {
+          flex-direction: column;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">Excel/CSV 转 JSON</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        Excel/CSV 转 JSON
-      </h1>
-      <p>将 CSV/TSV 数据转换为 JSON 格式，支持自动检测分隔符</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">Excel/CSV 转 JSON</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              Excel/CSV 转 JSON
+            </h1>
+            <p>将 CSV/TSV 数据转换为 JSON 格式，支持自动检测分隔符</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">输入数据</div>
-      <div class="file-upload" onclick="document.getElementById('fileInput').click()">
-        <input type="file" id="fileInput" accept=".csv,.tsv,.txt" onchange="handleFile(event)">
-        <div class="file-upload-text">📁 点击上传 CSV/TSV 文件，或拖拽文件到此处</div>
-      </div>
-      <div class="input-group">
-        <label class="input-label">或粘贴 CSV/TSV 数据</label>
-        <textarea id="input" placeholder="姓名,年龄,城市
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">输入数据</div>
+            <div class="file-upload" onclick="document.getElementById('fileInput').click()">
+              <input
+                type="file"
+                id="fileInput"
+                accept=".csv,.tsv,.txt"
+                onchange="handleFile(event)"
+              />
+              <div class="file-upload-text">📁 点击上传 CSV/TSV 文件，或拖拽文件到此处</div>
+            </div>
+            <div class="input-group">
+              <label class="input-label">或粘贴 CSV/TSV 数据</label>
+              <textarea
+                id="input"
+                placeholder="姓名,年龄,城市
 张三,25,北京
 李四,30,上海
-王五,28,广州"></textarea>
-      </div>
+王五,28,广州"
+              ></textarea>
+            </div>
 
-      <div class="options-row">
-        <div class="option-group">
-          <label>分隔符：</label>
-          <select id="delimiter">
-            <option value="auto">自动检测</option>
-            <option value=",">逗号 (,)</option>
-            <option value="	">制表符 (Tab)</option>
-            <option value=";">分号 (;)</option>
-            <option value="|">竖线 (|)</option>
-          </select>
-        </div>
-        <div class="option-group">
-          <label>输出格式：</label>
-          <select id="outputFormat">
-            <option value="objects">对象数组 [{...}]</option>
-            <option value="arrays">二维数组 [[...]]</option>
-          </select>
-        </div>
-        <div class="option-group">
-          <label>缩进：</label>
-          <select id="indent">
-            <option value="2">2 空格</option>
-            <option value="4">4 空格</option>
-            <option value="0">紧凑</option>
-          </select>
-        </div>
-      </div>
+            <div class="options-row">
+              <div class="option-group">
+                <label>分隔符：</label>
+                <select id="delimiter">
+                  <option value="auto">自动检测</option>
+                  <option value=",">逗号 (,)</option>
+                  <option value="	">制表符 (Tab)</option>
+                  <option value=";">分号 (;)</option>
+                  <option value="|">竖线 (|)</option>
+                </select>
+              </div>
+              <div class="option-group">
+                <label>输出格式：</label>
+                <select id="outputFormat">
+                  <option value="objects">对象数组 [{...}]</option>
+                  <option value="arrays">二维数组 [[...]]</option>
+                </select>
+              </div>
+              <div class="option-group">
+                <label>缩进：</label>
+                <select id="indent">
+                  <option value="2">2 空格</option>
+                  <option value="4">4 空格</option>
+                  <option value="0">紧凑</option>
+                </select>
+              </div>
+            </div>
 
-      <div class="options-row">
-        <div class="checkbox-group">
-          <input type="checkbox" id="firstRowHeader" checked="">
-          <label for="firstRowHeader">首行作为字段名</label>
-        </div>
-        <div class="checkbox-group">
-          <input type="checkbox" id="trimValues" checked="">
-          <label for="trimValues">去除空白</label>
-        </div>
-        <div class="checkbox-group">
-          <input type="checkbox" id="skipEmpty" checked="">
-          <label for="skipEmpty">跳过空行</label>
-        </div>
-      </div>
+            <div class="options-row">
+              <div class="checkbox-group">
+                <input type="checkbox" id="firstRowHeader" checked="" />
+                <label for="firstRowHeader">首行作为字段名</label>
+              </div>
+              <div class="checkbox-group">
+                <input type="checkbox" id="trimValues" checked="" />
+                <label for="trimValues">去除空白</label>
+              </div>
+              <div class="checkbox-group">
+                <input type="checkbox" id="skipEmpty" checked="" />
+                <label for="skipEmpty">跳过空行</label>
+              </div>
+            </div>
 
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="convertToJSON()">🔄 转换</button>
-        <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
-        <button class="btn btn-secondary" onclick="loadSample()">📝 示例</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="convertToJSON()">🔄 转换</button>
+              <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
+              <button class="btn btn-secondary" onclick="loadSample()">📝 示例</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🗑️ 清空</button>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">JSON 输出</div>
+            <div class="result-box" id="result">转换结果将显示在这里...</div>
+            <div class="stats" id="stats" style="display: none">
+              <div class="stat-item">
+                <span class="stat-label">行数：</span>
+                <span class="stat-value" id="rowCount">0</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-label">列数：</span>
+                <span class="stat-value" id="colCount">0</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-label">检测分隔符：</span>
+                <span class="stat-value" id="detectedDelimiter">-</span>
+              </div>
+            </div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-primary" onclick="copyResult()">📋 复制</button>
+              <button class="btn btn-secondary" onclick="downloadJSON()">💾 下载 JSON</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="tool-section">
-      <div class="section-title">JSON 输出</div>
-      <div class="result-box" id="result">转换结果将显示在这里...</div>
-      <div class="stats" id="stats" style="display: none">
-        <div class="stat-item">
-          <span class="stat-label">行数：</span>
-          <span class="stat-value" id="rowCount">0</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">列数：</span>
-          <span class="stat-value" id="colCount">0</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">检测分隔符：</span>
-          <span class="stat-value" id="detectedDelimiter">-</span>
-        </div>
-      </div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-primary" onclick="copyResult()">📋 复制</button>
-        <button class="btn btn-secondary" onclick="downloadJSON()">💾 下载 JSON</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "Excel/CSV 转 JSON",
-              "item": "https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Excel/CSV 转 JSON",
+            "item": "https://tools.realtime-ai.chat/tools/data/excel-to-json.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // Theme toggle
+      function toggleTheme() {
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        document.body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") document.body.setAttribute("data-theme", "light");
+      })();
 
-  // Theme toggle
-        function toggleTheme() {
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          document.body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") document.body.setAttribute("data-theme", "light");
-        })();
+      // File upload
+      function handleFile(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          document.getElementById("input").value = e.target.result;
+          showToast("文件已加载");
+        };
+        reader.readAsText(file);
+      }
 
-        // File upload
-        function handleFile(event) {
-          const file = event.target.files[0];
-          if (!file) return;
+      // Drag and drop
+      const fileUpload = document.querySelector(".file-upload");
+      fileUpload.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        fileUpload.style.borderColor = "var(--color-accent-cyan)";
+      });
+      fileUpload.addEventListener("dragleave", () => {
+        fileUpload.style.borderColor = "var(--border-subtle)";
+      });
+      fileUpload.addEventListener("drop", (e) => {
+        e.preventDefault();
+        fileUpload.style.borderColor = "var(--border-subtle)";
+        const file = e.dataTransfer.files[0];
+        if (file) {
           const reader = new FileReader();
-          reader.onload = (e) => {
-            document.getElementById("input").value = e.target.result;
+          reader.onload = (ev) => {
+            document.getElementById("input").value = ev.target.result;
             showToast("文件已加载");
           };
           reader.readAsText(file);
         }
+      });
 
-        // Drag and drop
-        const fileUpload = document.querySelector(".file-upload");
-        fileUpload.addEventListener("dragover", (e) => {
-          e.preventDefault();
-          fileUpload.style.borderColor = "var(--color-accent-cyan)";
-        });
-        fileUpload.addEventListener("dragleave", () => {
-          fileUpload.style.borderColor = "var(--border-subtle)";
-        });
-        fileUpload.addEventListener("drop", (e) => {
-          e.preventDefault();
-          fileUpload.style.borderColor = "var(--border-subtle)";
-          const file = e.dataTransfer.files[0];
-          if (file) {
-            const reader = new FileReader();
-            reader.onload = (ev) => {
-              document.getElementById("input").value = ev.target.result;
-              showToast("文件已加载");
-            };
-            reader.readAsText(file);
+      // Detect delimiter
+      function detectDelimiter(text) {
+        const firstLine = text.split("\n")[0];
+        const delimiters = [",", "\t", ";", "|"];
+        let maxCount = 0;
+        let detected = ",";
+
+        for (const d of delimiters) {
+          const count = (firstLine.match(new RegExp(d === "|" ? "\\|" : d, "g")) || []).length;
+          if (count > maxCount) {
+            maxCount = count;
+            detected = d;
           }
-        });
-
-        // Detect delimiter
-        function detectDelimiter(text) {
-          const firstLine = text.split("\n")[0];
-          const delimiters = [",", "\t", ";", "|"];
-          let maxCount = 0;
-          let detected = ",";
-
-          for (const d of delimiters) {
-            const count = (firstLine.match(new RegExp(d === "|" ? "\\|" : d, "g")) || []).length;
-            if (count > maxCount) {
-              maxCount = count;
-              detected = d;
-            }
-          }
-          return detected;
         }
+        return detected;
+      }
 
-        // Parse CSV with proper quote handling
-        function parseCSV(text, delimiter, trimValues, skipEmpty) {
-          const rows = [];
-          let currentRow = [];
-          let currentValue = "";
-          let inQuotes = false;
+      // Parse CSV with proper quote handling
+      function parseCSV(text, delimiter, trimValues, skipEmpty) {
+        const rows = [];
+        let currentRow = [];
+        let currentValue = "";
+        let inQuotes = false;
 
-          for (let i = 0; i < text.length; i++) {
-            const char = text[i];
-            const nextChar = text[i + 1];
+        for (let i = 0; i < text.length; i++) {
+          const char = text[i];
+          const nextChar = text[i + 1];
 
-            if (inQuotes) {
-              if (char === '"' && nextChar === '"') {
-                currentValue += '"';
-                i++;
-              } else if (char === '"') {
-                inQuotes = false;
-              } else {
-                currentValue += char;
-              }
+          if (inQuotes) {
+            if (char === '"' && nextChar === '"') {
+              currentValue += '"';
+              i++;
+            } else if (char === '"') {
+              inQuotes = false;
             } else {
-              if (char === '"') {
-                inQuotes = true;
-              } else if (char === delimiter) {
-                currentRow.push(trimValues ? currentValue.trim() : currentValue);
-                currentValue = "";
-              } else if (char === "\n" || (char === "\r" && nextChar === "\n")) {
-                currentRow.push(trimValues ? currentValue.trim() : currentValue);
-                if (!skipEmpty || currentRow.some((v) => v !== "")) {
-                  rows.push(currentRow);
-                }
-                currentRow = [];
-                currentValue = "";
-                if (char === "\r") i++;
-              } else if (char !== "\r") {
-                currentValue += char;
+              currentValue += char;
+            }
+          } else {
+            if (char === '"') {
+              inQuotes = true;
+            } else if (char === delimiter) {
+              currentRow.push(trimValues ? currentValue.trim() : currentValue);
+              currentValue = "";
+            } else if (char === "\n" || (char === "\r" && nextChar === "\n")) {
+              currentRow.push(trimValues ? currentValue.trim() : currentValue);
+              if (!skipEmpty || currentRow.some((v) => v !== "")) {
+                rows.push(currentRow);
               }
+              currentRow = [];
+              currentValue = "";
+              if (char === "\r") i++;
+            } else if (char !== "\r") {
+              currentValue += char;
             }
           }
-
-          // Handle last row
-          if (currentValue || currentRow.length > 0) {
-            currentRow.push(trimValues ? currentValue.trim() : currentValue);
-            if (!skipEmpty || currentRow.some((v) => v !== "")) {
-              rows.push(currentRow);
-            }
-          }
-
-          return rows;
         }
 
-        // Convert to JSON
-        function convertToJSON() {
-          const input = document.getElementById("input").value;
-          if (!input.trim()) {
-            showToast("请输入数据");
+        // Handle last row
+        if (currentValue || currentRow.length > 0) {
+          currentRow.push(trimValues ? currentValue.trim() : currentValue);
+          if (!skipEmpty || currentRow.some((v) => v !== "")) {
+            rows.push(currentRow);
+          }
+        }
+
+        return rows;
+      }
+
+      // Convert to JSON
+      function convertToJSON() {
+        const input = document.getElementById("input").value;
+        if (!input.trim()) {
+          showToast("请输入数据");
+          return;
+        }
+
+        const delimiterSelect = document.getElementById("delimiter").value;
+        const delimiter = delimiterSelect === "auto" ? detectDelimiter(input) : delimiterSelect;
+        const outputFormat = document.getElementById("outputFormat").value;
+        const indent = parseInt(document.getElementById("indent").value);
+        const firstRowHeader = document.getElementById("firstRowHeader").checked;
+        const trimValues = document.getElementById("trimValues").checked;
+        const skipEmpty = document.getElementById("skipEmpty").checked;
+
+        try {
+          const rows = parseCSV(input, delimiter, trimValues, skipEmpty);
+
+          if (rows.length === 0) {
+            showToast("没有有效数据");
             return;
           }
 
-          const delimiterSelect = document.getElementById("delimiter").value;
-          const delimiter = delimiterSelect === "auto" ? detectDelimiter(input) : delimiterSelect;
-          const outputFormat = document.getElementById("outputFormat").value;
-          const indent = parseInt(document.getElementById("indent").value);
-          const firstRowHeader = document.getElementById("firstRowHeader").checked;
-          const trimValues = document.getElementById("trimValues").checked;
-          const skipEmpty = document.getElementById("skipEmpty").checked;
+          let result;
+          let headers = [];
+          let dataRows = rows;
 
-          try {
-            const rows = parseCSV(input, delimiter, trimValues, skipEmpty);
-
-            if (rows.length === 0) {
-              showToast("没有有效数据");
-              return;
-            }
-
-            let result;
-            let headers = [];
-            let dataRows = rows;
-
-            if (outputFormat === "objects" && firstRowHeader) {
-              headers = rows[0];
-              dataRows = rows.slice(1);
-              result = dataRows.map((row) => {
-                const obj = {};
-                headers.forEach((header, i) => {
-                  obj[header] = row[i] !== undefined ? row[i] : "";
-                });
-                return obj;
+          if (outputFormat === "objects" && firstRowHeader) {
+            headers = rows[0];
+            dataRows = rows.slice(1);
+            result = dataRows.map((row) => {
+              const obj = {};
+              headers.forEach((header, i) => {
+                obj[header] = row[i] !== undefined ? row[i] : "";
               });
-            } else if (outputFormat === "objects" && !firstRowHeader) {
-              result = dataRows.map((row) => {
-                const obj = {};
-                row.forEach((val, i) => {
-                  obj[`col${i + 1}`] = val;
-                });
-                return obj;
+              return obj;
+            });
+          } else if (outputFormat === "objects" && !firstRowHeader) {
+            result = dataRows.map((row) => {
+              const obj = {};
+              row.forEach((val, i) => {
+                obj[`col${i + 1}`] = val;
               });
-            } else {
-              result = rows;
-            }
-
-            const jsonStr = JSON.stringify(result, null, indent || undefined);
-            document.getElementById("result").textContent = jsonStr;
-
-            // Update stats
-            document.getElementById("stats").style.display = "flex";
-            document.getElementById("rowCount").textContent =
-              outputFormat === "objects" && firstRowHeader ? dataRows.length : rows.length;
-            document.getElementById("colCount").textContent = rows[0]?.length || 0;
-            const delimiterNames = { ",": "逗号", "\t": "制表符", ";": "分号", "|": "竖线" };
-            document.getElementById("detectedDelimiter").textContent =
-              delimiterNames[delimiter] || delimiter;
-
-            showToast("转换成功");
-          } catch (err) {
-            showToast("转换失败: " + err.message);
+              return obj;
+            });
+          } else {
+            result = rows;
           }
-        }
 
-        // Paste from clipboard
-        async function pasteData() {
-          try {
-            const text = await navigator.clipboard.readText();
-            document.getElementById("input").value = text;
-            showToast("已粘贴");
-          } catch (err) {
-            showToast("粘贴失败");
-          }
-        }
+          const jsonStr = JSON.stringify(result, null, indent || undefined);
+          document.getElementById("result").textContent = jsonStr;
 
-        // Load sample data
-        function loadSample() {
-          document.getElementById("input").value = `姓名,年龄,城市,职业
+          // Update stats
+          document.getElementById("stats").style.display = "flex";
+          document.getElementById("rowCount").textContent =
+            outputFormat === "objects" && firstRowHeader ? dataRows.length : rows.length;
+          document.getElementById("colCount").textContent = rows[0]?.length || 0;
+          const delimiterNames = { ",": "逗号", "\t": "制表符", ";": "分号", "|": "竖线" };
+          document.getElementById("detectedDelimiter").textContent =
+            delimiterNames[delimiter] || delimiter;
+
+          showToast("转换成功");
+        } catch (err) {
+          showToast("转换失败: " + err.message);
+        }
+      }
+
+      // Paste from clipboard
+      async function pasteData() {
+        try {
+          const text = await navigator.clipboard.readText();
+          document.getElementById("input").value = text;
+          showToast("已粘贴");
+        } catch (err) {
+          showToast("粘贴失败");
+        }
+      }
+
+      // Load sample data
+      function loadSample() {
+        document.getElementById("input").value = `姓名,年龄,城市,职业
   张三,25,北京,工程师
   李四,30,上海,设计师
   王五,28,"广州,天河区",产品经理
   "赵六",35,深圳,"数据分析师"`;
-          showToast("示例数据已加载");
+        showToast("示例数据已加载");
+      }
+
+      // Copy result
+      function copyResult() {
+        const result = document.getElementById("result").textContent;
+        if (!result || result === "转换结果将显示在这里...") {
+          showToast("没有可复制的内容");
+          return;
         }
+        navigator.clipboard.writeText(result).then(() => showToast("已复制"));
+      }
 
-        // Copy result
-        function copyResult() {
-          const result = document.getElementById("result").textContent;
-          if (!result || result === "转换结果将显示在这里...") {
-            showToast("没有可复制的内容");
-            return;
-          }
-          navigator.clipboard.writeText(result).then(() => showToast("已复制"));
+      // Download JSON
+      function downloadJSON() {
+        const result = document.getElementById("result").textContent;
+        if (!result || result === "转换结果将显示在这里...") {
+          showToast("没有可下载的内容");
+          return;
         }
+        const blob = new Blob([result], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "data.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        showToast("下载已开始");
+      }
 
-        // Download JSON
-        function downloadJSON() {
-          const result = document.getElementById("result").textContent;
-          if (!result || result === "转换结果将显示在这里...") {
-            showToast("没有可下载的内容");
-            return;
-          }
-          const blob = new Blob([result], { type: "application/json" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "data.json";
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast("下载已开始");
+      // Clear all
+      function clearAll() {
+        document.getElementById("input").value = "";
+        document.getElementById("result").textContent = "转换结果将显示在这里...";
+        document.getElementById("stats").style.display = "none";
+        showToast("已清空");
+      }
+
+      // Show toast
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // Keyboard shortcut
+      document.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+          e.preventDefault();
+          convertToJSON();
         }
+      });
 
-        // Clear all
-        function clearAll() {
-          document.getElementById("input").value = "";
-          document.getElementById("result").textContent = "转换结果将显示在这里...";
-          document.getElementById("stats").style.display = "none";
-          showToast("已清空");
-        }
+      // Load from localStorage
+      const savedInput = localStorage.getItem("excel-to-json-input");
+      if (savedInput) document.getElementById("input").value = savedInput;
 
-        // Show toast
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
+      // Save to localStorage on change
+      document.getElementById("input").addEventListener("input", () => {
+        localStorage.setItem("excel-to-json-input", document.getElementById("input").value);
+      });
+    </script>
 
-        // Keyboard shortcut
-        document.addEventListener("keydown", (e) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-            e.preventDefault();
-            convertToJSON();
-          }
-        });
-
-        // Load from localStorage
-        const savedInput = localStorage.getItem("excel-to-json-input");
-        if (savedInput) document.getElementById("input").value = savedInput;
-
-        // Save to localStorage on change
-        document.getElementById("input").addEventListener("input", () => {
-          localStorage.setItem("excel-to-json-input", document.getElementById("input").value);
-        });
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/heatmap-generator.html
+++ b/tools/data/heatmap-generator.html
@@ -6,7 +6,10 @@
     <title>Heatmap Generator - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="heatmap generator" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Heatmap Generator - WebUtils" />
-    <meta property="og:description" content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/heatmap-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Heatmap Generator - WebUtils" />
-    <meta name="twitter:description" content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Heatmap Generator，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Heatmap Generator",
-      "item": "https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Heatmap Generator",
+            "item": "https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Heatmap Generator - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Heatmap Generator - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,988 +100,993 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0 245 212 / 15%);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-  .tool-grid {
-    display: grid;
-    grid-template-columns: 380px 1fr;
-    gap: 24px;
-  }
-  .tool-section {
-    margin-bottom: 20px;
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 12px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .input-group {
-    margin-bottom: 12px;
-  }
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 6px;
-  }
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  textarea {
-    min-height: 160px;
-    resize: vertical;
-    font-size: 0.8rem;
-    line-height: 1.5;
-  }
-  .color-row {
-    display: flex;
-    gap: 10px;
-    align-items: flex-end;
-  }
-  .color-picker-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    flex: 1;
-  }
-  .color-picker-wrapper span {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--color-text-muted);
-  }
-  input[type="color"] {
-    width: 100%;
-    height: 36px;
-    padding: 2px;
-    cursor: pointer;
-  }
-  .gradient-preview {
-    margin-top: 8px;
-    height: 16px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle);
-  }
-  .preset-colors {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-    margin-top: 10px;
-  }
-  .preset-btn {
-    padding: 4px 10px;
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .preset-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .btn-row {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .canvas-container {
-    position: relative;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    min-height: 400px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    overflow: auto;
-  }
-  .canvas-container.empty {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-  #heatmapCanvas {
-    max-width: 100%;
-    cursor: crosshair;
-  }
-  .tooltip {
-    position: fixed;
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-primary);
-    pointer-events: none;
-    z-index: 1000;
-    opacity: 0;
-    transition: opacity 0.15s;
-    box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
-  }
-  .tooltip.visible {
-    opacity: 1;
-  }
-  .tooltip-row {
-    color: var(--color-accent-cyan);
-  }
-  .tooltip-col {
-    color: var(--color-accent-purple);
-  }
-  .tooltip-value {
-    color: var(--accent-yellow);
-    font-weight: 600;
-  }
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-top: 12px;
-    padding-top: 12px;
-    border-top: 1px solid var(--border-subtle);
-  }
-  .stat-item {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-  }
-  .stat-item span {
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-  }
-  .checkbox-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 10px;
-  }
-  .checkbox-group input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    accent-color: var(--color-accent-cyan);
-  }
-  .checkbox-group label {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-  }
-  .options-row {
-    display: flex;
-    gap: 12px;
-  }
-  .options-row .input-group {
-    flex: 1;
-    min-width: 80px;
-  }
-  .sample-hint {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--color-text-muted);
-    margin-top: 6px;
-    line-height: 1.4;
-  }
-  .sample-hint code {
-    background: var(--bg-input);
-    padding: 1px 4px;
-    border-radius: 2px;
-  }
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 10px 20px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s;
-    z-index: 1000;
-  }
-  .toast.error {
-    background: var(--accent-red);
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  @media (max-width: 900px) {
-    .tool-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .btn {
-      width: 100%;
-    }
-    .color-row {
-      flex-direction: column;
-    }
-    .options-row {
-      flex-direction: column;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0 245 212 / 15%);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+      .tool-grid {
+        display: grid;
+        grid-template-columns: 380px 1fr;
+        gap: 24px;
+      }
+      .tool-section {
+        margin-bottom: 20px;
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 12px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .input-group {
+        margin-bottom: 12px;
+      }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 6px;
+      }
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 8px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      textarea {
+        min-height: 160px;
+        resize: vertical;
+        font-size: 0.8rem;
+        line-height: 1.5;
+      }
+      .color-row {
+        display: flex;
+        gap: 10px;
+        align-items: flex-end;
+      }
+      .color-picker-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1;
+      }
+      .color-picker-wrapper span {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        color: var(--color-text-muted);
+      }
+      input[type="color"] {
+        width: 100%;
+        height: 36px;
+        padding: 2px;
+        cursor: pointer;
+      }
+      .gradient-preview {
+        margin-top: 8px;
+        height: 16px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-subtle);
+      }
+      .preset-colors {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .preset-btn {
+        padding: 4px 10px;
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .preset-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .btn-row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .canvas-container {
+        position: relative;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        min-height: 400px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: auto;
+      }
+      .canvas-container.empty {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+      #heatmapCanvas {
+        max-width: 100%;
+        cursor: crosshair;
+      }
+      .tooltip {
+        position: fixed;
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        padding: 8px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-primary);
+        pointer-events: none;
+        z-index: 1000;
+        opacity: 0;
+        transition: opacity 0.15s;
+        box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
+      }
+      .tooltip.visible {
+        opacity: 1;
+      }
+      .tooltip-row {
+        color: var(--color-accent-cyan);
+      }
+      .tooltip-col {
+        color: var(--color-accent-purple);
+      }
+      .tooltip-value {
+        color: var(--accent-yellow);
+        font-weight: 600;
+      }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-top: 12px;
+        padding-top: 12px;
+        border-top: 1px solid var(--border-subtle);
+      }
+      .stat-item {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-secondary);
+      }
+      .stat-item span {
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+      }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 10px;
+      }
+      .checkbox-group input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        accent-color: var(--color-accent-cyan);
+      }
+      .checkbox-group label {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
+      .options-row {
+        display: flex;
+        gap: 12px;
+      }
+      .options-row .input-group {
+        flex: 1;
+        min-width: 80px;
+      }
+      .sample-hint {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        color: var(--color-text-muted);
+        margin-top: 6px;
+        line-height: 1.4;
+      }
+      .sample-hint code {
+        background: var(--bg-input);
+        padding: 1px 4px;
+        border-radius: 2px;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 10px 20px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s;
+        z-index: 1000;
+      }
+      .toast.error {
+        background: var(--accent-red);
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      @media (max-width: 900px) {
+        .tool-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .btn {
+          width: 100%;
+        }
+        .color-row {
+          flex-direction: column;
+        }
+        .options-row {
+          flex-direction: column;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">热力图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔥</span>
-        热力图生成器
-      </h1>
-      <p>创建数据热力图，支持CSV数据、颜色自定义、行列标签、PNG导出</p>
-    </div>
-  </header>
-  <main class="main-content">
-    <div class="tool-grid">
-      <div class="settings-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入 (CSV格式)</div>
-          <div class="input-group">
-            <label class="input-label">矩阵数据 (每行一行数据，值用逗号分隔)</label>
-            <textarea id="dataInput" placeholder=",列A,列B,列C
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">热力图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔥</span>
+              热力图生成器
+            </h1>
+            <p>创建数据热力图，支持CSV数据、颜色自定义、行列标签、PNG导出</p>
+          </div>
+        </header>
+        <main class="main-content">
+          <div class="tool-grid">
+            <div class="settings-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入 (CSV格式)</div>
+                <div class="input-group">
+                  <label class="input-label">矩阵数据 (每行一行数据，值用逗号分隔)</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder=",列A,列B,列C
 行1,10,20,30
 行2,15,25,35
-行3,20,30,40"></textarea>
-            <div class="sample-hint">
-              提示: 第一行可作为列标签，第一列可作为行标签。如
-              <code>,A,B,C</code>
-              表示3列标签
+行3,20,30,40"
+                  ></textarea>
+                  <div class="sample-hint">
+                    提示: 第一行可作为列标签，第一列可作为行标签。如
+                    <code>,A,B,C</code>
+                    表示3列标签
+                  </div>
+                </div>
+                <div class="checkbox-group">
+                  <input type="checkbox" id="hasRowLabels" checked="" />
+                  <label for="hasRowLabels">第一列为行标签</label>
+                </div>
+                <div class="checkbox-group">
+                  <input type="checkbox" id="hasColLabels" checked="" />
+                  <label for="hasColLabels">第一行为列标签</label>
+                </div>
+              </div>
+              <div class="tool-section">
+                <div class="section-title">颜色设置</div>
+                <div class="color-row">
+                  <div class="color-picker-wrapper">
+                    <span>低值</span>
+                    <input type="color" id="lowColor" value="#0d47a1" />
+                  </div>
+                  <div class="color-picker-wrapper">
+                    <span>中值</span>
+                    <input type="color" id="midColor" value="#fff176" />
+                  </div>
+                  <div class="color-picker-wrapper">
+                    <span>高值</span>
+                    <input type="color" id="highColor" value="#b71c1c" />
+                  </div>
+                </div>
+                <div id="gradientPreview" class="gradient-preview"></div>
+                <div class="preset-colors">
+                  <button class="preset-btn" onclick="applyPreset('cool')">冷色</button>
+                  <button class="preset-btn" onclick="applyPreset('warm')">暖色</button>
+                  <button class="preset-btn" onclick="applyPreset('viridis')">Viridis</button>
+                  <button class="preset-btn" onclick="applyPreset('plasma')">Plasma</button>
+                  <button class="preset-btn" onclick="applyPreset('gray')">灰度</button>
+                </div>
+              </div>
+              <div class="tool-section">
+                <div class="section-title">显示选项</div>
+                <div class="options-row">
+                  <div class="input-group">
+                    <label class="input-label">单元格大小</label>
+                    <input type="number" id="cellSize" value="50" min="20" max="200" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">字体大小</label>
+                    <input type="number" id="fontSize" value="12" min="8" max="24" />
+                  </div>
+                </div>
+                <div class="checkbox-group">
+                  <input type="checkbox" id="showValues" checked="" />
+                  <label for="showValues">显示数值</label>
+                </div>
+                <div class="checkbox-group">
+                  <input type="checkbox" id="showLegend" checked="" />
+                  <label for="showLegend">显示图例</label>
+                </div>
+              </div>
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="generateHeatmap()">生成热力图</button>
+                <button class="btn btn-secondary" onclick="loadSample()">示例数据</button>
+              </div>
+              <div class="btn-row" style="margin-top: 10px">
+                <button class="btn btn-secondary" onclick="exportPNG()">导出 PNG</button>
+                <button class="btn btn-secondary" onclick="clearAll()">清空</button>
+              </div>
+            </div>
+            <div class="preview-panel">
+              <div class="tool-section" style="height: 100%">
+                <div class="section-title">热力图预览</div>
+                <div class="canvas-container empty" id="canvasContainer">
+                  <span id="placeholder">输入数据并点击"生成热力图"查看结果</span>
+                  <canvas id="heatmapCanvas" style="display: none"></canvas>
+                </div>
+                <div class="stats-row" id="statsRow" style="display: none">
+                  <div class="stat-item">
+                    行数:
+                    <span id="statRows">0</span>
+                  </div>
+                  <div class="stat-item">
+                    列数:
+                    <span id="statCols">0</span>
+                  </div>
+                  <div class="stat-item">
+                    最小值:
+                    <span id="statMin">0</span>
+                  </div>
+                  <div class="stat-item">
+                    最大值:
+                    <span id="statMax">0</span>
+                  </div>
+                  <div class="stat-item">
+                    平均值:
+                    <span id="statAvg">0</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="checkbox-group">
-            <input type="checkbox" id="hasRowLabels" checked="">
-            <label for="hasRowLabels">第一列为行标签</label>
-          </div>
-          <div class="checkbox-group">
-            <input type="checkbox" id="hasColLabels" checked="">
-            <label for="hasColLabels">第一行为列标签</label>
-          </div>
-        </div>
-        <div class="tool-section">
-          <div class="section-title">颜色设置</div>
-          <div class="color-row">
-            <div class="color-picker-wrapper">
-              <span>低值</span>
-              <input type="color" id="lowColor" value="#0d47a1">
-            </div>
-            <div class="color-picker-wrapper">
-              <span>中值</span>
-              <input type="color" id="midColor" value="#fff176">
-            </div>
-            <div class="color-picker-wrapper">
-              <span>高值</span>
-              <input type="color" id="highColor" value="#b71c1c">
-            </div>
-          </div>
-          <div id="gradientPreview" class="gradient-preview"></div>
-          <div class="preset-colors">
-            <button class="preset-btn" onclick="applyPreset('cool')">冷色</button>
-            <button class="preset-btn" onclick="applyPreset('warm')">暖色</button>
-            <button class="preset-btn" onclick="applyPreset('viridis')">Viridis</button>
-            <button class="preset-btn" onclick="applyPreset('plasma')">Plasma</button>
-            <button class="preset-btn" onclick="applyPreset('gray')">灰度</button>
-          </div>
-        </div>
-        <div class="tool-section">
-          <div class="section-title">显示选项</div>
-          <div class="options-row">
-            <div class="input-group">
-              <label class="input-label">单元格大小</label>
-              <input type="number" id="cellSize" value="50" min="20" max="200">
-            </div>
-            <div class="input-group">
-              <label class="input-label">字体大小</label>
-              <input type="number" id="fontSize" value="12" min="8" max="24">
-            </div>
-          </div>
-          <div class="checkbox-group">
-            <input type="checkbox" id="showValues" checked="">
-            <label for="showValues">显示数值</label>
-          </div>
-          <div class="checkbox-group">
-            <input type="checkbox" id="showLegend" checked="">
-            <label for="showLegend">显示图例</label>
-          </div>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="generateHeatmap()">生成热力图</button>
-          <button class="btn btn-secondary" onclick="loadSample()">示例数据</button>
-        </div>
-        <div class="btn-row" style="margin-top: 10px">
-          <button class="btn btn-secondary" onclick="exportPNG()">导出 PNG</button>
-          <button class="btn btn-secondary" onclick="clearAll()">清空</button>
-        </div>
-      </div>
-      <div class="preview-panel">
-        <div class="tool-section" style="height: 100%">
-          <div class="section-title">热力图预览</div>
-          <div class="canvas-container empty" id="canvasContainer">
-            <span id="placeholder">输入数据并点击"生成热力图"查看结果</span>
-            <canvas id="heatmapCanvas" style="display: none"></canvas>
-          </div>
-          <div class="stats-row" id="statsRow" style="display: none">
-            <div class="stat-item">
-              行数:
-              <span id="statRows">0</span>
-            </div>
-            <div class="stat-item">
-              列数:
-              <span id="statCols">0</span>
-            </div>
-            <div class="stat-item">
-              最小值:
-              <span id="statMin">0</span>
-            </div>
-            <div class="stat-item">
-              最大值:
-              <span id="statMax">0</span>
-            </div>
-            <div class="stat-item">
-              平均值:
-              <span id="statAvg">0</span>
-            </div>
-          </div>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "热力图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "热力图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/heatmap-generator.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      const LS_KEY = "heatmap_gen_v1";
+      let matrixData = [];
+      let rowLabels = [];
+      let colLabels = [];
+      let minVal = 0,
+        maxVal = 1;
+      const canvas = document.getElementById("heatmapCanvas");
+      const ctx = canvas.getContext("2d");
+      const tooltip = document.getElementById("tooltip");
+      const container = document.getElementById("canvasContainer");
 
-  const LS_KEY = "heatmap_gen_v1";
-        let matrixData = [];
-        let rowLabels = [];
-        let colLabels = [];
-        let minVal = 0,
-          maxVal = 1;
-        const canvas = document.getElementById("heatmapCanvas");
-        const ctx = canvas.getContext("2d");
-        const tooltip = document.getElementById("tooltip");
-        const container = document.getElementById("canvasContainer");
+      function toggleTheme() {
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        document.body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        if (matrixData.length > 0) generateHeatmap();
+      }
+      (function () {
+        if (localStorage.getItem("theme") === "light")
+          document.body.setAttribute("data-theme", "light");
+      })();
 
-        function toggleTheme() {
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          document.body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          if (matrixData.length > 0) generateHeatmap();
-        }
-        (function () {
-          if (localStorage.getItem("theme") === "light")
-            document.body.setAttribute("data-theme", "light");
-        })();
+      function updateGradient() {
+        const low = document.getElementById("lowColor").value;
+        const mid = document.getElementById("midColor").value;
+        const high = document.getElementById("highColor").value;
+        document.getElementById("gradientPreview").style.background =
+          `linear-gradient(to right, ${low}, ${mid}, ${high})`;
+      }
+      document.getElementById("lowColor").addEventListener("input", updateGradient);
+      document.getElementById("midColor").addEventListener("input", updateGradient);
+      document.getElementById("highColor").addEventListener("input", updateGradient);
+      updateGradient();
 
-        function updateGradient() {
-          const low = document.getElementById("lowColor").value;
-          const mid = document.getElementById("midColor").value;
-          const high = document.getElementById("highColor").value;
-          document.getElementById("gradientPreview").style.background =
-            `linear-gradient(to right, ${low}, ${mid}, ${high})`;
-        }
-        document.getElementById("lowColor").addEventListener("input", updateGradient);
-        document.getElementById("midColor").addEventListener("input", updateGradient);
-        document.getElementById("highColor").addEventListener("input", updateGradient);
+      const presets = {
+        cool: { low: "#0d47a1", mid: "#4fc3f7", high: "#e1f5fe" },
+        warm: { low: "#fff3e0", mid: "#ff9800", high: "#b71c1c" },
+        viridis: { low: "#440154", mid: "#21918c", high: "#fde725" },
+        plasma: { low: "#0d0887", mid: "#cc4778", high: "#f0f921" },
+        gray: { low: "#ffffff", mid: "#888888", high: "#000000" }
+      };
+      function applyPreset(name) {
+        const p = presets[name];
+        document.getElementById("lowColor").value = p.low;
+        document.getElementById("midColor").value = p.mid;
+        document.getElementById("highColor").value = p.high;
         updateGradient();
+        if (matrixData.length > 0) generateHeatmap();
+      }
 
-        const presets = {
-          cool: { low: "#0d47a1", mid: "#4fc3f7", high: "#e1f5fe" },
-          warm: { low: "#fff3e0", mid: "#ff9800", high: "#b71c1c" },
-          viridis: { low: "#440154", mid: "#21918c", high: "#fde725" },
-          plasma: { low: "#0d0887", mid: "#cc4778", high: "#f0f921" },
-          gray: { low: "#ffffff", mid: "#888888", high: "#000000" }
-        };
-        function applyPreset(name) {
-          const p = presets[name];
-          document.getElementById("lowColor").value = p.low;
-          document.getElementById("midColor").value = p.mid;
-          document.getElementById("highColor").value = p.high;
-          updateGradient();
-          if (matrixData.length > 0) generateHeatmap();
+      function parseData() {
+        const input = document.getElementById("dataInput").value.trim();
+        if (!input) {
+          showToast("请输入数据", true);
+          return false;
         }
-
-        function parseData() {
-          const input = document.getElementById("dataInput").value.trim();
-          if (!input) {
-            showToast("请输入数据", true);
-            return false;
-          }
-          const hasRow = document.getElementById("hasRowLabels").checked;
-          const hasCol = document.getElementById("hasColLabels").checked;
-          const lines = input.split("\n").filter((l) => l.trim());
-          if (lines.length === 0) {
-            showToast("数据为空", true);
-            return false;
-          }
-          let startRow = 0,
+        const hasRow = document.getElementById("hasRowLabels").checked;
+        const hasCol = document.getElementById("hasColLabels").checked;
+        const lines = input.split("\n").filter((l) => l.trim());
+        if (lines.length === 0) {
+          showToast("数据为空", true);
+          return false;
+        }
+        let startRow = 0,
+          startCol = 0;
+        if (hasCol) {
+          const first = lines[0].split(",").map((s) => s.trim());
+          colLabels = hasRow ? first.slice(1) : first;
+          startRow = 1;
+        } else {
+          colLabels = [];
+        }
+        matrixData = [];
+        rowLabels = [];
+        for (let i = startRow; i < lines.length; i++) {
+          const cells = lines[i].split(",").map((s) => s.trim());
+          if (hasRow) {
+            rowLabels.push(cells[0] || `R${i - startRow + 1}`);
+            startCol = 1;
+          } else {
             startCol = 0;
-          if (hasCol) {
-            const first = lines[0].split(",").map((s) => s.trim());
-            colLabels = hasRow ? first.slice(1) : first;
-            startRow = 1;
-          } else {
-            colLabels = [];
           }
-          matrixData = [];
-          rowLabels = [];
-          for (let i = startRow; i < lines.length; i++) {
-            const cells = lines[i].split(",").map((s) => s.trim());
-            if (hasRow) {
-              rowLabels.push(cells[0] || `R${i - startRow + 1}`);
-              startCol = 1;
-            } else {
-              startCol = 0;
-            }
-            const row = [];
-            for (let j = startCol; j < cells.length; j++) {
-              const v = parseFloat(cells[j]);
-              row.push(isNaN(v) ? 0 : v);
-            }
-            if (row.length > 0) matrixData.push(row);
+          const row = [];
+          for (let j = startCol; j < cells.length; j++) {
+            const v = parseFloat(cells[j]);
+            row.push(isNaN(v) ? 0 : v);
           }
-          if (matrixData.length === 0) {
-            showToast("无法解析有效数据", true);
-            return false;
-          }
-          const maxCols = Math.max(...matrixData.map((r) => r.length));
-          matrixData = matrixData.map((r) => {
-            while (r.length < maxCols) r.push(0);
-            return r;
-          });
-          if (!hasRow || rowLabels.length === 0) rowLabels = matrixData.map((_, i) => `R${i + 1}`);
-          if (!hasCol || colLabels.length === 0) colLabels = matrixData[0].map((_, i) => `C${i + 1}`);
-          while (rowLabels.length < matrixData.length) rowLabels.push(`R${rowLabels.length + 1}`);
-          while (colLabels.length < matrixData[0].length) colLabels.push(`C${colLabels.length + 1}`);
-          const all = matrixData.flat();
-          minVal = Math.min(...all);
-          maxVal = Math.max(...all);
-          return true;
+          if (row.length > 0) matrixData.push(row);
         }
-
-        function hexToRgb(hex) {
-          const r = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-          return r
-            ? { r: parseInt(r[1], 16), g: parseInt(r[2], 16), b: parseInt(r[3], 16) }
-            : { r: 0, g: 0, b: 0 };
+        if (matrixData.length === 0) {
+          showToast("无法解析有效数据", true);
+          return false;
         }
-        function interpolate(lowHex, midHex, highHex, t) {
-          const low = hexToRgb(lowHex),
-            mid = hexToRgb(midHex),
-            high = hexToRgb(highHex);
-          let r, g, b;
-          if (t < 0.5) {
-            const t2 = t * 2;
-            r = Math.round(low.r + (mid.r - low.r) * t2);
-            g = Math.round(low.g + (mid.g - low.g) * t2);
-            b = Math.round(low.b + (mid.b - low.b) * t2);
-          } else {
-            const t2 = (t - 0.5) * 2;
-            r = Math.round(mid.r + (high.r - mid.r) * t2);
-            g = Math.round(mid.g + (high.g - mid.g) * t2);
-            b = Math.round(mid.b + (high.b - mid.b) * t2);
-          }
-          return `rgb(${r},${g},${b})`;
-        }
-        function contrast(bg) {
-          const m = bg.match(/rgb\((\d+),(\d+),(\d+)\)/);
-          if (!m) return "#000";
-          const lum =
-            (0.299 * parseInt(m[1]) + 0.587 * parseInt(m[2]) + 0.114 * parseInt(m[3])) / 255;
-          return lum > 0.5 ? "#000" : "#fff";
-        }
-
-        function generateHeatmap() {
-          if (!parseData()) return;
-          const cellSize = parseInt(document.getElementById("cellSize").value) || 50;
-          const fontSize = parseInt(document.getElementById("fontSize").value) || 12;
-          const showVals = document.getElementById("showValues").checked;
-          const showLeg = document.getElementById("showLegend").checked;
-          const lowC = document.getElementById("lowColor").value;
-          const midC = document.getElementById("midColor").value;
-          const highC = document.getElementById("highColor").value;
-          const rows = matrixData.length,
-            cols = matrixData[0].length;
-          ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
-          const maxRowW = Math.max(...rowLabels.map((l) => ctx.measureText(l).width), 40);
-          const pad = 10,
-            legW = showLeg ? 70 : 0,
-            legPad = showLeg ? 20 : 0,
-            headerH = 70;
-          const canvasW = maxRowW + pad + cols * cellSize + legW + legPad + 30;
-          const canvasH = headerH + rows * cellSize + 30;
-          canvas.width = canvasW;
-          canvas.height = canvasH;
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          const bgC = isDark ? "#0e0e14" : "#f5f5f5";
-          const txtC = isDark ? "#e8e8ed" : "#1a1a1a";
-          const mutC = isDark ? "#8888a0" : "#666";
-          const borC = isDark ? "#2a2a3a" : "#e5e5e5";
-          ctx.fillStyle = bgC;
-          ctx.fillRect(0, 0, canvasW, canvasH);
-          const offX = maxRowW + pad,
-            offY = headerH;
-          ctx.fillStyle = mutC;
-          ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
-          ctx.textAlign = "center";
-          ctx.textBaseline = "bottom";
-          for (let j = 0; j < cols; j++) {
-            const x = offX + j * cellSize + cellSize / 2;
-            ctx.save();
-            ctx.translate(x, offY - 8);
-            ctx.rotate(-Math.PI / 4);
-            ctx.fillText(colLabels[j], 0, 0);
-            ctx.restore();
-          }
-          ctx.textAlign = "right";
-          ctx.textBaseline = "middle";
-          for (let i = 0; i < rows; i++) {
-            const y = offY + i * cellSize + cellSize / 2;
-            ctx.fillText(rowLabels[i], offX - pad, y);
-          }
-          for (let i = 0; i < rows; i++) {
-            for (let j = 0; j < cols; j++) {
-              const v = matrixData[i][j];
-              const t = maxVal === minVal ? 0.5 : (v - minVal) / (maxVal - minVal);
-              const color = interpolate(lowC, midC, highC, t);
-              const x = offX + j * cellSize,
-                y = offY + i * cellSize;
-              ctx.fillStyle = color;
-              ctx.fillRect(x, y, cellSize, cellSize);
-              ctx.strokeStyle = borC;
-              ctx.lineWidth = 1;
-              ctx.strokeRect(x, y, cellSize, cellSize);
-              if (showVals) {
-                ctx.fillStyle = contrast(color);
-                ctx.font = `${Math.max(fontSize - 2, 8)}px "JetBrains Mono", monospace`;
-                ctx.textAlign = "center";
-                ctx.textBaseline = "middle";
-                const dv = Number.isInteger(v) ? v : v.toFixed(1);
-                ctx.fillText(dv, x + cellSize / 2, y + cellSize / 2);
-              }
-            }
-          }
-          if (showLeg) {
-            const lx = offX + cols * cellSize + legPad,
-              ly = offY,
-              lh = rows * cellSize,
-              lw = 18;
-            const grad = ctx.createLinearGradient(0, ly + lh, 0, ly);
-            grad.addColorStop(0, lowC);
-            grad.addColorStop(0.5, midC);
-            grad.addColorStop(1, highC);
-            ctx.fillStyle = grad;
-            ctx.fillRect(lx, ly, lw, lh);
-            ctx.strokeStyle = borC;
-            ctx.strokeRect(lx, ly, lw, lh);
-            ctx.fillStyle = mutC;
-            ctx.font = `${fontSize - 2}px "JetBrains Mono", monospace`;
-            ctx.textAlign = "left";
-            ctx.textBaseline = "middle";
-            const fmt = (n) => (Number.isInteger(n) ? n : n.toFixed(1));
-            ctx.fillText(fmt(maxVal), lx + lw + 4, ly + 5);
-            ctx.fillText(fmt((minVal + maxVal) / 2), lx + lw + 4, ly + lh / 2);
-            ctx.fillText(fmt(minVal), lx + lw + 4, ly + lh - 5);
-          }
-          container.classList.remove("empty");
-          document.getElementById("placeholder").style.display = "none";
-          canvas.style.display = "block";
-          updateStats();
-          saveStorage();
-          showToast("热力图已生成");
-        }
-
-        function updateStats() {
-          const rows = matrixData.length,
-            cols = matrixData[0] ? matrixData[0].length : 0;
-          const all = matrixData.flat();
-          const avg = all.reduce((a, b) => a + b, 0) / all.length;
-          const fmt = (n) => (Number.isInteger(n) ? n : n.toFixed(2));
-          document.getElementById("statRows").textContent = rows;
-          document.getElementById("statCols").textContent = cols;
-          document.getElementById("statMin").textContent = fmt(minVal);
-          document.getElementById("statMax").textContent = fmt(maxVal);
-          document.getElementById("statAvg").textContent = fmt(avg);
-          document.getElementById("statsRow").style.display = "flex";
-        }
-
-        canvas.addEventListener("mousemove", function (e) {
-          if (matrixData.length === 0) return;
-          const rect = canvas.getBoundingClientRect();
-          const scaleX = canvas.width / rect.width,
-            scaleY = canvas.height / rect.height;
-          const x = (e.clientX - rect.left) * scaleX,
-            y = (e.clientY - rect.top) * scaleY;
-          const cellSize = parseInt(document.getElementById("cellSize").value) || 50;
-          const fontSize = parseInt(document.getElementById("fontSize").value) || 12;
-          ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
-          const maxRowW = Math.max(...rowLabels.map((l) => ctx.measureText(l).width), 40);
-          const pad = 10,
-            headerH = 70;
-          const offX = maxRowW + pad,
-            offY = headerH;
-          const col = Math.floor((x - offX) / cellSize);
-          const row = Math.floor((y - offY) / cellSize);
-          if (
-            row >= 0 &&
-            row < matrixData.length &&
-            col >= 0 &&
-            col < matrixData[0].length &&
-            x >= offX &&
-            y >= offY
-          ) {
-            const v = matrixData[row][col];
-            document.getElementById("tipRow").textContent = rowLabels[row];
-            document.getElementById("tipCol").textContent = colLabels[col];
-            document.getElementById("tipValue").textContent = Number.isInteger(v) ? v : v.toFixed(4);
-            tooltip.style.left = e.clientX + 12 + "px";
-            tooltip.style.top = e.clientY + 12 + "px";
-            tooltip.classList.add("visible");
-          } else {
-            tooltip.classList.remove("visible");
-          }
+        const maxCols = Math.max(...matrixData.map((r) => r.length));
+        matrixData = matrixData.map((r) => {
+          while (r.length < maxCols) r.push(0);
+          return r;
         });
-        canvas.addEventListener("mouseleave", () => tooltip.classList.remove("visible"));
+        if (!hasRow || rowLabels.length === 0) rowLabels = matrixData.map((_, i) => `R${i + 1}`);
+        if (!hasCol || colLabels.length === 0) colLabels = matrixData[0].map((_, i) => `C${i + 1}`);
+        while (rowLabels.length < matrixData.length) rowLabels.push(`R${rowLabels.length + 1}`);
+        while (colLabels.length < matrixData[0].length) colLabels.push(`C${colLabels.length + 1}`);
+        const all = matrixData.flat();
+        minVal = Math.min(...all);
+        maxVal = Math.max(...all);
+        return true;
+      }
 
-        function exportPNG() {
-          if (matrixData.length === 0) {
-            showToast("请先生成热力图", true);
-            return;
-          }
-          const link = document.createElement("a");
-          link.download = `heatmap_${Date.now()}.png`;
-          link.href = canvas.toDataURL("image/png");
-          link.click();
-          showToast("PNG已导出");
+      function hexToRgb(hex) {
+        const r = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+        return r
+          ? { r: parseInt(r[1], 16), g: parseInt(r[2], 16), b: parseInt(r[3], 16) }
+          : { r: 0, g: 0, b: 0 };
+      }
+      function interpolate(lowHex, midHex, highHex, t) {
+        const low = hexToRgb(lowHex),
+          mid = hexToRgb(midHex),
+          high = hexToRgb(highHex);
+        let r, g, b;
+        if (t < 0.5) {
+          const t2 = t * 2;
+          r = Math.round(low.r + (mid.r - low.r) * t2);
+          g = Math.round(low.g + (mid.g - low.g) * t2);
+          b = Math.round(low.b + (mid.b - low.b) * t2);
+        } else {
+          const t2 = (t - 0.5) * 2;
+          r = Math.round(mid.r + (high.r - mid.r) * t2);
+          g = Math.round(mid.g + (high.g - mid.g) * t2);
+          b = Math.round(mid.b + (high.b - mid.b) * t2);
         }
+        return `rgb(${r},${g},${b})`;
+      }
+      function contrast(bg) {
+        const m = bg.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        if (!m) return "#000";
+        const lum =
+          (0.299 * parseInt(m[1]) + 0.587 * parseInt(m[2]) + 0.114 * parseInt(m[3])) / 255;
+        return lum > 0.5 ? "#000" : "#fff";
+      }
 
-        function loadSample() {
-          document.getElementById("dataInput").value = `,周一,周二,周三,周四,周五,周六,周日
+      function generateHeatmap() {
+        if (!parseData()) return;
+        const cellSize = parseInt(document.getElementById("cellSize").value) || 50;
+        const fontSize = parseInt(document.getElementById("fontSize").value) || 12;
+        const showVals = document.getElementById("showValues").checked;
+        const showLeg = document.getElementById("showLegend").checked;
+        const lowC = document.getElementById("lowColor").value;
+        const midC = document.getElementById("midColor").value;
+        const highC = document.getElementById("highColor").value;
+        const rows = matrixData.length,
+          cols = matrixData[0].length;
+        ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
+        const maxRowW = Math.max(...rowLabels.map((l) => ctx.measureText(l).width), 40);
+        const pad = 10,
+          legW = showLeg ? 70 : 0,
+          legPad = showLeg ? 20 : 0,
+          headerH = 70;
+        const canvasW = maxRowW + pad + cols * cellSize + legW + legPad + 30;
+        const canvasH = headerH + rows * cellSize + 30;
+        canvas.width = canvasW;
+        canvas.height = canvasH;
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        const bgC = isDark ? "#0e0e14" : "#f5f5f5";
+        const txtC = isDark ? "#e8e8ed" : "#1a1a1a";
+        const mutC = isDark ? "#8888a0" : "#666";
+        const borC = isDark ? "#2a2a3a" : "#e5e5e5";
+        ctx.fillStyle = bgC;
+        ctx.fillRect(0, 0, canvasW, canvasH);
+        const offX = maxRowW + pad,
+          offY = headerH;
+        ctx.fillStyle = mutC;
+        ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "bottom";
+        for (let j = 0; j < cols; j++) {
+          const x = offX + j * cellSize + cellSize / 2;
+          ctx.save();
+          ctx.translate(x, offY - 8);
+          ctx.rotate(-Math.PI / 4);
+          ctx.fillText(colLabels[j], 0, 0);
+          ctx.restore();
+        }
+        ctx.textAlign = "right";
+        ctx.textBaseline = "middle";
+        for (let i = 0; i < rows; i++) {
+          const y = offY + i * cellSize + cellSize / 2;
+          ctx.fillText(rowLabels[i], offX - pad, y);
+        }
+        for (let i = 0; i < rows; i++) {
+          for (let j = 0; j < cols; j++) {
+            const v = matrixData[i][j];
+            const t = maxVal === minVal ? 0.5 : (v - minVal) / (maxVal - minVal);
+            const color = interpolate(lowC, midC, highC, t);
+            const x = offX + j * cellSize,
+              y = offY + i * cellSize;
+            ctx.fillStyle = color;
+            ctx.fillRect(x, y, cellSize, cellSize);
+            ctx.strokeStyle = borC;
+            ctx.lineWidth = 1;
+            ctx.strokeRect(x, y, cellSize, cellSize);
+            if (showVals) {
+              ctx.fillStyle = contrast(color);
+              ctx.font = `${Math.max(fontSize - 2, 8)}px "JetBrains Mono", monospace`;
+              ctx.textAlign = "center";
+              ctx.textBaseline = "middle";
+              const dv = Number.isInteger(v) ? v : v.toFixed(1);
+              ctx.fillText(dv, x + cellSize / 2, y + cellSize / 2);
+            }
+          }
+        }
+        if (showLeg) {
+          const lx = offX + cols * cellSize + legPad,
+            ly = offY,
+            lh = rows * cellSize,
+            lw = 18;
+          const grad = ctx.createLinearGradient(0, ly + lh, 0, ly);
+          grad.addColorStop(0, lowC);
+          grad.addColorStop(0.5, midC);
+          grad.addColorStop(1, highC);
+          ctx.fillStyle = grad;
+          ctx.fillRect(lx, ly, lw, lh);
+          ctx.strokeStyle = borC;
+          ctx.strokeRect(lx, ly, lw, lh);
+          ctx.fillStyle = mutC;
+          ctx.font = `${fontSize - 2}px "JetBrains Mono", monospace`;
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          const fmt = (n) => (Number.isInteger(n) ? n : n.toFixed(1));
+          ctx.fillText(fmt(maxVal), lx + lw + 4, ly + 5);
+          ctx.fillText(fmt((minVal + maxVal) / 2), lx + lw + 4, ly + lh / 2);
+          ctx.fillText(fmt(minVal), lx + lw + 4, ly + lh - 5);
+        }
+        container.classList.remove("empty");
+        document.getElementById("placeholder").style.display = "none";
+        canvas.style.display = "block";
+        updateStats();
+        saveStorage();
+        showToast("热力图已生成");
+      }
+
+      function updateStats() {
+        const rows = matrixData.length,
+          cols = matrixData[0] ? matrixData[0].length : 0;
+        const all = matrixData.flat();
+        const avg = all.reduce((a, b) => a + b, 0) / all.length;
+        const fmt = (n) => (Number.isInteger(n) ? n : n.toFixed(2));
+        document.getElementById("statRows").textContent = rows;
+        document.getElementById("statCols").textContent = cols;
+        document.getElementById("statMin").textContent = fmt(minVal);
+        document.getElementById("statMax").textContent = fmt(maxVal);
+        document.getElementById("statAvg").textContent = fmt(avg);
+        document.getElementById("statsRow").style.display = "flex";
+      }
+
+      canvas.addEventListener("mousemove", function (e) {
+        if (matrixData.length === 0) return;
+        const rect = canvas.getBoundingClientRect();
+        const scaleX = canvas.width / rect.width,
+          scaleY = canvas.height / rect.height;
+        const x = (e.clientX - rect.left) * scaleX,
+          y = (e.clientY - rect.top) * scaleY;
+        const cellSize = parseInt(document.getElementById("cellSize").value) || 50;
+        const fontSize = parseInt(document.getElementById("fontSize").value) || 12;
+        ctx.font = `${fontSize}px "JetBrains Mono", monospace`;
+        const maxRowW = Math.max(...rowLabels.map((l) => ctx.measureText(l).width), 40);
+        const pad = 10,
+          headerH = 70;
+        const offX = maxRowW + pad,
+          offY = headerH;
+        const col = Math.floor((x - offX) / cellSize);
+        const row = Math.floor((y - offY) / cellSize);
+        if (
+          row >= 0 &&
+          row < matrixData.length &&
+          col >= 0 &&
+          col < matrixData[0].length &&
+          x >= offX &&
+          y >= offY
+        ) {
+          const v = matrixData[row][col];
+          document.getElementById("tipRow").textContent = rowLabels[row];
+          document.getElementById("tipCol").textContent = colLabels[col];
+          document.getElementById("tipValue").textContent = Number.isInteger(v) ? v : v.toFixed(4);
+          tooltip.style.left = e.clientX + 12 + "px";
+          tooltip.style.top = e.clientY + 12 + "px";
+          tooltip.classList.add("visible");
+        } else {
+          tooltip.classList.remove("visible");
+        }
+      });
+      canvas.addEventListener("mouseleave", () => tooltip.classList.remove("visible"));
+
+      function exportPNG() {
+        if (matrixData.length === 0) {
+          showToast("请先生成热力图", true);
+          return;
+        }
+        const link = document.createElement("a");
+        link.download = `heatmap_${Date.now()}.png`;
+        link.href = canvas.toDataURL("image/png");
+        link.click();
+        showToast("PNG已导出");
+      }
+
+      function loadSample() {
+        document.getElementById("dataInput").value = `,周一,周二,周三,周四,周五,周六,周日
   00:00,5,3,2,1,2,8,10
   04:00,2,1,1,1,1,3,4
   08:00,45,52,48,55,60,25,15
   12:00,80,85,82,88,75,40,35
   16:00,65,70,68,72,55,30,28
   20:00,40,42,38,45,48,55,60`;
-          document.getElementById("hasRowLabels").checked = true;
-          document.getElementById("hasColLabels").checked = true;
-          showToast("示例数据已加载");
-        }
+        document.getElementById("hasRowLabels").checked = true;
+        document.getElementById("hasColLabels").checked = true;
+        showToast("示例数据已加载");
+      }
 
-        function clearAll() {
-          document.getElementById("dataInput").value = "";
-          matrixData = [];
-          rowLabels = [];
-          colLabels = [];
-          container.classList.add("empty");
-          document.getElementById("placeholder").style.display = "";
-          canvas.style.display = "none";
-          document.getElementById("statsRow").style.display = "none";
-          localStorage.removeItem(LS_KEY);
-          showToast("已清空");
-        }
+      function clearAll() {
+        document.getElementById("dataInput").value = "";
+        matrixData = [];
+        rowLabels = [];
+        colLabels = [];
+        container.classList.add("empty");
+        document.getElementById("placeholder").style.display = "";
+        canvas.style.display = "none";
+        document.getElementById("statsRow").style.display = "none";
+        localStorage.removeItem(LS_KEY);
+        showToast("已清空");
+      }
 
-        function saveStorage() {
-          const d = {
-            input: document.getElementById("dataInput").value,
-            hasRow: document.getElementById("hasRowLabels").checked,
-            hasCol: document.getElementById("hasColLabels").checked,
-            lowC: document.getElementById("lowColor").value,
-            midC: document.getElementById("midColor").value,
-            highC: document.getElementById("highColor").value,
-            cell: document.getElementById("cellSize").value,
-            font: document.getElementById("fontSize").value,
-            showV: document.getElementById("showValues").checked,
-            showL: document.getElementById("showLegend").checked
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(d));
+      function saveStorage() {
+        const d = {
+          input: document.getElementById("dataInput").value,
+          hasRow: document.getElementById("hasRowLabels").checked,
+          hasCol: document.getElementById("hasColLabels").checked,
+          lowC: document.getElementById("lowColor").value,
+          midC: document.getElementById("midColor").value,
+          highC: document.getElementById("highColor").value,
+          cell: document.getElementById("cellSize").value,
+          font: document.getElementById("fontSize").value,
+          showV: document.getElementById("showValues").checked,
+          showL: document.getElementById("showLegend").checked
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(d));
+      }
+      function loadStorage() {
+        const s = localStorage.getItem(LS_KEY);
+        if (!s) return;
+        try {
+          const d = JSON.parse(s);
+          if (d.input) document.getElementById("dataInput").value = d.input;
+          if (d.hasRow !== undefined) document.getElementById("hasRowLabels").checked = d.hasRow;
+          if (d.hasCol !== undefined) document.getElementById("hasColLabels").checked = d.hasCol;
+          if (d.lowC) document.getElementById("lowColor").value = d.lowC;
+          if (d.midC) document.getElementById("midColor").value = d.midC;
+          if (d.highC) document.getElementById("highColor").value = d.highC;
+          if (d.cell) document.getElementById("cellSize").value = d.cell;
+          if (d.font) document.getElementById("fontSize").value = d.font;
+          if (d.showV !== undefined) document.getElementById("showValues").checked = d.showV;
+          if (d.showL !== undefined) document.getElementById("showLegend").checked = d.showL;
+          updateGradient();
+          if (d.input && d.input.trim()) generateHeatmap();
+        } catch (e) {
+          console.error(e);
         }
-        function loadStorage() {
-          const s = localStorage.getItem(LS_KEY);
-          if (!s) return;
-          try {
-            const d = JSON.parse(s);
-            if (d.input) document.getElementById("dataInput").value = d.input;
-            if (d.hasRow !== undefined) document.getElementById("hasRowLabels").checked = d.hasRow;
-            if (d.hasCol !== undefined) document.getElementById("hasColLabels").checked = d.hasCol;
-            if (d.lowC) document.getElementById("lowColor").value = d.lowC;
-            if (d.midC) document.getElementById("midColor").value = d.midC;
-            if (d.highC) document.getElementById("highColor").value = d.highC;
-            if (d.cell) document.getElementById("cellSize").value = d.cell;
-            if (d.font) document.getElementById("fontSize").value = d.font;
-            if (d.showV !== undefined) document.getElementById("showValues").checked = d.showV;
-            if (d.showL !== undefined) document.getElementById("showLegend").checked = d.showL;
-            updateGradient();
-            if (d.input && d.input.trim()) generateHeatmap();
-          } catch (e) {
-            console.error(e);
-          }
-        }
+      }
 
-        function showToast(msg, isErr = false) {
-          const t = document.getElementById("toast");
-          t.textContent = msg;
-          t.classList.toggle("error", isErr);
-          t.classList.add("show");
-          setTimeout(() => t.classList.remove("show"), 2000);
-        }
+      function showToast(msg, isErr = false) {
+        const t = document.getElementById("toast");
+        t.textContent = msg;
+        t.classList.toggle("error", isErr);
+        t.classList.add("show");
+        setTimeout(() => t.classList.remove("show"), 2000);
+      }
 
-        loadStorage();
-</script>
-    
+      loadStorage();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/histogram-generator.html
+++ b/tools/data/histogram-generator.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="histogram 直方图 分布 统计 数据可视化 频率" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/data/histogram-generator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="直方图生成器 - WebUtils" />
     <meta property="og:description" content="创建数据分布直方图，支持统计分析和PNG导出" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/histogram-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "直方图生成器",
-      "item": "https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "直方图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "直方图生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "直方图生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,452 +94,458 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1.2fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1.2fr;
+        gap: 24px;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="color"] {
-    width: 60px;
-    height: 40px;
-    padding: 2px;
-    cursor: pointer;
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="color"] {
+        width: 60px;
+        height: 40px;
+        padding: 2px;
+        cursor: pointer;
+      }
 
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .inline-group {
-    display: flex;
-    gap: 12px;
-    align-items: flex-end;
-  }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
 
-  .inline-group .input-group {
-    flex: 1;
-    margin-bottom: 0;
-  }
+      .inline-group {
+        display: flex;
+        gap: 12px;
+        align-items: flex-end;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .inline-group .input-group {
+        flex: 1;
+        margin-bottom: 0;
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .chart-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    min-height: 350px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .chart-placeholder {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    text-align: center;
-  }
+      .chart-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        min-height: 350px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
 
-  #chartCanvas {
-    max-width: 100%;
-    max-height: 100%;
-  }
+      .chart-placeholder {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        text-align: center;
+      }
 
-  .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 12px;
-    margin-top: 16px;
-  }
+      #chartCanvas {
+        max-width: 100%;
+        max-height: 100%;
+      }
 
-  .stat-card {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 12px 16px;
-    text-align: center;
-  }
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 12px;
+        margin-top: 16px;
+      }
 
-  .stat-label {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 4px;
-  }
+      .stat-card {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 12px 16px;
+        text-align: center;
+      }
 
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .stat-label {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 4px;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  .example-data {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-top: 8px;
-    font-family: var(--font-mono);
-  }
+      .toast.error {
+        background: var(--accent-red);
+      }
 
-  .color-preview {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
+      .example-data {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 8px;
+        font-family: var(--font-mono);
+      }
 
-  .color-preview input[type="color"] {
-    width: 50px;
-    height: 35px;
-  }
+      .color-preview {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .color-preview input[type="color"] {
+        width: 50px;
+        height: 35px;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .inline-group {
-      flex-direction: column;
-      align-items: stretch;
-    }
+        .btn {
+          width: 100%;
+        }
 
-    .stats-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-</style>
+        .inline-group {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .stats-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">直方图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        直方图生成器
-      </h1>
-      <p>创建数据分布直方图，支持统计分析和PNG导出</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">直方图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              直方图生成器
+            </h1>
+            <p>创建数据分布直方图，支持统计分析和PNG导出</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- Left Panel: Input & Settings -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">数值数据 (每行一个或逗号分隔)</label>
-            <textarea id="dataInput" placeholder="23
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- Left Panel: Input & Settings -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">数值数据 (每行一个或逗号分隔)</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder="23
 45
 67
 34
@@ -552,614 +564,620 @@
 45
 67
 23
-56"></textarea>
-            <div class="example-data">支持每行一个数值，或逗号/空格/制表符分隔</div>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-secondary" onclick="loadSampleData()">📋 示例数据</button>
-            <button class="btn btn-secondary" onclick="pasteFromClipboard()">📥 粘贴</button>
-          </div>
-        </div>
+56"
+                  ></textarea>
+                  <div class="example-data">支持每行一个数值，或逗号/空格/制表符分隔</div>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-secondary" onclick="loadSampleData()">📋 示例数据</button>
+                  <button class="btn btn-secondary" onclick="pasteFromClipboard()">📥 粘贴</button>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">图表设置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="直方图标题" value="数据分布直方图">
-          </div>
-          <div class="inline-group">
-            <div class="input-group">
-              <label class="input-label">X轴标签</label>
-              <input type="text" id="xAxisLabel" placeholder="X轴" value="数值区间">
+              <div class="tool-section">
+                <div class="section-title">图表设置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input
+                    type="text"
+                    id="chartTitle"
+                    placeholder="直方图标题"
+                    value="数据分布直方图"
+                  />
+                </div>
+                <div class="inline-group">
+                  <div class="input-group">
+                    <label class="input-label">X轴标签</label>
+                    <input type="text" id="xAxisLabel" placeholder="X轴" value="数值区间" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">Y轴标签</label>
+                    <input type="text" id="yAxisLabel" placeholder="Y轴" value="频数" />
+                  </div>
+                </div>
+                <div class="inline-group" style="margin-top: 16px">
+                  <div class="input-group">
+                    <label class="input-label">分组数量 (Bins)</label>
+                    <input type="number" id="binCount" value="10" min="2" max="100" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">柱状颜色</label>
+                    <div class="color-preview">
+                      <input type="color" id="barColor" value="#00f5d4" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="generateHistogram()">📊 生成直方图</button>
+                <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+              </div>
             </div>
-            <div class="input-group">
-              <label class="input-label">Y轴标签</label>
-              <input type="text" id="yAxisLabel" placeholder="Y轴" value="频数">
-            </div>
-          </div>
-          <div class="inline-group" style="margin-top: 16px">
-            <div class="input-group">
-              <label class="input-label">分组数量 (Bins)</label>
-              <input type="number" id="binCount" value="10" min="2" max="100">
-            </div>
-            <div class="input-group">
-              <label class="input-label">柱状颜色</label>
-              <div class="color-preview">
-                <input type="color" id="barColor" value="#00f5d4">
+
+            <!-- Right Panel: Chart Output -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">直方图预览</div>
+                <div class="chart-container" id="chartContainer">
+                  <canvas id="chartCanvas"></canvas>
+                  <div class="chart-placeholder" id="chartPlaceholder">
+                    输入数据后点击"生成直方图"
+                  </div>
+                </div>
+              </div>
+
+              <div class="tool-section">
+                <div class="section-title">统计信息</div>
+                <div class="stats-grid" id="statsGrid">
+                  <div class="stat-card">
+                    <div class="stat-label">样本数</div>
+                    <div class="stat-value" id="statCount">-</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-label">平均值</div>
+                    <div class="stat-value" id="statMean">-</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-label">中位数</div>
+                    <div class="stat-value" id="statMedian">-</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-label">标准差</div>
+                    <div class="stat-value" id="statStd">-</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-label">最小值</div>
+                    <div class="stat-value" id="statMin">-</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-label">最大值</div>
+                    <div class="stat-value" id="statMax">-</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="btn-row" style="margin-top: 16px">
+                <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
+                <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
               </div>
             </div>
           </div>
-        </div>
-
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="generateHistogram()">📊 生成直方图</button>
-          <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        </div>
-      </div>
-
-      <!-- Right Panel: Chart Output -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">直方图预览</div>
-          <div class="chart-container" id="chartContainer">
-            <canvas id="chartCanvas"></canvas>
-            <div class="chart-placeholder" id="chartPlaceholder">输入数据后点击"生成直方图"</div>
-          </div>
-        </div>
-
-        <div class="tool-section">
-          <div class="section-title">统计信息</div>
-          <div class="stats-grid" id="statsGrid">
-            <div class="stat-card">
-              <div class="stat-label">样本数</div>
-              <div class="stat-value" id="statCount">-</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-label">平均值</div>
-              <div class="stat-value" id="statMean">-</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-label">中位数</div>
-              <div class="stat-value" id="statMedian">-</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-label">标准差</div>
-              <div class="stat-value" id="statStd">-</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-label">最小值</div>
-              <div class="stat-value" id="statMin">-</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-label">最大值</div>
-              <div class="stat-value" id="statMax">-</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="btn-row" style="margin-top: 16px">
-          <button class="btn btn-primary" onclick="exportPNG()">📥 导出PNG</button>
-          <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "直方图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
-            }
-          ]
-        }
-
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "直方图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/histogram-generator.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      let chartInstance = null;
 
-  let chartInstance = null;
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        // 如果有图表，重新生成以更新颜色
+        if (chartInstance) {
+          generateHistogram();
+        }
+      }
 
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          // 如果有图表，重新生成以更新颜色
-          if (chartInstance) {
-            generateHistogram();
-          }
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // 解析数值数据
+      function parseData(input) {
+        // 支持多种分隔符: 换行、逗号、空格、制表符、分号
+        const values = input
+          .split(/[\n,\s\t;]+/)
+          .map((v) => v.trim())
+          .filter((v) => v !== "")
+          .map((v) => parseFloat(v))
+          .filter((v) => !isNaN(v) && isFinite(v));
+
+        return values.length > 0 ? values : null;
+      }
+
+      // 计算统计信息
+      function calculateStats(data) {
+        const n = data.length;
+        const sorted = [...data].sort((a, b) => a - b);
+
+        // 平均值
+        const mean = data.reduce((sum, v) => sum + v, 0) / n;
+
+        // 中位数
+        const median =
+          n % 2 === 0 ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2 : sorted[Math.floor(n / 2)];
+
+        // 标准差
+        const variance = data.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / n;
+        const stdDev = Math.sqrt(variance);
+
+        // 最小值和最大值
+        const min = sorted[0];
+        const max = sorted[n - 1];
+
+        return { count: n, mean, median, stdDev, min, max };
+      }
+
+      // 创建直方图数据
+      function createHistogramData(values, binCount) {
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const range = max - min;
+
+        // 处理所有值相同的情况
+        if (range === 0) {
+          return {
+            labels: [min.toFixed(2)],
+            counts: [values.length]
+          };
         }
 
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+        const binWidth = range / binCount;
+        const bins = new Array(binCount).fill(0);
+        const labels = [];
 
-        // 解析数值数据
-        function parseData(input) {
-          // 支持多种分隔符: 换行、逗号、空格、制表符、分号
-          const values = input
-            .split(/[\n,\s\t;]+/)
-            .map((v) => v.trim())
-            .filter((v) => v !== "")
-            .map((v) => parseFloat(v))
-            .filter((v) => !isNaN(v) && isFinite(v));
-
-          return values.length > 0 ? values : null;
+        // 计算每个bin的范围标签
+        for (let i = 0; i < binCount; i++) {
+          const binStart = min + i * binWidth;
+          const binEnd = min + (i + 1) * binWidth;
+          labels.push(`${binStart.toFixed(1)}-${binEnd.toFixed(1)}`);
         }
+
+        // 将数据分配到bins
+        values.forEach((v) => {
+          let binIndex = Math.floor((v - min) / binWidth);
+          // 处理边界情况：最大值应该放在最后一个bin
+          if (binIndex >= binCount) binIndex = binCount - 1;
+          bins[binIndex]++;
+        });
+
+        return { labels, counts: bins };
+      }
+
+      // 更新统计显示
+      function updateStatsDisplay(stats) {
+        document.getElementById("statCount").textContent = stats.count;
+        document.getElementById("statMean").textContent = stats.mean.toFixed(2);
+        document.getElementById("statMedian").textContent = stats.median.toFixed(2);
+        document.getElementById("statStd").textContent = stats.stdDev.toFixed(2);
+        document.getElementById("statMin").textContent = stats.min.toFixed(2);
+        document.getElementById("statMax").textContent = stats.max.toFixed(2);
+      }
+
+      // 重置统计显示
+      function resetStatsDisplay() {
+        ["statCount", "statMean", "statMedian", "statStd", "statMin", "statMax"].forEach((id) => {
+          document.getElementById(id).textContent = "-";
+        });
+      }
+
+      // 生成直方图
+      function generateHistogram() {
+        const input = document.getElementById("dataInput").value;
+        const data = parseData(input);
+
+        if (!data) {
+          showToast("请输入有效的数值数据", true);
+          return;
+        }
+
+        if (data.length < 2) {
+          showToast("至少需要2个数据点", true);
+          return;
+        }
+
+        const chartTitle = document.getElementById("chartTitle").value || "直方图";
+        const xAxisLabel = document.getElementById("xAxisLabel").value || "";
+        const yAxisLabel = document.getElementById("yAxisLabel").value || "";
+        const binCount = parseInt(document.getElementById("binCount").value) || 10;
+        const barColor = document.getElementById("barColor").value;
 
         // 计算统计信息
-        function calculateStats(data) {
-          const n = data.length;
-          const sorted = [...data].sort((a, b) => a - b);
-
-          // 平均值
-          const mean = data.reduce((sum, v) => sum + v, 0) / n;
-
-          // 中位数
-          const median =
-            n % 2 === 0 ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2 : sorted[Math.floor(n / 2)];
-
-          // 标准差
-          const variance = data.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / n;
-          const stdDev = Math.sqrt(variance);
-
-          // 最小值和最大值
-          const min = sorted[0];
-          const max = sorted[n - 1];
-
-          return { count: n, mean, median, stdDev, min, max };
-        }
+        const stats = calculateStats(data);
+        updateStatsDisplay(stats);
 
         // 创建直方图数据
-        function createHistogramData(values, binCount) {
-          const min = Math.min(...values);
-          const max = Math.max(...values);
-          const range = max - min;
+        const histData = createHistogramData(data, binCount);
 
-          // 处理所有值相同的情况
-          if (range === 0) {
-            return {
-              labels: [min.toFixed(2)],
-              counts: [values.length]
-            };
-          }
+        // 隐藏占位符
+        document.getElementById("chartPlaceholder").style.display = "none";
 
-          const binWidth = range / binCount;
-          const bins = new Array(binCount).fill(0);
-          const labels = [];
-
-          // 计算每个bin的范围标签
-          for (let i = 0; i < binCount; i++) {
-            const binStart = min + i * binWidth;
-            const binEnd = min + (i + 1) * binWidth;
-            labels.push(`${binStart.toFixed(1)}-${binEnd.toFixed(1)}`);
-          }
-
-          // 将数据分配到bins
-          values.forEach((v) => {
-            let binIndex = Math.floor((v - min) / binWidth);
-            // 处理边界情况：最大值应该放在最后一个bin
-            if (binIndex >= binCount) binIndex = binCount - 1;
-            bins[binIndex]++;
-          });
-
-          return { labels, counts: bins };
+        // 销毁旧图表
+        if (chartInstance) {
+          chartInstance.destroy();
         }
 
-        // 更新统计显示
-        function updateStatsDisplay(stats) {
-          document.getElementById("statCount").textContent = stats.count;
-          document.getElementById("statMean").textContent = stats.mean.toFixed(2);
-          document.getElementById("statMedian").textContent = stats.median.toFixed(2);
-          document.getElementById("statStd").textContent = stats.stdDev.toFixed(2);
-          document.getElementById("statMin").textContent = stats.min.toFixed(2);
-          document.getElementById("statMax").textContent = stats.max.toFixed(2);
-        }
+        const ctx = document.getElementById("chartCanvas").getContext("2d");
 
-        // 重置统计显示
-        function resetStatsDisplay() {
-          ["statCount", "statMean", "statMedian", "statStd", "statMin", "statMax"].forEach((id) => {
-            document.getElementById(id).textContent = "-";
-          });
-        }
+        // 获取当前主题
+        const isLight = document.body.getAttribute("data-theme") === "light";
+        const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
+        const gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
 
-        // 生成直方图
-        function generateHistogram() {
-          const input = document.getElementById("dataInput").value;
-          const data = parseData(input);
+        // 计算颜色的较深版本用于边框
+        const borderColor = adjustColorBrightness(barColor, -20);
 
-          if (!data) {
-            showToast("请输入有效的数值数据", true);
-            return;
-          }
-
-          if (data.length < 2) {
-            showToast("至少需要2个数据点", true);
-            return;
-          }
-
-          const chartTitle = document.getElementById("chartTitle").value || "直方图";
-          const xAxisLabel = document.getElementById("xAxisLabel").value || "";
-          const yAxisLabel = document.getElementById("yAxisLabel").value || "";
-          const binCount = parseInt(document.getElementById("binCount").value) || 10;
-          const barColor = document.getElementById("barColor").value;
-
-          // 计算统计信息
-          const stats = calculateStats(data);
-          updateStatsDisplay(stats);
-
-          // 创建直方图数据
-          const histData = createHistogramData(data, binCount);
-
-          // 隐藏占位符
-          document.getElementById("chartPlaceholder").style.display = "none";
-
-          // 销毁旧图表
-          if (chartInstance) {
-            chartInstance.destroy();
-          }
-
-          const ctx = document.getElementById("chartCanvas").getContext("2d");
-
-          // 获取当前主题
-          const isLight = document.body.getAttribute("data-theme") === "light";
-          const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
-          const gridColor = isLight ? "#e5e5e5" : "#2a2a3a";
-
-          // 计算颜色的较深版本用于边框
-          const borderColor = adjustColorBrightness(barColor, -20);
-
-          chartInstance = new Chart(ctx, {
-            type: "bar",
-            data: {
-              labels: histData.labels,
-              datasets: [
-                {
-                  label: "频数",
-                  data: histData.counts,
-                  backgroundColor: barColor + "cc", // 添加透明度
-                  borderColor: borderColor,
-                  borderWidth: 1,
-                  borderRadius: 2,
-                  borderSkipped: false,
-                  barPercentage: 1,
-                  categoryPercentage: 0.95
+        chartInstance = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: histData.labels,
+            datasets: [
+              {
+                label: "频数",
+                data: histData.counts,
+                backgroundColor: barColor + "cc", // 添加透明度
+                borderColor: borderColor,
+                borderWidth: 1,
+                borderRadius: 2,
+                borderSkipped: false,
+                barPercentage: 1,
+                categoryPercentage: 0.95
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              title: {
+                display: true,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "bold",
+                  family: "'Space Grotesk', sans-serif"
+                },
+                padding: {
+                  top: 10,
+                  bottom: 20
                 }
-              ]
+              },
+              legend: {
+                display: false
+              },
+              tooltip: {
+                backgroundColor: isLight ? "#fff" : "#1a1a24",
+                titleColor: textColor,
+                bodyColor: textColor,
+                borderColor: gridColor,
+                borderWidth: 1,
+                cornerRadius: 4,
+                titleFont: {
+                  family: "'JetBrains Mono', monospace"
+                },
+                bodyFont: {
+                  family: "'JetBrains Mono', monospace"
+                },
+                callbacks: {
+                  label: function (context) {
+                    const count = context.raw;
+                    const total = histData.counts.reduce((a, b) => a + b, 0);
+                    const percentage = ((count / total) * 100).toFixed(1);
+                    return `频数: ${count} (${percentage}%)`;
+                  }
+                }
+              }
             },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: {
+            scales: {
+              x: {
                 title: {
-                  display: true,
-                  text: chartTitle,
+                  display: !!xAxisLabel,
+                  text: xAxisLabel,
                   color: textColor,
                   font: {
-                    size: 16,
-                    weight: "bold",
-                    family: "'Space Grotesk', sans-serif"
-                  },
-                  padding: {
-                    top: 10,
-                    bottom: 20
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
                   }
                 },
-                legend: {
-                  display: false
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 10
+                  },
+                  maxRotation: 45,
+                  minRotation: 0
                 },
-                tooltip: {
-                  backgroundColor: isLight ? "#fff" : "#1a1a24",
-                  titleColor: textColor,
-                  bodyColor: textColor,
-                  borderColor: gridColor,
-                  borderWidth: 1,
-                  cornerRadius: 4,
-                  titleFont: {
-                    family: "'JetBrains Mono', monospace"
-                  },
-                  bodyFont: {
-                    family: "'JetBrains Mono', monospace"
-                  },
-                  callbacks: {
-                    label: function (context) {
-                      const count = context.raw;
-                      const total = histData.counts.reduce((a, b) => a + b, 0);
-                      const percentage = ((count / total) * 100).toFixed(1);
-                      return `频数: ${count} (${percentage}%)`;
-                    }
-                  }
+                grid: {
+                  color: gridColor,
+                  drawBorder: false
                 }
               },
-              scales: {
-                x: {
-                  title: {
-                    display: !!xAxisLabel,
-                    text: xAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 10
-                    },
-                    maxRotation: 45,
-                    minRotation: 0
-                  },
-                  grid: {
-                    color: gridColor,
-                    drawBorder: false
+              y: {
+                title: {
+                  display: !!yAxisLabel,
+                  text: yAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
                   }
                 },
-                y: {
-                  title: {
-                    display: !!yAxisLabel,
-                    text: yAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace"
                   },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace"
-                    },
-                    stepSize: 1,
-                    precision: 0
-                  },
-                  grid: {
-                    color: gridColor,
-                    drawBorder: false
-                  },
-                  beginAtZero: true
-                }
-              },
-              animation: {
-                duration: 800,
-                easing: "easeOutQuart"
+                  stepSize: 1,
+                  precision: 0
+                },
+                grid: {
+                  color: gridColor,
+                  drawBorder: false
+                },
+                beginAtZero: true
               }
+            },
+            animation: {
+              duration: 800,
+              easing: "easeOutQuart"
             }
-          });
+          }
+        });
 
-          // 保存到 localStorage
+        // 保存到 localStorage
+        saveState();
+        showToast("直方图生成成功");
+      }
+
+      // 调整颜色亮度
+      function adjustColorBrightness(hex, percent) {
+        const num = parseInt(hex.replace("#", ""), 16);
+        const r = Math.min(255, Math.max(0, (num >> 16) + percent));
+        const g = Math.min(255, Math.max(0, ((num >> 8) & 0x00ff) + percent));
+        const b = Math.min(255, Math.max(0, (num & 0x0000ff) + percent));
+        return "#" + (0x1000000 + r * 0x10000 + g * 0x100 + b).toString(16).slice(1);
+      }
+
+      // 导出PNG
+      function exportPNG() {
+        if (!chartInstance) {
+          showToast("请先生成直方图", true);
+          return;
+        }
+
+        const canvas = document.getElementById("chartCanvas");
+        const link = document.createElement("a");
+        link.download = "histogram.png";
+        link.href = canvas.toDataURL("image/png", 1.0);
+        link.click();
+        showToast("PNG已下载");
+      }
+
+      // 分享功能
+      function shareChart() {
+        const state = {
+          data: document.getElementById("dataInput").value,
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          bins: document.getElementById("binCount").value,
+          color: document.getElementById("barColor").value
+        };
+
+        const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
+        const url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(() => {
+            showToast("分享链接已复制到剪贴板");
+          })
+          .catch(() => {
+            showToast("复制失败，请手动复制URL", true);
+          });
+      }
+
+      // 从URL加载状态
+      function loadFromUrl() {
+        const hash = window.location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          const state = JSON.parse(decodeURIComponent(atob(hash)));
+          if (state.data) document.getElementById("dataInput").value = state.data;
+          if (state.title) document.getElementById("chartTitle").value = state.title;
+          if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
+          if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
+          if (state.bins) document.getElementById("binCount").value = state.bins;
+          if (state.color) document.getElementById("barColor").value = state.color;
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 保存状态到 localStorage
+      function saveState() {
+        const state = {
+          data: document.getElementById("dataInput").value,
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          bins: document.getElementById("binCount").value,
+          color: document.getElementById("barColor").value
+        };
+        localStorage.setItem("histogram-generator-state", JSON.stringify(state));
+      }
+
+      // 从 localStorage 加载状态
+      function loadState() {
+        const saved = localStorage.getItem("histogram-generator-state");
+        if (!saved) return false;
+
+        try {
+          const state = JSON.parse(saved);
+          if (state.data) document.getElementById("dataInput").value = state.data;
+          if (state.title) document.getElementById("chartTitle").value = state.title;
+          if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
+          if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
+          if (state.bins) document.getElementById("binCount").value = state.bins;
+          if (state.color) document.getElementById("barColor").value = state.color;
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 加载示例数据
+      function loadSampleData() {
+        // 生成正态分布样本数据
+        const sampleData = [];
+        const mean = 50;
+        const stdDev = 15;
+
+        for (let i = 0; i < 100; i++) {
+          // Box-Muller变换生成正态分布
+          const u1 = Math.random();
+          const u2 = Math.random();
+          const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+          const value = mean + z * stdDev;
+          sampleData.push(Math.round(value * 10) / 10);
+        }
+
+        document.getElementById("dataInput").value = sampleData.join("\n");
+        document.getElementById("chartTitle").value = "正态分布示例";
+        showToast("已加载100个正态分布示例数据");
+      }
+
+      // 从剪贴板粘贴
+      async function pasteFromClipboard() {
+        try {
+          const text = await navigator.clipboard.readText();
+          document.getElementById("dataInput").value = text;
           saveState();
-          showToast("直方图生成成功");
+          showToast("已从剪贴板粘贴");
+        } catch (e) {
+          showToast("无法访问剪贴板", true);
+        }
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("dataInput").value = "";
+        document.getElementById("chartTitle").value = "数据分布直方图";
+        document.getElementById("xAxisLabel").value = "数值区间";
+        document.getElementById("yAxisLabel").value = "频数";
+        document.getElementById("binCount").value = "10";
+        document.getElementById("barColor").value = "#00f5d4";
+
+        // 销毁图表
+        if (chartInstance) {
+          chartInstance.destroy();
+          chartInstance = null;
+        }
+        document.getElementById("chartPlaceholder").style.display = "block";
+
+        // 重置统计信息
+        resetStatsDisplay();
+
+        // 清除 localStorage
+        localStorage.removeItem("histogram-generator-state");
+
+        // 清除 URL hash
+        history.replaceState(null, "", window.location.pathname);
+
+        showToast("已清空");
+      }
+
+      // 显示提示
+      function showToast(msg, isError = false) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.toggle("error", isError);
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // 初始化
+      (function init() {
+        // 优先从URL加载，否则从localStorage加载
+        const loadedFromUrl = loadFromUrl();
+        if (!loadedFromUrl) {
+          loadState();
         }
 
-        // 调整颜色亮度
-        function adjustColorBrightness(hex, percent) {
-          const num = parseInt(hex.replace("#", ""), 16);
-          const r = Math.min(255, Math.max(0, (num >> 16) + percent));
-          const g = Math.min(255, Math.max(0, ((num >> 8) & 0x00ff) + percent));
-          const b = Math.min(255, Math.max(0, (num & 0x0000ff) + percent));
-          return "#" + (0x1000000 + r * 0x10000 + g * 0x100 + b).toString(16).slice(1);
+        // 如果有数据，自动生成图表
+        const dataInput = document.getElementById("dataInput").value;
+        if (dataInput.trim()) {
+          generateHistogram();
         }
 
-        // 导出PNG
-        function exportPNG() {
-          if (!chartInstance) {
-            showToast("请先生成直方图", true);
-            return;
-          }
+        // 监听输入变化保存状态
+        const inputs = [
+          "dataInput",
+          "chartTitle",
+          "xAxisLabel",
+          "yAxisLabel",
+          "binCount",
+          "barColor"
+        ];
+        inputs.forEach((id) => {
+          const el = document.getElementById(id);
+          el.addEventListener("input", saveState);
+          el.addEventListener("change", saveState);
+        });
+      })();
+    </script>
 
-          const canvas = document.getElementById("chartCanvas");
-          const link = document.createElement("a");
-          link.download = "histogram.png";
-          link.href = canvas.toDataURL("image/png", 1.0);
-          link.click();
-          showToast("PNG已下载");
-        }
-
-        // 分享功能
-        function shareChart() {
-          const state = {
-            data: document.getElementById("dataInput").value,
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            bins: document.getElementById("binCount").value,
-            color: document.getElementById("barColor").value
-          };
-
-          const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
-          const url = window.location.href.split("#")[0] + "#" + encoded;
-
-          navigator.clipboard
-            .writeText(url)
-            .then(() => {
-              showToast("分享链接已复制到剪贴板");
-            })
-            .catch(() => {
-              showToast("复制失败，请手动复制URL", true);
-            });
-        }
-
-        // 从URL加载状态
-        function loadFromUrl() {
-          const hash = window.location.hash.slice(1);
-          if (!hash) return false;
-
-          try {
-            const state = JSON.parse(decodeURIComponent(atob(hash)));
-            if (state.data) document.getElementById("dataInput").value = state.data;
-            if (state.title) document.getElementById("chartTitle").value = state.title;
-            if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
-            if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
-            if (state.bins) document.getElementById("binCount").value = state.bins;
-            if (state.color) document.getElementById("barColor").value = state.color;
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 保存状态到 localStorage
-        function saveState() {
-          const state = {
-            data: document.getElementById("dataInput").value,
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            bins: document.getElementById("binCount").value,
-            color: document.getElementById("barColor").value
-          };
-          localStorage.setItem("histogram-generator-state", JSON.stringify(state));
-        }
-
-        // 从 localStorage 加载状态
-        function loadState() {
-          const saved = localStorage.getItem("histogram-generator-state");
-          if (!saved) return false;
-
-          try {
-            const state = JSON.parse(saved);
-            if (state.data) document.getElementById("dataInput").value = state.data;
-            if (state.title) document.getElementById("chartTitle").value = state.title;
-            if (state.xAxis) document.getElementById("xAxisLabel").value = state.xAxis;
-            if (state.yAxis) document.getElementById("yAxisLabel").value = state.yAxis;
-            if (state.bins) document.getElementById("binCount").value = state.bins;
-            if (state.color) document.getElementById("barColor").value = state.color;
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 加载示例数据
-        function loadSampleData() {
-          // 生成正态分布样本数据
-          const sampleData = [];
-          const mean = 50;
-          const stdDev = 15;
-
-          for (let i = 0; i < 100; i++) {
-            // Box-Muller变换生成正态分布
-            const u1 = Math.random();
-            const u2 = Math.random();
-            const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
-            const value = mean + z * stdDev;
-            sampleData.push(Math.round(value * 10) / 10);
-          }
-
-          document.getElementById("dataInput").value = sampleData.join("\n");
-          document.getElementById("chartTitle").value = "正态分布示例";
-          showToast("已加载100个正态分布示例数据");
-        }
-
-        // 从剪贴板粘贴
-        async function pasteFromClipboard() {
-          try {
-            const text = await navigator.clipboard.readText();
-            document.getElementById("dataInput").value = text;
-            saveState();
-            showToast("已从剪贴板粘贴");
-          } catch (e) {
-            showToast("无法访问剪贴板", true);
-          }
-        }
-
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("dataInput").value = "";
-          document.getElementById("chartTitle").value = "数据分布直方图";
-          document.getElementById("xAxisLabel").value = "数值区间";
-          document.getElementById("yAxisLabel").value = "频数";
-          document.getElementById("binCount").value = "10";
-          document.getElementById("barColor").value = "#00f5d4";
-
-          // 销毁图表
-          if (chartInstance) {
-            chartInstance.destroy();
-            chartInstance = null;
-          }
-          document.getElementById("chartPlaceholder").style.display = "block";
-
-          // 重置统计信息
-          resetStatsDisplay();
-
-          // 清除 localStorage
-          localStorage.removeItem("histogram-generator-state");
-
-          // 清除 URL hash
-          history.replaceState(null, "", window.location.pathname);
-
-          showToast("已清空");
-        }
-
-        // 显示提示
-        function showToast(msg, isError = false) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.toggle("error", isError);
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
-
-        // 初始化
-        (function init() {
-          // 优先从URL加载，否则从localStorage加载
-          const loadedFromUrl = loadFromUrl();
-          if (!loadedFromUrl) {
-            loadState();
-          }
-
-          // 如果有数据，自动生成图表
-          const dataInput = document.getElementById("dataInput").value;
-          if (dataInput.trim()) {
-            generateHistogram();
-          }
-
-          // 监听输入变化保存状态
-          const inputs = [
-            "dataInput",
-            "chartTitle",
-            "xAxisLabel",
-            "yAxisLabel",
-            "binCount",
-            "barColor"
-          ];
-          inputs.forEach((id) => {
-            const el = document.getElementById(id);
-            el.addEventListener("input", saveState);
-            el.addEventListener("change", saveState);
-          });
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/line-chart.html
+++ b/tools/data/line-chart.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Line Chart - WebUtils" />
-    <meta property="og:description" content="Line Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Line Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/line-chart.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Line Chart - WebUtils" />
-    <meta name="twitter:description" content="Line Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Line Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Line Chart",
-      "item": "https://tools.realtime-ai.chat/tools/data/line-chart.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Line Chart",
+            "item": "https://tools.realtime-ai.chat/tools/data/line-chart.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Line Chart - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Line Chart - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,516 +94,522 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .input-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  @media (max-width: 600px) {
-    .input-row {
-      grid-template-columns: 1fr;
-    }
-  }
+      .input-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      @media (max-width: 600px) {
+        .input-row {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-success {
-    background: var(--accent-green);
-    color: white;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
+      .btn-success {
+        background: var(--accent-green);
+        color: white;
+      }
 
-  .chart-container {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    min-height: 400px;
-    position: relative;
-  }
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
 
-  .chart-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 360px;
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
+      .chart-container {
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        min-height: 400px;
+        position: relative;
+      }
 
-  .series-manager {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
+      .chart-placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 360px;
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
 
-  .series-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
+      .series-manager {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
 
-  .series-color {
-    width: 32px;
-    height: 32px;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    padding: 0;
-  }
+      .series-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
 
-  .series-name {
-    flex: 1;
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-  }
+      .series-color {
+        width: 32px;
+        height: 32px;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        padding: 0;
+      }
 
-  .series-btn {
-    padding: 8px 12px;
-    font-size: 0.85rem;
-    background: transparent;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .series-name {
+        flex: 1;
+        padding: 8px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+      }
 
-  .series-btn:hover {
-    border-color: var(--accent-red);
-    color: var(--accent-red);
-  }
+      .series-btn {
+        padding: 8px 12px;
+        font-size: 0.85rem;
+        background: transparent;
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .add-series-btn {
-    padding: 10px;
-    background: transparent;
-    border: 1px dashed var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    transition: all 0.2s;
-  }
+      .series-btn:hover {
+        border-color: var(--accent-red);
+        color: var(--accent-red);
+      }
 
-  .add-series-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .add-series-btn {
+        padding: 10px;
+        background: transparent;
+        border: 1px dashed var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        transition: all 0.2s;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .add-series-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .series-item {
-      flex-wrap: wrap;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .series-item {
+          flex-wrap: wrap;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">折线图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📈</span>
-        折线图生成器
-      </h1>
-      <p>创建折线图和曲线图，支持多数据系列</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">折线图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📈</span>
+              折线图生成器
+            </h1>
+            <p>创建折线图和曲线图，支持多数据系列</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- 左侧：数据输入 -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">图表设置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="我的折线图" value="折线图">
-          </div>
-          <div class="input-row">
-            <div class="input-group">
-              <label class="input-label">X 轴标签</label>
-              <input type="text" id="xAxisLabel" placeholder="X 轴">
-            </div>
-            <div class="input-group">
-              <label class="input-label">Y 轴标签</label>
-              <input type="text" id="yAxisLabel" placeholder="Y 轴">
-            </div>
-          </div>
-          <div class="input-row">
-            <div class="input-group">
-              <label class="input-label">线条样式</label>
-              <select id="lineStyle">
-                <option value="smooth">平滑曲线</option>
-                <option value="linear">直线</option>
-                <option value="stepped">阶梯</option>
-              </select>
-            </div>
-            <div class="input-group">
-              <label class="input-label">显示数据点</label>
-              <select id="showPoints">
-                <option value="true">显示</option>
-                <option value="false">隐藏</option>
-              </select>
-            </div>
-          </div>
-        </div>
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- 左侧：数据输入 -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">图表设置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input type="text" id="chartTitle" placeholder="我的折线图" value="折线图" />
+                </div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="input-label">X 轴标签</label>
+                    <input type="text" id="xAxisLabel" placeholder="X 轴" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">Y 轴标签</label>
+                    <input type="text" id="yAxisLabel" placeholder="Y 轴" />
+                  </div>
+                </div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="input-label">线条样式</label>
+                    <select id="lineStyle">
+                      <option value="smooth">平滑曲线</option>
+                      <option value="linear">直线</option>
+                      <option value="stepped">阶梯</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">显示数据点</label>
+                    <select id="showPoints">
+                      <option value="true">显示</option>
+                      <option value="false">隐藏</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">数据系列</div>
-          <div class="series-manager" id="seriesManager">
-            <!-- 动态添加的系列 -->
-          </div>
-          <button class="add-series-btn" onclick="addSeries()">+ 添加数据系列</button>
-        </div>
+              <div class="tool-section">
+                <div class="section-title">数据系列</div>
+                <div class="series-manager" id="seriesManager">
+                  <!-- 动态添加的系列 -->
+                </div>
+                <button class="add-series-btn" onclick="addSeries()">+ 添加数据系列</button>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">输入数据（每行一个点）</label>
-            <textarea id="dataInput" placeholder="格式：X,Y 或 X,Y1,Y2,Y3...
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">输入数据（每行一个点）</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder="格式：X,Y 或 X,Y1,Y2,Y3...
 
 示例（单系列）：
 1,10
@@ -611,595 +623,594 @@ Jan,65,28
 Feb,59,48
 Mar,80,40
 Apr,81,19
-May,56,86"></textarea>
-            <div class="input-hint">提示：第一列为X轴标签，后续列对应各数据系列的Y值</div>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
-            <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例数据</button>
-            <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-          </div>
-        </div>
-      </div>
+May,56,86"
+                  ></textarea>
+                  <div class="input-hint">提示：第一列为X轴标签，后续列对应各数据系列的Y值</div>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
+                  <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例数据</button>
+                  <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+                </div>
+              </div>
+            </div>
 
-      <!-- 右侧：图表显示 -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">图表预览</div>
-          <div class="chart-container">
-            <canvas id="lineChart"></canvas>
-            <div class="chart-placeholder" id="chartPlaceholder">输入数据后生成图表</div>
+            <!-- 右侧：图表显示 -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">图表预览</div>
+                <div class="chart-container">
+                  <canvas id="lineChart"></canvas>
+                  <div class="chart-placeholder" id="chartPlaceholder">输入数据后生成图表</div>
+                </div>
+                <div class="btn-row" style="margin-top: 16px">
+                  <button class="btn btn-success" onclick="exportPNG()">📥 导出 PNG</button>
+                  <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="btn-row" style="margin-top: 16px">
-            <button class="btn btn-success" onclick="exportPNG()">📥 导出 PNG</button>
-            <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
-          </div>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "折线图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/line-chart.html"
-            }
-          ]
-        }
-
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "折线图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/line-chart.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // 全局变量
+      let chart = null;
+      let seriesCount = 0;
+      const defaultColors = [
+        "#00f5d4", // cyan
+        "#f72585", // magenta
+        "#fbbf24", // yellow
+        "#a855f7", // purple
+        "#10b981", // green
+        "#3b82f6", // blue
+        "#f43f5e", // red
+        "#06b6d4" // teal
+      ];
 
-  // 全局变量
-        let chart = null;
-        let seriesCount = 0;
-        const defaultColors = [
-          "#00f5d4", // cyan
-          "#f72585", // magenta
-          "#fbbf24", // yellow
-          "#a855f7", // purple
-          "#10b981", // green
-          "#3b82f6", // blue
-          "#f43f5e", // red
-          "#06b6d4" // teal
-        ];
+      const LS_KEY = "line-chart-data";
 
-        const LS_KEY = "line-chart-data";
-
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          // 重新生成图表以更新主题
-          if (chart) {
-            generateChart();
-          }
-        }
-
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // 创建系列元素
-        function createSeriesElement(name, color, id) {
-          const item = document.createElement("div");
-          item.className = "series-item";
-          item.dataset.seriesId = id;
-
-          const colorInput = document.createElement("input");
-          colorInput.type = "color";
-          colorInput.className = "series-color";
-          colorInput.value = color;
-          colorInput.title = "选择颜色";
-
-          const nameInput = document.createElement("input");
-          nameInput.type = "text";
-          nameInput.className = "series-name";
-          nameInput.value = name;
-          nameInput.placeholder = "系列名称";
-
-          const removeBtn = document.createElement("button");
-          removeBtn.className = "series-btn";
-          removeBtn.title = "删除系列";
-          removeBtn.textContent = "✕";
-          removeBtn.onclick = function () {
-            removeSeries(this);
-          };
-
-          item.appendChild(colorInput);
-          item.appendChild(nameInput);
-          item.appendChild(removeBtn);
-
-          // 绑定事件
-          colorInput.addEventListener("input", saveToStorage);
-          colorInput.addEventListener("change", saveToStorage);
-          nameInput.addEventListener("input", saveToStorage);
-          nameInput.addEventListener("change", saveToStorage);
-
-          return item;
-        }
-
-        // 初始化
-        document.addEventListener("DOMContentLoaded", function () {
-          // 添加默认数据系列
-          addSeries("系列 1", defaultColors[0]);
-
-          // 从 localStorage 加载
-          loadFromStorage();
-
-          // 从 URL hash 加载
-          loadFromUrl();
-
-          // 自动保存
-          document.querySelectorAll("input, textarea, select").forEach((el) => {
-            el.addEventListener("input", saveToStorage);
-            el.addEventListener("change", saveToStorage);
-          });
-        });
-
-        // 添加数据系列
-        function addSeries(name, color) {
-          seriesCount++;
-          const seriesName = name || "系列 " + seriesCount;
-          const seriesColor = color || defaultColors[(seriesCount - 1) % defaultColors.length];
-
-          const container = document.getElementById("seriesManager");
-          const item = createSeriesElement(seriesName, seriesColor, seriesCount);
-          container.appendChild(item);
-        }
-
-        // 移除数据系列
-        function removeSeries(btn) {
-          const items = document.querySelectorAll(".series-item");
-          if (items.length <= 1) {
-            showToast("至少保留一个数据系列", "error");
-            return;
-          }
-          btn.closest(".series-item").remove();
-          saveToStorage();
-        }
-
-        // 获取所有系列配置
-        function getSeriesConfig() {
-          const items = document.querySelectorAll(".series-item");
-          return Array.from(items).map(function (item) {
-            return {
-              name: item.querySelector(".series-name").value || "未命名",
-              color: item.querySelector(".series-color").value
-            };
-          });
-        }
-
-        // 解析数据
-        function parseData(input) {
-          const lines = input
-            .trim()
-            .split("\n")
-            .filter(function (line) {
-              return line.trim();
-            });
-          if (lines.length === 0) return null;
-
-          const labels = [];
-          const datasets = [];
-          const seriesConfig = getSeriesConfig();
-
-          // 解析每行数据
-          lines.forEach(function (line) {
-            const parts = line.split(",").map(function (s) {
-              return s.trim();
-            });
-            if (parts.length < 2) return;
-
-            labels.push(parts[0]);
-
-            // 解析 Y 值
-            for (let i = 1; i < parts.length; i++) {
-              const value = parseFloat(parts[i]);
-              if (!isNaN(value)) {
-                if (!datasets[i - 1]) {
-                  datasets[i - 1] = [];
-                }
-                datasets[i - 1].push(value);
-              }
-            }
-          });
-
-          if (labels.length === 0 || datasets.length === 0) return null;
-
-          // 确保有足够的系列配置
-          while (seriesConfig.length < datasets.length) {
-            const idx = seriesConfig.length;
-            seriesConfig.push({
-              name: "系列 " + (idx + 1),
-              color: defaultColors[idx % defaultColors.length]
-            });
-            // 添加 UI
-            addSeries(seriesConfig[idx].name, seriesConfig[idx].color);
-          }
-
-          return { labels: labels, datasets: datasets, seriesConfig: seriesConfig };
-        }
-
-        // 生成图表
-        function generateChart() {
-          const input = document.getElementById("dataInput").value;
-          if (!input.trim()) {
-            showToast("请输入数据", "error");
-            return;
-          }
-
-          const parsed = parseData(input);
-          if (!parsed) {
-            showToast("数据格式错误，请检查输入", "error");
-            return;
-          }
-
-          const labels = parsed.labels;
-          const datasets = parsed.datasets;
-          const seriesConfig = parsed.seriesConfig;
-          const chartTitle = document.getElementById("chartTitle").value || "折线图";
-          const xAxisLabel = document.getElementById("xAxisLabel").value;
-          const yAxisLabel = document.getElementById("yAxisLabel").value;
-          const lineStyle = document.getElementById("lineStyle").value;
-          const showPoints = document.getElementById("showPoints").value === "true";
-
-          // 判断当前主题
-          const isLight = document.body.getAttribute("data-theme") === "light";
-          const gridColor = isLight ? "rgba(0, 0, 0, 0.1)" : "rgba(255, 255, 255, 0.1)";
-          const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
-
-          // 隐藏占位符
-          document.getElementById("chartPlaceholder").style.display = "none";
-
-          // 销毁旧图表
-          if (chart) {
-            chart.destroy();
-          }
-
-          // 构建数据集
-          const chartDatasets = datasets.map(function (data, index) {
-            const config = seriesConfig[index] || {
-              name: "系列 " + (index + 1),
-              color: defaultColors[index % defaultColors.length]
-            };
-
-            return {
-              label: config.name,
-              data: data,
-              borderColor: config.color,
-              backgroundColor: config.color + "20",
-              borderWidth: 2,
-              fill: false,
-              tension: lineStyle === "smooth" ? 0.4 : 0,
-              stepped: lineStyle === "stepped",
-              pointRadius: showPoints ? 4 : 0,
-              pointHoverRadius: showPoints ? 6 : 4,
-              pointBackgroundColor: config.color,
-              pointBorderColor: config.color
-            };
-          });
-
-          // 创建图表
-          const ctx = document.getElementById("lineChart").getContext("2d");
-          chart = new Chart(ctx, {
-            type: "line",
-            data: {
-              labels: labels,
-              datasets: chartDatasets
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: true,
-              interaction: {
-                mode: "index",
-                intersect: false
-              },
-              plugins: {
-                title: {
-                  display: !!chartTitle,
-                  text: chartTitle,
-                  color: textColor,
-                  font: {
-                    size: 16,
-                    weight: "600",
-                    family: "'Space Grotesk', sans-serif"
-                  },
-                  padding: { bottom: 20 }
-                },
-                legend: {
-                  display: datasets.length > 1,
-                  position: "top",
-                  labels: {
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif"
-                    },
-                    usePointStyle: true,
-                    padding: 15
-                  }
-                },
-                tooltip: {
-                  backgroundColor: isLight ? "rgba(255, 255, 255, 0.95)" : "rgba(26, 26, 36, 0.95)",
-                  titleColor: textColor,
-                  bodyColor: textColor,
-                  borderColor: isLight ? "#e5e5e5" : "#3a3a4a",
-                  borderWidth: 1,
-                  cornerRadius: 8,
-                  titleFont: {
-                    family: "'Space Grotesk', sans-serif",
-                    weight: "600"
-                  },
-                  bodyFont: {
-                    family: "'JetBrains Mono', monospace"
-                  },
-                  padding: 12
-                }
-              },
-              scales: {
-                x: {
-                  display: true,
-                  title: {
-                    display: !!xAxisLabel,
-                    text: xAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  grid: {
-                    color: gridColor
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 11
-                    }
-                  }
-                },
-                y: {
-                  display: true,
-                  title: {
-                    display: !!yAxisLabel,
-                    text: yAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif",
-                      weight: "500"
-                    }
-                  },
-                  grid: {
-                    color: gridColor
-                  },
-                  ticks: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 11
-                    }
-                  },
-                  beginAtZero: true
-                }
-              }
-            }
-          });
-
-          showToast("图表生成成功");
-          saveToStorage();
-        }
-
-        // 导出 PNG
-        function exportPNG() {
-          if (!chart) {
-            showToast("请先生成图表", "error");
-            return;
-          }
-
-          const canvas = document.getElementById("lineChart");
-          const link = document.createElement("a");
-          link.download = "line-chart.png";
-          link.href = canvas.toDataURL("image/png", 1.0);
-          link.click();
-
-          showToast("图表已导出");
-        }
-
-        // 分享图表
-        function shareChart() {
-          const data = {
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            style: document.getElementById("lineStyle").value,
-            points: document.getElementById("showPoints").value,
-            series: getSeriesConfig(),
-            data: document.getElementById("dataInput").value
-          };
-
-          const encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-          const url = window.location.href.split("#")[0] + "#" + encoded;
-
-          navigator.clipboard
-            .writeText(url)
-            .then(function () {
-              showToast("分享链接已复制到剪贴板");
-            })
-            .catch(function () {
-              showToast("复制失败，请手动复制地址栏链接", "error");
-            });
-        }
-
-        // 从 URL 加载
-        function loadFromUrl() {
-          const hash = window.location.hash.slice(1);
-          if (!hash) return;
-
-          try {
-            const data = JSON.parse(decodeURIComponent(atob(hash)));
-
-            if (data.title) document.getElementById("chartTitle").value = data.title;
-            if (data.xAxis) document.getElementById("xAxisLabel").value = data.xAxis;
-            if (data.yAxis) document.getElementById("yAxisLabel").value = data.yAxis;
-            if (data.style) document.getElementById("lineStyle").value = data.style;
-            if (data.points) document.getElementById("showPoints").value = data.points;
-            if (data.data) document.getElementById("dataInput").value = data.data;
-
-            // 恢复系列配置
-            if (data.series && data.series.length > 0) {
-              document.getElementById("seriesManager").textContent = "";
-              seriesCount = 0;
-              data.series.forEach(function (s) {
-                addSeries(s.name, s.color);
-              });
-            }
-
-            // 自动生成图表
-            if (data.data) {
-              setTimeout(generateChart, 100);
-            }
-          } catch (e) {
-            // 忽略解析错误
-          }
-        }
-
-        // 保存到 localStorage
-        function saveToStorage() {
-          const data = {
-            title: document.getElementById("chartTitle").value,
-            xAxis: document.getElementById("xAxisLabel").value,
-            yAxis: document.getElementById("yAxisLabel").value,
-            style: document.getElementById("lineStyle").value,
-            points: document.getElementById("showPoints").value,
-            series: getSeriesConfig(),
-            data: document.getElementById("dataInput").value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // 从 localStorage 加载
-        function loadFromStorage() {
-          // 如果有 URL hash，优先使用 URL
-          if (window.location.hash) return;
-
-          const saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
-
-          try {
-            const data = JSON.parse(saved);
-
-            if (data.title) document.getElementById("chartTitle").value = data.title;
-            if (data.xAxis) document.getElementById("xAxisLabel").value = data.xAxis;
-            if (data.yAxis) document.getElementById("yAxisLabel").value = data.yAxis;
-            if (data.style) document.getElementById("lineStyle").value = data.style;
-            if (data.points) document.getElementById("showPoints").value = data.points;
-            if (data.data) document.getElementById("dataInput").value = data.data;
-
-            // 恢复系列配置
-            if (data.series && data.series.length > 0) {
-              document.getElementById("seriesManager").textContent = "";
-              seriesCount = 0;
-              data.series.forEach(function (s) {
-                addSeries(s.name, s.color);
-              });
-            }
-          } catch (e) {
-            // 忽略解析错误
-          }
-        }
-
-        // 加载示例数据
-        function loadSampleData() {
-          const sampleData =
-            "Jan,65,28,45\nFeb,59,48,52\nMar,80,40,61\nApr,81,19,73\nMay,56,86,42\nJun,55,27,58\nJul,40,90,35";
-
-          document.getElementById("dataInput").value = sampleData;
-          document.getElementById("chartTitle").value = "月度数据对比";
-          document.getElementById("xAxisLabel").value = "月份";
-          document.getElementById("yAxisLabel").value = "数值";
-
-          // 确保有 3 个系列
-          const manager = document.getElementById("seriesManager");
-          manager.textContent = "";
-          seriesCount = 0;
-          addSeries("销售额", "#00f5d4");
-          addSeries("成本", "#f72585");
-          addSeries("利润", "#fbbf24");
-
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        // 重新生成图表以更新主题
+        if (chart) {
           generateChart();
         }
+      }
 
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("chartTitle").value = "折线图";
-          document.getElementById("xAxisLabel").value = "";
-          document.getElementById("yAxisLabel").value = "";
-          document.getElementById("lineStyle").value = "smooth";
-          document.getElementById("showPoints").value = "true";
-          document.getElementById("dataInput").value = "";
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
 
-          // 重置系列
-          document.getElementById("seriesManager").textContent = "";
-          seriesCount = 0;
-          addSeries("系列 1", defaultColors[0]);
+      // 创建系列元素
+      function createSeriesElement(name, color, id) {
+        const item = document.createElement("div");
+        item.className = "series-item";
+        item.dataset.seriesId = id;
 
-          // 销毁图表
-          if (chart) {
-            chart.destroy();
-            chart = null;
+        const colorInput = document.createElement("input");
+        colorInput.type = "color";
+        colorInput.className = "series-color";
+        colorInput.value = color;
+        colorInput.title = "选择颜色";
+
+        const nameInput = document.createElement("input");
+        nameInput.type = "text";
+        nameInput.className = "series-name";
+        nameInput.value = name;
+        nameInput.placeholder = "系列名称";
+
+        const removeBtn = document.createElement("button");
+        removeBtn.className = "series-btn";
+        removeBtn.title = "删除系列";
+        removeBtn.textContent = "✕";
+        removeBtn.onclick = function () {
+          removeSeries(this);
+        };
+
+        item.appendChild(colorInput);
+        item.appendChild(nameInput);
+        item.appendChild(removeBtn);
+
+        // 绑定事件
+        colorInput.addEventListener("input", saveToStorage);
+        colorInput.addEventListener("change", saveToStorage);
+        nameInput.addEventListener("input", saveToStorage);
+        nameInput.addEventListener("change", saveToStorage);
+
+        return item;
+      }
+
+      // 初始化
+      document.addEventListener("DOMContentLoaded", function () {
+        // 添加默认数据系列
+        addSeries("系列 1", defaultColors[0]);
+
+        // 从 localStorage 加载
+        loadFromStorage();
+
+        // 从 URL hash 加载
+        loadFromUrl();
+
+        // 自动保存
+        document.querySelectorAll("input, textarea, select").forEach((el) => {
+          el.addEventListener("input", saveToStorage);
+          el.addEventListener("change", saveToStorage);
+        });
+      });
+
+      // 添加数据系列
+      function addSeries(name, color) {
+        seriesCount++;
+        const seriesName = name || "系列 " + seriesCount;
+        const seriesColor = color || defaultColors[(seriesCount - 1) % defaultColors.length];
+
+        const container = document.getElementById("seriesManager");
+        const item = createSeriesElement(seriesName, seriesColor, seriesCount);
+        container.appendChild(item);
+      }
+
+      // 移除数据系列
+      function removeSeries(btn) {
+        const items = document.querySelectorAll(".series-item");
+        if (items.length <= 1) {
+          showToast("至少保留一个数据系列", "error");
+          return;
+        }
+        btn.closest(".series-item").remove();
+        saveToStorage();
+      }
+
+      // 获取所有系列配置
+      function getSeriesConfig() {
+        const items = document.querySelectorAll(".series-item");
+        return Array.from(items).map(function (item) {
+          return {
+            name: item.querySelector(".series-name").value || "未命名",
+            color: item.querySelector(".series-color").value
+          };
+        });
+      }
+
+      // 解析数据
+      function parseData(input) {
+        const lines = input
+          .trim()
+          .split("\n")
+          .filter(function (line) {
+            return line.trim();
+          });
+        if (lines.length === 0) return null;
+
+        const labels = [];
+        const datasets = [];
+        const seriesConfig = getSeriesConfig();
+
+        // 解析每行数据
+        lines.forEach(function (line) {
+          const parts = line.split(",").map(function (s) {
+            return s.trim();
+          });
+          if (parts.length < 2) return;
+
+          labels.push(parts[0]);
+
+          // 解析 Y 值
+          for (let i = 1; i < parts.length; i++) {
+            const value = parseFloat(parts[i]);
+            if (!isNaN(value)) {
+              if (!datasets[i - 1]) {
+                datasets[i - 1] = [];
+              }
+              datasets[i - 1].push(value);
+            }
           }
-          document.getElementById("chartPlaceholder").style.display = "flex";
+        });
 
-          // 清除存储
-          localStorage.removeItem(LS_KEY);
-          window.location.hash = "";
+        if (labels.length === 0 || datasets.length === 0) return null;
 
-          showToast("已清空");
+        // 确保有足够的系列配置
+        while (seriesConfig.length < datasets.length) {
+          const idx = seriesConfig.length;
+          seriesConfig.push({
+            name: "系列 " + (idx + 1),
+            color: defaultColors[idx % defaultColors.length]
+          });
+          // 添加 UI
+          addSeries(seriesConfig[idx].name, seriesConfig[idx].color);
         }
 
-        // 显示提示
-        function showToast(msg, type) {
-          type = type || "success";
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (type === "error" ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
+        return { labels: labels, datasets: datasets, seriesConfig: seriesConfig };
+      }
+
+      // 生成图表
+      function generateChart() {
+        const input = document.getElementById("dataInput").value;
+        if (!input.trim()) {
+          showToast("请输入数据", "error");
+          return;
         }
-</script>
-    
+
+        const parsed = parseData(input);
+        if (!parsed) {
+          showToast("数据格式错误，请检查输入", "error");
+          return;
+        }
+
+        const labels = parsed.labels;
+        const datasets = parsed.datasets;
+        const seriesConfig = parsed.seriesConfig;
+        const chartTitle = document.getElementById("chartTitle").value || "折线图";
+        const xAxisLabel = document.getElementById("xAxisLabel").value;
+        const yAxisLabel = document.getElementById("yAxisLabel").value;
+        const lineStyle = document.getElementById("lineStyle").value;
+        const showPoints = document.getElementById("showPoints").value === "true";
+
+        // 判断当前主题
+        const isLight = document.body.getAttribute("data-theme") === "light";
+        const gridColor = isLight ? "rgba(0, 0, 0, 0.1)" : "rgba(255, 255, 255, 0.1)";
+        const textColor = isLight ? "#1a1a1a" : "#e8e8ed";
+
+        // 隐藏占位符
+        document.getElementById("chartPlaceholder").style.display = "none";
+
+        // 销毁旧图表
+        if (chart) {
+          chart.destroy();
+        }
+
+        // 构建数据集
+        const chartDatasets = datasets.map(function (data, index) {
+          const config = seriesConfig[index] || {
+            name: "系列 " + (index + 1),
+            color: defaultColors[index % defaultColors.length]
+          };
+
+          return {
+            label: config.name,
+            data: data,
+            borderColor: config.color,
+            backgroundColor: config.color + "20",
+            borderWidth: 2,
+            fill: false,
+            tension: lineStyle === "smooth" ? 0.4 : 0,
+            stepped: lineStyle === "stepped",
+            pointRadius: showPoints ? 4 : 0,
+            pointHoverRadius: showPoints ? 6 : 4,
+            pointBackgroundColor: config.color,
+            pointBorderColor: config.color
+          };
+        });
+
+        // 创建图表
+        const ctx = document.getElementById("lineChart").getContext("2d");
+        chart = new Chart(ctx, {
+          type: "line",
+          data: {
+            labels: labels,
+            datasets: chartDatasets
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            interaction: {
+              mode: "index",
+              intersect: false
+            },
+            plugins: {
+              title: {
+                display: !!chartTitle,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "600",
+                  family: "'Space Grotesk', sans-serif"
+                },
+                padding: { bottom: 20 }
+              },
+              legend: {
+                display: datasets.length > 1,
+                position: "top",
+                labels: {
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif"
+                  },
+                  usePointStyle: true,
+                  padding: 15
+                }
+              },
+              tooltip: {
+                backgroundColor: isLight ? "rgba(255, 255, 255, 0.95)" : "rgba(26, 26, 36, 0.95)",
+                titleColor: textColor,
+                bodyColor: textColor,
+                borderColor: isLight ? "#e5e5e5" : "#3a3a4a",
+                borderWidth: 1,
+                cornerRadius: 8,
+                titleFont: {
+                  family: "'Space Grotesk', sans-serif",
+                  weight: "600"
+                },
+                bodyFont: {
+                  family: "'JetBrains Mono', monospace"
+                },
+                padding: 12
+              }
+            },
+            scales: {
+              x: {
+                display: true,
+                title: {
+                  display: !!xAxisLabel,
+                  text: xAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
+                  }
+                },
+                grid: {
+                  color: gridColor
+                },
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 11
+                  }
+                }
+              },
+              y: {
+                display: true,
+                title: {
+                  display: !!yAxisLabel,
+                  text: yAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif",
+                    weight: "500"
+                  }
+                },
+                grid: {
+                  color: gridColor
+                },
+                ticks: {
+                  color: textColor,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 11
+                  }
+                },
+                beginAtZero: true
+              }
+            }
+          }
+        });
+
+        showToast("图表生成成功");
+        saveToStorage();
+      }
+
+      // 导出 PNG
+      function exportPNG() {
+        if (!chart) {
+          showToast("请先生成图表", "error");
+          return;
+        }
+
+        const canvas = document.getElementById("lineChart");
+        const link = document.createElement("a");
+        link.download = "line-chart.png";
+        link.href = canvas.toDataURL("image/png", 1.0);
+        link.click();
+
+        showToast("图表已导出");
+      }
+
+      // 分享图表
+      function shareChart() {
+        const data = {
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          style: document.getElementById("lineStyle").value,
+          points: document.getElementById("showPoints").value,
+          series: getSeriesConfig(),
+          data: document.getElementById("dataInput").value
+        };
+
+        const encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+        const url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(function () {
+            showToast("分享链接已复制到剪贴板");
+          })
+          .catch(function () {
+            showToast("复制失败，请手动复制地址栏链接", "error");
+          });
+      }
+
+      // 从 URL 加载
+      function loadFromUrl() {
+        const hash = window.location.hash.slice(1);
+        if (!hash) return;
+
+        try {
+          const data = JSON.parse(decodeURIComponent(atob(hash)));
+
+          if (data.title) document.getElementById("chartTitle").value = data.title;
+          if (data.xAxis) document.getElementById("xAxisLabel").value = data.xAxis;
+          if (data.yAxis) document.getElementById("yAxisLabel").value = data.yAxis;
+          if (data.style) document.getElementById("lineStyle").value = data.style;
+          if (data.points) document.getElementById("showPoints").value = data.points;
+          if (data.data) document.getElementById("dataInput").value = data.data;
+
+          // 恢复系列配置
+          if (data.series && data.series.length > 0) {
+            document.getElementById("seriesManager").textContent = "";
+            seriesCount = 0;
+            data.series.forEach(function (s) {
+              addSeries(s.name, s.color);
+            });
+          }
+
+          // 自动生成图表
+          if (data.data) {
+            setTimeout(generateChart, 100);
+          }
+        } catch (e) {
+          // 忽略解析错误
+        }
+      }
+
+      // 保存到 localStorage
+      function saveToStorage() {
+        const data = {
+          title: document.getElementById("chartTitle").value,
+          xAxis: document.getElementById("xAxisLabel").value,
+          yAxis: document.getElementById("yAxisLabel").value,
+          style: document.getElementById("lineStyle").value,
+          points: document.getElementById("showPoints").value,
+          series: getSeriesConfig(),
+          data: document.getElementById("dataInput").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // 从 localStorage 加载
+      function loadFromStorage() {
+        // 如果有 URL hash，优先使用 URL
+        if (window.location.hash) return;
+
+        const saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          const data = JSON.parse(saved);
+
+          if (data.title) document.getElementById("chartTitle").value = data.title;
+          if (data.xAxis) document.getElementById("xAxisLabel").value = data.xAxis;
+          if (data.yAxis) document.getElementById("yAxisLabel").value = data.yAxis;
+          if (data.style) document.getElementById("lineStyle").value = data.style;
+          if (data.points) document.getElementById("showPoints").value = data.points;
+          if (data.data) document.getElementById("dataInput").value = data.data;
+
+          // 恢复系列配置
+          if (data.series && data.series.length > 0) {
+            document.getElementById("seriesManager").textContent = "";
+            seriesCount = 0;
+            data.series.forEach(function (s) {
+              addSeries(s.name, s.color);
+            });
+          }
+        } catch (e) {
+          // 忽略解析错误
+        }
+      }
+
+      // 加载示例数据
+      function loadSampleData() {
+        const sampleData =
+          "Jan,65,28,45\nFeb,59,48,52\nMar,80,40,61\nApr,81,19,73\nMay,56,86,42\nJun,55,27,58\nJul,40,90,35";
+
+        document.getElementById("dataInput").value = sampleData;
+        document.getElementById("chartTitle").value = "月度数据对比";
+        document.getElementById("xAxisLabel").value = "月份";
+        document.getElementById("yAxisLabel").value = "数值";
+
+        // 确保有 3 个系列
+        const manager = document.getElementById("seriesManager");
+        manager.textContent = "";
+        seriesCount = 0;
+        addSeries("销售额", "#00f5d4");
+        addSeries("成本", "#f72585");
+        addSeries("利润", "#fbbf24");
+
+        generateChart();
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("chartTitle").value = "折线图";
+        document.getElementById("xAxisLabel").value = "";
+        document.getElementById("yAxisLabel").value = "";
+        document.getElementById("lineStyle").value = "smooth";
+        document.getElementById("showPoints").value = "true";
+        document.getElementById("dataInput").value = "";
+
+        // 重置系列
+        document.getElementById("seriesManager").textContent = "";
+        seriesCount = 0;
+        addSeries("系列 1", defaultColors[0]);
+
+        // 销毁图表
+        if (chart) {
+          chart.destroy();
+          chart = null;
+        }
+        document.getElementById("chartPlaceholder").style.display = "flex";
+
+        // 清除存储
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+
+        showToast("已清空");
+      }
+
+      // 显示提示
+      function showToast(msg, type) {
+        type = type || "success";
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/outlier-detector.html
+++ b/tools/data/outlier-detector.html
@@ -6,7 +6,10 @@
     <title>异常值检测器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果" />
+    <meta
+      name="description"
+      content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果"
+    />
     <meta name="keywords" content="outlier detector 异常值 离群点 IQR Z-score 数据清洗 统计分析" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="异常值检测器 - WebUtils" />
-    <meta property="og:description" content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果" />
+    <meta
+      property="og:description"
+      content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/outlier-detector.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="异常值检测器 - WebUtils" />
-    <meta name="twitter:description" content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果" />
+    <meta
+      name="twitter:description"
+      content="检测数据中的异常值，支持IQR和Z-score方法，可视化显示检测结果"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "异常值检测器",
-      "item": "https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "异常值检测器",
+            "item": "https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "异常值检测器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "异常值检测器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,549 +100,555 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
-
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .tool-section:last-child {
-    margin-bottom: 0;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 200px;
-    resize: vertical;
-  }
-
-  .input-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
-
-  @media (max-width: 600px) {
-    .input-row {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-success {
-    background: var(--accent-green);
-    color: white;
-  }
-
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
-
-  /* Stats Grid */
-  .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 12px;
-    margin-bottom: 20px;
-  }
-
-  .stat-card {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 14px;
-    text-align: center;
-  }
-
-  .stat-card .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    margin-bottom: 4px;
-  }
-
-  .stat-card .stat-label {
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .stat-card.outlier .stat-value {
-    color: var(--accent-red);
-  }
-
-  .stat-card.normal .stat-value {
-    color: var(--accent-green);
-  }
-
-  /* Results List */
-  .results-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    max-height: 350px;
-    overflow-y: auto;
-  }
-
-  .results-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 150px;
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  .result-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 14px;
-    margin-bottom: 8px;
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    transition: all 0.2s;
-  }
-
-  .result-item:last-child {
-    margin-bottom: 0;
-  }
-
-  .result-item.normal {
-    background: rgba(16, 185, 129, 0.1);
-    border: 1px solid rgba(16, 185, 129, 0.3);
-    color: var(--accent-green);
-  }
-
-  .result-item.outlier {
-    background: rgba(244, 63, 94, 0.15);
-    border: 1px solid rgba(244, 63, 94, 0.4);
-    color: var(--accent-red);
-  }
-
-  .result-item .value {
-    font-weight: 600;
-  }
-
-  .result-item .badge {
-    font-size: 0.7rem;
-    padding: 2px 8px;
-    border-radius: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .result-item.normal .badge {
-    background: rgba(16, 185, 129, 0.2);
-  }
-
-  .result-item.outlier .badge {
-    background: rgba(244, 63, 94, 0.2);
-  }
-
-  /* Bounds Info */
-  .bounds-info {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    margin-top: 16px;
-  }
-
-  .bounds-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 0;
-    border-bottom: 1px solid var(--border-subtle);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-
-  .bounds-row:last-child {
-    border-bottom: none;
-  }
-
-  .bounds-label {
-    color: var(--color-text-secondary);
-  }
-
-  .bounds-value {
-    color: var(--color-accent-cyan);
-    font-weight: 500;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .stats-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .tool-section:last-child {
+        margin-bottom: 0;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 200px;
+        resize: vertical;
+      }
+
+      .input-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+
+      @media (max-width: 600px) {
+        .input-row {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-success {
+        background: var(--accent-green);
+        color: white;
+      }
+
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
+
+      /* Stats Grid */
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 12px;
+        margin-bottom: 20px;
+      }
+
+      .stat-card {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 14px;
+        text-align: center;
+      }
+
+      .stat-card .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.4rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        margin-bottom: 4px;
+      }
+
+      .stat-card .stat-label {
+        font-size: 0.75rem;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .stat-card.outlier .stat-value {
+        color: var(--accent-red);
+      }
+
+      .stat-card.normal .stat-value {
+        color: var(--accent-green);
+      }
+
+      /* Results List */
+      .results-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        max-height: 350px;
+        overflow-y: auto;
+      }
+
+      .results-placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 150px;
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .result-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 14px;
+        margin-bottom: 8px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        transition: all 0.2s;
+      }
+
+      .result-item:last-child {
+        margin-bottom: 0;
+      }
+
+      .result-item.normal {
+        background: rgba(16, 185, 129, 0.1);
+        border: 1px solid rgba(16, 185, 129, 0.3);
+        color: var(--accent-green);
+      }
+
+      .result-item.outlier {
+        background: rgba(244, 63, 94, 0.15);
+        border: 1px solid rgba(244, 63, 94, 0.4);
+        color: var(--accent-red);
+      }
+
+      .result-item .value {
+        font-weight: 600;
+      }
+
+      .result-item .badge {
+        font-size: 0.7rem;
+        padding: 2px 8px;
+        border-radius: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .result-item.normal .badge {
+        background: rgba(16, 185, 129, 0.2);
+      }
+
+      .result-item.outlier .badge {
+        background: rgba(244, 63, 94, 0.2);
+      }
+
+      /* Bounds Info */
+      .bounds-info {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        margin-top: 16px;
+      }
+
+      .bounds-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--border-subtle);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+
+      .bounds-row:last-child {
+        border-bottom: none;
+      }
+
+      .bounds-label {
+        color: var(--color-text-secondary);
+      }
+
+      .bounds-value {
+        color: var(--color-accent-cyan);
+        font-weight: 500;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .stats-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">异常值检测器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        异常值检测器
-      </h1>
-      <p>检测数据中的异常值，支持 IQR 和 Z-score 方法</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- Left: Input -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">检测设置</div>
-          <div class="input-row">
-            <div class="input-group">
-              <label class="input-label">检测方法</label>
-              <select id="method" onchange="updateMethodOptions()">
-                <option value="iqr">IQR（四分位距）</option>
-                <option value="zscore">Z-score（标准分数）</option>
-              </select>
-            </div>
-            <div class="input-group">
-              <label class="input-label" id="thresholdLabel">IQR 乘数</label>
-              <select id="threshold">
-                <option value="1.5">1.5（标准）</option>
-                <option value="2.2">2.2（中等）</option>
-                <option value="3">3（宽松）</option>
-              </select>
-            </div>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">异常值检测器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              异常值检测器
+            </h1>
+            <p>检测数据中的异常值，支持 IQR 和 Z-score 方法</p>
           </div>
-          <div class="input-hint" id="methodHint">
-            IQR 方法：异常值 = 值 &lt; Q1 - k×IQR 或 值 &gt; Q3 + k×IQR
-          </div>
-        </div>
+        </header>
 
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">输入数值（每行一个）</label>
-            <textarea id="dataInput" placeholder="输入数值，每行一个
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- Left: Input -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">检测设置</div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="input-label">检测方法</label>
+                    <select id="method" onchange="updateMethodOptions()">
+                      <option value="iqr">IQR（四分位距）</option>
+                      <option value="zscore">Z-score（标准分数）</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label" id="thresholdLabel">IQR 乘数</label>
+                    <select id="threshold">
+                      <option value="1.5">1.5（标准）</option>
+                      <option value="2.2">2.2（中等）</option>
+                      <option value="3">3（宽松）</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="input-hint" id="methodHint">
+                  IQR 方法：异常值 = 值 &lt; Q1 - k×IQR 或 值 &gt; Q3 + k×IQR
+                </div>
+              </div>
+
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">输入数值（每行一个）</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder="输入数值，每行一个
 
 示例：
 10
@@ -642,534 +660,535 @@
 20
 22
 -50
-25"></textarea>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-primary" onclick="detectOutliers()">🔍 检测异常值</button>
-            <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
-            <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例</button>
-            <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-          </div>
-        </div>
-      </div>
+25"
+                  ></textarea>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-primary" onclick="detectOutliers()">🔍 检测异常值</button>
+                  <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
+                  <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例</button>
+                  <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+                </div>
+              </div>
+            </div>
 
-      <!-- Right: Results -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">统计信息</div>
-          <div class="stats-grid" id="statsGrid">
-            <div class="stat-card">
-              <div class="stat-value" id="totalCount">-</div>
-              <div class="stat-label">总数量</div>
-            </div>
-            <div class="stat-card normal">
-              <div class="stat-value" id="normalCount">-</div>
-              <div class="stat-label">正常值</div>
-            </div>
-            <div class="stat-card outlier">
-              <div class="stat-value" id="outlierCount">-</div>
-              <div class="stat-label">异常值</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-value" id="outlierPercent">-</div>
-              <div class="stat-label">异常比例</div>
-            </div>
-          </div>
+            <!-- Right: Results -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">统计信息</div>
+                <div class="stats-grid" id="statsGrid">
+                  <div class="stat-card">
+                    <div class="stat-value" id="totalCount">-</div>
+                    <div class="stat-label">总数量</div>
+                  </div>
+                  <div class="stat-card normal">
+                    <div class="stat-value" id="normalCount">-</div>
+                    <div class="stat-label">正常值</div>
+                  </div>
+                  <div class="stat-card outlier">
+                    <div class="stat-value" id="outlierCount">-</div>
+                    <div class="stat-label">异常值</div>
+                  </div>
+                  <div class="stat-card">
+                    <div class="stat-value" id="outlierPercent">-</div>
+                    <div class="stat-label">异常比例</div>
+                  </div>
+                </div>
 
-          <div class="bounds-info" id="boundsInfo" style="display: none">
-            <div class="bounds-row">
-              <span class="bounds-label">下界</span>
-              <span class="bounds-value" id="lowerBound">-</span>
-            </div>
-            <div class="bounds-row">
-              <span class="bounds-label">上界</span>
-              <span class="bounds-value" id="upperBound">-</span>
-            </div>
-            <div class="bounds-row">
-              <span class="bounds-label">平均值</span>
-              <span class="bounds-value" id="meanValue">-</span>
-            </div>
-            <div class="bounds-row">
-              <span class="bounds-label">中位数</span>
-              <span class="bounds-value" id="medianValue">-</span>
-            </div>
-            <div class="bounds-row">
-              <span class="bounds-label">标准差</span>
-              <span class="bounds-value" id="stdValue">-</span>
-            </div>
-          </div>
-        </div>
+                <div class="bounds-info" id="boundsInfo" style="display: none">
+                  <div class="bounds-row">
+                    <span class="bounds-label">下界</span>
+                    <span class="bounds-value" id="lowerBound">-</span>
+                  </div>
+                  <div class="bounds-row">
+                    <span class="bounds-label">上界</span>
+                    <span class="bounds-value" id="upperBound">-</span>
+                  </div>
+                  <div class="bounds-row">
+                    <span class="bounds-label">平均值</span>
+                    <span class="bounds-value" id="meanValue">-</span>
+                  </div>
+                  <div class="bounds-row">
+                    <span class="bounds-label">中位数</span>
+                    <span class="bounds-value" id="medianValue">-</span>
+                  </div>
+                  <div class="bounds-row">
+                    <span class="bounds-label">标准差</span>
+                    <span class="bounds-value" id="stdValue">-</span>
+                  </div>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">检测结果</div>
-          <div class="results-container" id="resultsContainer">
-            <div class="results-placeholder" id="resultsPlaceholder">输入数据后显示结果</div>
+              <div class="tool-section">
+                <div class="section-title">检测结果</div>
+                <div class="results-container" id="resultsContainer">
+                  <div class="results-placeholder" id="resultsPlaceholder">输入数据后显示结果</div>
+                </div>
+                <div class="btn-row" style="margin-top: 16px">
+                  <button class="btn btn-success" onclick="copyResults()">📋 复制结果</button>
+                  <button class="btn btn-secondary" onclick="copyOutliersOnly()">
+                    📋 仅复制异常值
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="btn-row" style="margin-top: 16px">
-            <button class="btn btn-success" onclick="copyResults()">📋 复制结果</button>
-            <button class="btn btn-secondary" onclick="copyOutliersOnly()">📋 仅复制异常值</button>
-          </div>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "异常值检测器",
-              "item": "https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "异常值检测器",
+            "item": "https://tools.realtime-ai.chat/tools/data/outlier-detector.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      var LS_KEY = "outlier-detector-data";
+      var lastResults = null;
 
-  var LS_KEY = "outlier-detector-data";
-        var lastResults = null;
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Load theme
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // Load theme
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+      // Update method options
+      function updateMethodOptions() {
+        var method = document.getElementById("method").value;
+        var thresholdLabel = document.getElementById("thresholdLabel");
+        var thresholdSelect = document.getElementById("threshold");
+        var methodHint = document.getElementById("methodHint");
 
-        // Update method options
-        function updateMethodOptions() {
-          var method = document.getElementById("method").value;
-          var thresholdLabel = document.getElementById("thresholdLabel");
-          var thresholdSelect = document.getElementById("threshold");
-          var methodHint = document.getElementById("methodHint");
-
-          if (method === "iqr") {
-            thresholdLabel.textContent = "IQR 乘数";
-            thresholdSelect.innerHTML =
-              '<option value="1.5">1.5（标准）</option><option value="2.2">2.2（中等）</option><option value="3">3（宽松）</option>';
-            methodHint.textContent = "IQR 方法：异常值 = 值 < Q1 - k×IQR 或 值 > Q3 + k×IQR";
-          } else {
-            thresholdLabel.textContent = "Z-score 阈值";
-            thresholdSelect.innerHTML =
-              '<option value="2">2（严格）</option><option value="2.5">2.5（中等）</option><option value="3">3（宽松）</option>';
-            methodHint.textContent = "Z-score 方法：异常值 = |z| > 阈值，z = (x - μ) / σ";
-          }
-          saveToStorage();
+        if (method === "iqr") {
+          thresholdLabel.textContent = "IQR 乘数";
+          thresholdSelect.innerHTML =
+            '<option value="1.5">1.5（标准）</option><option value="2.2">2.2（中等）</option><option value="3">3（宽松）</option>';
+          methodHint.textContent = "IQR 方法：异常值 = 值 < Q1 - k×IQR 或 值 > Q3 + k×IQR";
+        } else {
+          thresholdLabel.textContent = "Z-score 阈值";
+          thresholdSelect.innerHTML =
+            '<option value="2">2（严格）</option><option value="2.5">2.5（中等）</option><option value="3">3（宽松）</option>';
+          methodHint.textContent = "Z-score 方法：异常值 = |z| > 阈值，z = (x - μ) / σ";
         }
+        saveToStorage();
+      }
 
-        // Parse input data
-        function parseData(input) {
-          var lines = input.trim().split("\n");
-          var values = [];
-          for (var i = 0; i < lines.length; i++) {
-            var line = lines[i].trim();
-            if (line === "") continue;
-            var num = parseFloat(line);
-            if (!isNaN(num)) {
-              values.push(num);
-            }
-          }
-          return values;
-        }
-
-        // Calculate statistics
-        function calculateStats(values) {
-          var n = values.length;
-          if (n === 0) return null;
-
-          var sorted = values.slice().sort(function (a, b) {
-            return a - b;
-          });
-
-          // Mean
-          var sum = 0;
-          for (var i = 0; i < n; i++) sum += values[i];
-          var mean = sum / n;
-
-          // Standard deviation
-          var sqSum = 0;
-          for (var i = 0; i < n; i++) sqSum += Math.pow(values[i] - mean, 2);
-          var std = Math.sqrt(sqSum / n);
-
-          // Median
-          var median;
-          var mid = Math.floor(n / 2);
-          if (n % 2 === 0) {
-            median = (sorted[mid - 1] + sorted[mid]) / 2;
-          } else {
-            median = sorted[mid];
-          }
-
-          // Quartiles
-          var q1Idx = Math.floor(n * 0.25);
-          var q3Idx = Math.floor(n * 0.75);
-          var q1 = sorted[q1Idx];
-          var q3 = sorted[q3Idx];
-          var iqr = q3 - q1;
-
-          return {
-            mean: mean,
-            std: std,
-            median: median,
-            q1: q1,
-            q3: q3,
-            iqr: iqr,
-            min: sorted[0],
-            max: sorted[n - 1]
-          };
-        }
-
-        // IQR method
-        function detectIQR(values, multiplier) {
-          var stats = calculateStats(values);
-          if (!stats) return null;
-
-          var lowerBound = stats.q1 - multiplier * stats.iqr;
-          var upperBound = stats.q3 + multiplier * stats.iqr;
-
-          var results = [];
-          for (var i = 0; i < values.length; i++) {
-            var v = values[i];
-            var isOutlier = v < lowerBound || v > upperBound;
-            results.push({
-              value: v,
-              isOutlier: isOutlier,
-              reason: isOutlier ? (v < lowerBound ? "低于下界" : "高于上界") : ""
-            });
-          }
-
-          return {
-            results: results,
-            stats: stats,
-            lowerBound: lowerBound,
-            upperBound: upperBound,
-            method: "IQR",
-            threshold: multiplier
-          };
-        }
-
-        // Z-score method
-        function detectZScore(values, threshold) {
-          var stats = calculateStats(values);
-          if (!stats) return null;
-
-          var lowerBound = stats.mean - threshold * stats.std;
-          var upperBound = stats.mean + threshold * stats.std;
-
-          var results = [];
-          for (var i = 0; i < values.length; i++) {
-            var v = values[i];
-            var zScore = stats.std > 0 ? (v - stats.mean) / stats.std : 0;
-            var isOutlier = Math.abs(zScore) > threshold;
-            results.push({
-              value: v,
-              isOutlier: isOutlier,
-              zScore: zScore,
-              reason: isOutlier ? "Z-score = " + zScore.toFixed(2) : ""
-            });
-          }
-
-          return {
-            results: results,
-            stats: stats,
-            lowerBound: lowerBound,
-            upperBound: upperBound,
-            method: "Z-score",
-            threshold: threshold
-          };
-        }
-
-        // Main detection function
-        function detectOutliers() {
-          var input = document.getElementById("dataInput").value;
-          var values = parseData(input);
-
-          if (values.length < 4) {
-            showToast("请输入至少 4 个数值", "error");
-            return;
-          }
-
-          var method = document.getElementById("method").value;
-          var threshold = parseFloat(document.getElementById("threshold").value);
-
-          var result;
-          if (method === "iqr") {
-            result = detectIQR(values, threshold);
-          } else {
-            result = detectZScore(values, threshold);
-          }
-
-          if (!result) {
-            showToast("检测失败", "error");
-            return;
-          }
-
-          lastResults = result;
-          displayResults(result);
-          saveToStorage();
-          showToast("检测完成");
-        }
-
-        // Display results
-        function displayResults(result) {
-          var stats = result.stats;
-          var results = result.results;
-
-          // Count stats
-          var total = results.length;
-          var outlierCount = 0;
-          for (var i = 0; i < results.length; i++) {
-            if (results[i].isOutlier) outlierCount++;
-          }
-          var normalCount = total - outlierCount;
-          var outlierPercent = ((outlierCount / total) * 100).toFixed(1) + "%";
-
-          document.getElementById("totalCount").textContent = total;
-          document.getElementById("normalCount").textContent = normalCount;
-          document.getElementById("outlierCount").textContent = outlierCount;
-          document.getElementById("outlierPercent").textContent = outlierPercent;
-
-          // Bounds info
-          document.getElementById("lowerBound").textContent = result.lowerBound.toFixed(4);
-          document.getElementById("upperBound").textContent = result.upperBound.toFixed(4);
-          document.getElementById("meanValue").textContent = stats.mean.toFixed(4);
-          document.getElementById("medianValue").textContent = stats.median.toFixed(4);
-          document.getElementById("stdValue").textContent = stats.std.toFixed(4);
-          document.getElementById("boundsInfo").style.display = "block";
-
-          // Results list
-          var container = document.getElementById("resultsContainer");
-          container.textContent = "";
-
-          for (var i = 0; i < results.length; i++) {
-            var r = results[i];
-            var item = document.createElement("div");
-            item.className = "result-item " + (r.isOutlier ? "outlier" : "normal");
-
-            var valueSpan = document.createElement("span");
-            valueSpan.className = "value";
-            valueSpan.textContent = r.value;
-
-            var badge = document.createElement("span");
-            badge.className = "badge";
-            badge.textContent = r.isOutlier ? "异常" : "正常";
-
-            item.appendChild(valueSpan);
-            item.appendChild(badge);
-            container.appendChild(item);
+      // Parse input data
+      function parseData(input) {
+        var lines = input.trim().split("\n");
+        var values = [];
+        for (var i = 0; i < lines.length; i++) {
+          var line = lines[i].trim();
+          if (line === "") continue;
+          var num = parseFloat(line);
+          if (!isNaN(num)) {
+            values.push(num);
           }
         }
+        return values;
+      }
 
-        // Copy results
-        function copyResults() {
-          if (!lastResults) {
-            showToast("请先检测异常值", "error");
-            return;
-          }
+      // Calculate statistics
+      function calculateStats(values) {
+        var n = values.length;
+        if (n === 0) return null;
 
-          var lines = ["检测方法: " + lastResults.method + " (阈值: " + lastResults.threshold + ")"];
-          lines.push("下界: " + lastResults.lowerBound.toFixed(4));
-          lines.push("上界: " + lastResults.upperBound.toFixed(4));
-          lines.push("");
-          lines.push("值\t状态");
-          lines.push("--------------------");
-
-          for (var i = 0; i < lastResults.results.length; i++) {
-            var r = lastResults.results[i];
-            lines.push(r.value + "\t" + (r.isOutlier ? "异常" : "正常"));
-          }
-
-          navigator.clipboard
-            .writeText(lines.join("\n"))
-            .then(function () {
-              showToast("结果已复制");
-            })
-            .catch(function () {
-              showToast("复制失败", "error");
-            });
-        }
-
-        // Copy outliers only
-        function copyOutliersOnly() {
-          if (!lastResults) {
-            showToast("请先检测异常值", "error");
-            return;
-          }
-
-          var outliers = [];
-          for (var i = 0; i < lastResults.results.length; i++) {
-            var r = lastResults.results[i];
-            if (r.isOutlier) outliers.push(r.value);
-          }
-
-          if (outliers.length === 0) {
-            showToast("没有检测到异常值", "error");
-            return;
-          }
-
-          navigator.clipboard
-            .writeText(outliers.join("\n"))
-            .then(function () {
-              showToast("异常值已复制");
-            })
-            .catch(function () {
-              showToast("复制失败", "error");
-            });
-        }
-
-        // Paste data
-        function pasteData() {
-          navigator.clipboard
-            .readText()
-            .then(function (text) {
-              document.getElementById("dataInput").value = text;
-              saveToStorage();
-              showToast("已粘贴");
-            })
-            .catch(function () {
-              showToast("无法访问剪贴板", "error");
-            });
-        }
-
-        // Load sample data
-        function loadSampleData() {
-          var sample = "10\n12\n14\n15\n16\n18\n20\n22\n24\n25\n100\n-50\n28\n30\n32";
-          document.getElementById("dataInput").value = sample;
-          saveToStorage();
-          detectOutliers();
-        }
-
-        // Clear all
-        function clearAll() {
-          document.getElementById("dataInput").value = "";
-          document.getElementById("method").value = "iqr";
-          updateMethodOptions();
-
-          document.getElementById("totalCount").textContent = "-";
-          document.getElementById("normalCount").textContent = "-";
-          document.getElementById("outlierCount").textContent = "-";
-          document.getElementById("outlierPercent").textContent = "-";
-          document.getElementById("boundsInfo").style.display = "none";
-
-          var container = document.getElementById("resultsContainer");
-          container.textContent = "";
-          var placeholder = document.createElement("div");
-          placeholder.className = "results-placeholder";
-          placeholder.textContent = "输入数据后显示结果";
-          container.appendChild(placeholder);
-
-          lastResults = null;
-          localStorage.removeItem(LS_KEY);
-          window.location.hash = "";
-
-          showToast("已清空");
-        }
-
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            input: document.getElementById("dataInput").value,
-            method: document.getElementById("method").value,
-            threshold: document.getElementById("threshold").value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // Load from localStorage
-        function loadFromStorage() {
-          if (window.location.hash) return;
-
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
-
-          try {
-            var data = JSON.parse(saved);
-            if (data.input) document.getElementById("dataInput").value = data.input;
-            if (data.method) {
-              document.getElementById("method").value = data.method;
-              updateMethodOptions();
-            }
-            if (data.threshold) document.getElementById("threshold").value = data.threshold;
-          } catch (e) {
-            // Ignore parse errors
-          }
-        }
-
-        // Load from URL
-        function loadFromUrl() {
-          var hash = window.location.hash.slice(1);
-          if (!hash) return;
-
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
-            if (data.input) document.getElementById("dataInput").value = data.input;
-            if (data.method) {
-              document.getElementById("method").value = data.method;
-              updateMethodOptions();
-            }
-            if (data.threshold) document.getElementById("threshold").value = data.threshold;
-
-            if (data.input) {
-              setTimeout(detectOutliers, 100);
-            }
-          } catch (e) {
-            // Ignore parse errors
-          }
-        }
-
-        // Show toast
-        function showToast(msg, type) {
-          type = type || "success";
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (type === "error" ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // Initialize
-        document.addEventListener("DOMContentLoaded", function () {
-          loadFromStorage();
-          loadFromUrl();
-
-          // Auto-save
-          document.querySelectorAll("input, textarea, select").forEach(function (el) {
-            el.addEventListener("input", saveToStorage);
-            el.addEventListener("change", saveToStorage);
-          });
+        var sorted = values.slice().sort(function (a, b) {
+          return a - b;
         });
-</script>
-    
+
+        // Mean
+        var sum = 0;
+        for (var i = 0; i < n; i++) sum += values[i];
+        var mean = sum / n;
+
+        // Standard deviation
+        var sqSum = 0;
+        for (var i = 0; i < n; i++) sqSum += Math.pow(values[i] - mean, 2);
+        var std = Math.sqrt(sqSum / n);
+
+        // Median
+        var median;
+        var mid = Math.floor(n / 2);
+        if (n % 2 === 0) {
+          median = (sorted[mid - 1] + sorted[mid]) / 2;
+        } else {
+          median = sorted[mid];
+        }
+
+        // Quartiles
+        var q1Idx = Math.floor(n * 0.25);
+        var q3Idx = Math.floor(n * 0.75);
+        var q1 = sorted[q1Idx];
+        var q3 = sorted[q3Idx];
+        var iqr = q3 - q1;
+
+        return {
+          mean: mean,
+          std: std,
+          median: median,
+          q1: q1,
+          q3: q3,
+          iqr: iqr,
+          min: sorted[0],
+          max: sorted[n - 1]
+        };
+      }
+
+      // IQR method
+      function detectIQR(values, multiplier) {
+        var stats = calculateStats(values);
+        if (!stats) return null;
+
+        var lowerBound = stats.q1 - multiplier * stats.iqr;
+        var upperBound = stats.q3 + multiplier * stats.iqr;
+
+        var results = [];
+        for (var i = 0; i < values.length; i++) {
+          var v = values[i];
+          var isOutlier = v < lowerBound || v > upperBound;
+          results.push({
+            value: v,
+            isOutlier: isOutlier,
+            reason: isOutlier ? (v < lowerBound ? "低于下界" : "高于上界") : ""
+          });
+        }
+
+        return {
+          results: results,
+          stats: stats,
+          lowerBound: lowerBound,
+          upperBound: upperBound,
+          method: "IQR",
+          threshold: multiplier
+        };
+      }
+
+      // Z-score method
+      function detectZScore(values, threshold) {
+        var stats = calculateStats(values);
+        if (!stats) return null;
+
+        var lowerBound = stats.mean - threshold * stats.std;
+        var upperBound = stats.mean + threshold * stats.std;
+
+        var results = [];
+        for (var i = 0; i < values.length; i++) {
+          var v = values[i];
+          var zScore = stats.std > 0 ? (v - stats.mean) / stats.std : 0;
+          var isOutlier = Math.abs(zScore) > threshold;
+          results.push({
+            value: v,
+            isOutlier: isOutlier,
+            zScore: zScore,
+            reason: isOutlier ? "Z-score = " + zScore.toFixed(2) : ""
+          });
+        }
+
+        return {
+          results: results,
+          stats: stats,
+          lowerBound: lowerBound,
+          upperBound: upperBound,
+          method: "Z-score",
+          threshold: threshold
+        };
+      }
+
+      // Main detection function
+      function detectOutliers() {
+        var input = document.getElementById("dataInput").value;
+        var values = parseData(input);
+
+        if (values.length < 4) {
+          showToast("请输入至少 4 个数值", "error");
+          return;
+        }
+
+        var method = document.getElementById("method").value;
+        var threshold = parseFloat(document.getElementById("threshold").value);
+
+        var result;
+        if (method === "iqr") {
+          result = detectIQR(values, threshold);
+        } else {
+          result = detectZScore(values, threshold);
+        }
+
+        if (!result) {
+          showToast("检测失败", "error");
+          return;
+        }
+
+        lastResults = result;
+        displayResults(result);
+        saveToStorage();
+        showToast("检测完成");
+      }
+
+      // Display results
+      function displayResults(result) {
+        var stats = result.stats;
+        var results = result.results;
+
+        // Count stats
+        var total = results.length;
+        var outlierCount = 0;
+        for (var i = 0; i < results.length; i++) {
+          if (results[i].isOutlier) outlierCount++;
+        }
+        var normalCount = total - outlierCount;
+        var outlierPercent = ((outlierCount / total) * 100).toFixed(1) + "%";
+
+        document.getElementById("totalCount").textContent = total;
+        document.getElementById("normalCount").textContent = normalCount;
+        document.getElementById("outlierCount").textContent = outlierCount;
+        document.getElementById("outlierPercent").textContent = outlierPercent;
+
+        // Bounds info
+        document.getElementById("lowerBound").textContent = result.lowerBound.toFixed(4);
+        document.getElementById("upperBound").textContent = result.upperBound.toFixed(4);
+        document.getElementById("meanValue").textContent = stats.mean.toFixed(4);
+        document.getElementById("medianValue").textContent = stats.median.toFixed(4);
+        document.getElementById("stdValue").textContent = stats.std.toFixed(4);
+        document.getElementById("boundsInfo").style.display = "block";
+
+        // Results list
+        var container = document.getElementById("resultsContainer");
+        container.textContent = "";
+
+        for (var i = 0; i < results.length; i++) {
+          var r = results[i];
+          var item = document.createElement("div");
+          item.className = "result-item " + (r.isOutlier ? "outlier" : "normal");
+
+          var valueSpan = document.createElement("span");
+          valueSpan.className = "value";
+          valueSpan.textContent = r.value;
+
+          var badge = document.createElement("span");
+          badge.className = "badge";
+          badge.textContent = r.isOutlier ? "异常" : "正常";
+
+          item.appendChild(valueSpan);
+          item.appendChild(badge);
+          container.appendChild(item);
+        }
+      }
+
+      // Copy results
+      function copyResults() {
+        if (!lastResults) {
+          showToast("请先检测异常值", "error");
+          return;
+        }
+
+        var lines = ["检测方法: " + lastResults.method + " (阈值: " + lastResults.threshold + ")"];
+        lines.push("下界: " + lastResults.lowerBound.toFixed(4));
+        lines.push("上界: " + lastResults.upperBound.toFixed(4));
+        lines.push("");
+        lines.push("值\t状态");
+        lines.push("--------------------");
+
+        for (var i = 0; i < lastResults.results.length; i++) {
+          var r = lastResults.results[i];
+          lines.push(r.value + "\t" + (r.isOutlier ? "异常" : "正常"));
+        }
+
+        navigator.clipboard
+          .writeText(lines.join("\n"))
+          .then(function () {
+            showToast("结果已复制");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      // Copy outliers only
+      function copyOutliersOnly() {
+        if (!lastResults) {
+          showToast("请先检测异常值", "error");
+          return;
+        }
+
+        var outliers = [];
+        for (var i = 0; i < lastResults.results.length; i++) {
+          var r = lastResults.results[i];
+          if (r.isOutlier) outliers.push(r.value);
+        }
+
+        if (outliers.length === 0) {
+          showToast("没有检测到异常值", "error");
+          return;
+        }
+
+        navigator.clipboard
+          .writeText(outliers.join("\n"))
+          .then(function () {
+            showToast("异常值已复制");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      // Paste data
+      function pasteData() {
+        navigator.clipboard
+          .readText()
+          .then(function (text) {
+            document.getElementById("dataInput").value = text;
+            saveToStorage();
+            showToast("已粘贴");
+          })
+          .catch(function () {
+            showToast("无法访问剪贴板", "error");
+          });
+      }
+
+      // Load sample data
+      function loadSampleData() {
+        var sample = "10\n12\n14\n15\n16\n18\n20\n22\n24\n25\n100\n-50\n28\n30\n32";
+        document.getElementById("dataInput").value = sample;
+        saveToStorage();
+        detectOutliers();
+      }
+
+      // Clear all
+      function clearAll() {
+        document.getElementById("dataInput").value = "";
+        document.getElementById("method").value = "iqr";
+        updateMethodOptions();
+
+        document.getElementById("totalCount").textContent = "-";
+        document.getElementById("normalCount").textContent = "-";
+        document.getElementById("outlierCount").textContent = "-";
+        document.getElementById("outlierPercent").textContent = "-";
+        document.getElementById("boundsInfo").style.display = "none";
+
+        var container = document.getElementById("resultsContainer");
+        container.textContent = "";
+        var placeholder = document.createElement("div");
+        placeholder.className = "results-placeholder";
+        placeholder.textContent = "输入数据后显示结果";
+        container.appendChild(placeholder);
+
+        lastResults = null;
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          input: document.getElementById("dataInput").value,
+          method: document.getElementById("method").value,
+          threshold: document.getElementById("threshold").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        if (window.location.hash) return;
+
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+          if (data.input) document.getElementById("dataInput").value = data.input;
+          if (data.method) {
+            document.getElementById("method").value = data.method;
+            updateMethodOptions();
+          }
+          if (data.threshold) document.getElementById("threshold").value = data.threshold;
+        } catch (e) {
+          // Ignore parse errors
+        }
+      }
+
+      // Load from URL
+      function loadFromUrl() {
+        var hash = window.location.hash.slice(1);
+        if (!hash) return;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          if (data.input) document.getElementById("dataInput").value = data.input;
+          if (data.method) {
+            document.getElementById("method").value = data.method;
+            updateMethodOptions();
+          }
+          if (data.threshold) document.getElementById("threshold").value = data.threshold;
+
+          if (data.input) {
+            setTimeout(detectOutliers, 100);
+          }
+        } catch (e) {
+          // Ignore parse errors
+        }
+      }
+
+      // Show toast
+      function showToast(msg, type) {
+        type = type || "success";
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Initialize
+      document.addEventListener("DOMContentLoaded", function () {
+        loadFromStorage();
+        loadFromUrl();
+
+        // Auto-save
+        document.querySelectorAll("input, textarea, select").forEach(function (el) {
+          el.addEventListener("input", saveToStorage);
+          el.addEventListener("change", saveToStorage);
+        });
+      });
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/data/pie-chart.html
+++ b/tools/data/pie-chart.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Pie Chart - WebUtils" />
-    <meta property="og:description" content="Pie Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Pie Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/pie-chart.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Pie Chart - WebUtils" />
-    <meta name="twitter:description" content="Pie Chart，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Pie Chart，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Pie Chart",
-      "item": "https://tools.realtime-ai.chat/tools/data/pie-chart.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Pie Chart",
+            "item": "https://tools.realtime-ai.chat/tools/data/pie-chart.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Pie Chart - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Pie Chart - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1264 +94,1269 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .options-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  @media (max-width: 600px) {
-    .options-grid {
-      grid-template-columns: 1fr;
-    }
-  }
+      .options-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
 
-  .checkbox-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 14px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-  }
+      @media (max-width: 600px) {
+        .options-grid {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .checkbox-group input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
-    accent-color: var(--color-accent-cyan);
-  }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+      }
 
-  .checkbox-group label {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-  }
+      .checkbox-group input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+        accent-color: var(--color-accent-cyan);
+      }
 
-  .color-picker-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
+      .checkbox-group label {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
 
-  .color-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 10px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
+      .color-picker-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
 
-  .color-item input[type="color"] {
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    border: none;
-    cursor: pointer;
-  }
+      .color-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
 
-  .color-item span {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-  }
+      .color-item input[type="color"] {
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border: none;
+        cursor: pointer;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .color-item span {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-success {
-    background: var(--accent-green);
-    color: #fff;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
+      .btn-success {
+        background: var(--accent-green);
+        color: #fff;
+      }
 
-  .chart-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 400px;
-    position: relative;
-  }
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
 
-  .chart-placeholder {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    text-align: center;
-  }
+      .chart-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 400px;
+        position: relative;
+      }
 
-  #chartCanvas {
-    max-width: 100%;
-    max-height: 400px;
-  }
+      .chart-placeholder {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        text-align: center;
+      }
 
-  .data-preview {
-    margin-top: 16px;
-    padding: 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    max-height: 120px;
-    overflow-y: auto;
-  }
+      #chartCanvas {
+        max-width: 100%;
+        max-height: 400px;
+      }
 
-  .data-preview-item {
-    display: flex;
-    justify-content: space-between;
-    padding: 4px 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .data-preview {
+        margin-top: 16px;
+        padding: 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        max-height: 120px;
+        overflow-y: auto;
+      }
 
-  .data-preview-item:last-child {
-    border-bottom: none;
-  }
+      .data-preview-item {
+        display: flex;
+        justify-content: space-between;
+        padding: 4px 0;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .data-preview-label {
-    color: var(--color-text-primary);
-  }
+      .data-preview-item:last-child {
+        border-bottom: none;
+      }
 
-  .data-preview-value {
-    color: var(--color-accent-cyan);
-  }
+      .data-preview-label {
+        color: var(--color-text-primary);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .data-preview-value {
+        color: var(--color-accent-cyan);
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-    color: #fff;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.error {
+        background: var(--accent-red);
+        color: #fff;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">饼图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🥧</span>
-        饼图生成器
-      </h1>
-      <p>创建饼图和环形图，支持导出为PNG图片</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">饼图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🥧</span>
+              饼图生成器
+            </h1>
+            <p>创建饼图和环形图，支持导出为PNG图片</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- 左侧：输入和配置 -->
-      <div class="input-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">数据格式：每行一条 "标签,数值"</label>
-            <textarea id="input" placeholder="苹果,30
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- 左侧：输入和配置 -->
+            <div class="input-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">数据格式：每行一条 "标签,数值"</label>
+                  <textarea
+                    id="input"
+                    placeholder="苹果,30
 香蕉,25
 橙子,20
 葡萄,15
-其他,10"></textarea>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例数据</button>
-            <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
-          </div>
-        </div>
+其他,10"
+                  ></textarea>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-secondary" onclick="loadSampleData()">📝 示例数据</button>
+                  <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">图表配置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="输入图表标题（可选）">
-          </div>
-          <div class="options-grid">
-            <div class="input-group">
-              <label class="input-label">图表类型</label>
-              <select id="chartType">
-                <option value="pie">饼图 (Pie)</option>
-                <option value="doughnut">环形图 (Doughnut)</option>
-              </select>
-            </div>
-            <div class="input-group">
-              <label class="input-label">配色方案</label>
-              <select id="colorScheme">
-                <option value="default">默认配色</option>
-                <option value="pastel">柔和色系</option>
-                <option value="vibrant">鲜艳色系</option>
-                <option value="ocean">海洋色系</option>
-                <option value="sunset">日落色系</option>
-                <option value="custom">自定义</option>
-              </select>
-            </div>
-          </div>
-          <div class="options-grid">
-            <div class="checkbox-group" onclick="toggleCheckbox('showLabels')">
-              <input type="checkbox" id="showLabels" checked="">
-              <label for="showLabels">显示标签</label>
-            </div>
-            <div class="checkbox-group" onclick="toggleCheckbox('showPercentage')">
-              <input type="checkbox" id="showPercentage" checked="">
-              <label for="showPercentage">显示百分比</label>
-            </div>
-            <div class="checkbox-group" onclick="toggleCheckbox('showLegend')">
-              <input type="checkbox" id="showLegend" checked="">
-              <label for="showLegend">显示图例</label>
-            </div>
-            <div class="checkbox-group" onclick="toggleCheckbox('showValues')">
-              <input type="checkbox" id="showValues">
-              <label for="showValues">显示数值</label>
-            </div>
-          </div>
-          <div class="input-group" id="customColorsSection" style="display: none">
-            <label class="input-label">自定义颜色（最多8个）</label>
-            <div class="color-picker-group" id="colorPickers">
-              <!-- 动态生成颜色选择器 -->
-            </div>
-          </div>
-        </div>
+              <div class="tool-section">
+                <div class="section-title">图表配置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input type="text" id="chartTitle" placeholder="输入图表标题（可选）" />
+                </div>
+                <div class="options-grid">
+                  <div class="input-group">
+                    <label class="input-label">图表类型</label>
+                    <select id="chartType">
+                      <option value="pie">饼图 (Pie)</option>
+                      <option value="doughnut">环形图 (Doughnut)</option>
+                    </select>
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">配色方案</label>
+                    <select id="colorScheme">
+                      <option value="default">默认配色</option>
+                      <option value="pastel">柔和色系</option>
+                      <option value="vibrant">鲜艳色系</option>
+                      <option value="ocean">海洋色系</option>
+                      <option value="sunset">日落色系</option>
+                      <option value="custom">自定义</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="options-grid">
+                  <div class="checkbox-group" onclick="toggleCheckbox('showLabels')">
+                    <input type="checkbox" id="showLabels" checked="" />
+                    <label for="showLabels">显示标签</label>
+                  </div>
+                  <div class="checkbox-group" onclick="toggleCheckbox('showPercentage')">
+                    <input type="checkbox" id="showPercentage" checked="" />
+                    <label for="showPercentage">显示百分比</label>
+                  </div>
+                  <div class="checkbox-group" onclick="toggleCheckbox('showLegend')">
+                    <input type="checkbox" id="showLegend" checked="" />
+                    <label for="showLegend">显示图例</label>
+                  </div>
+                  <div class="checkbox-group" onclick="toggleCheckbox('showValues')">
+                    <input type="checkbox" id="showValues" />
+                    <label for="showValues">显示数值</label>
+                  </div>
+                </div>
+                <div class="input-group" id="customColorsSection" style="display: none">
+                  <label class="input-label">自定义颜色（最多8个）</label>
+                  <div class="color-picker-group" id="colorPickers">
+                    <!-- 动态生成颜色选择器 -->
+                  </div>
+                </div>
+              </div>
 
-        <div class="btn-row">
-          <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
-          <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-        </div>
+              <div class="btn-row">
+                <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
+                <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+              </div>
 
-        <!-- 数据预览 -->
-        <div class="data-preview" id="dataPreview" style="display: none">
-          <div style="margin-bottom: 8px; color: var(--color-text-muted)">数据预览：</div>
-          <div id="previewContent"></div>
-        </div>
-      </div>
-
-      <!-- 右侧：图表展示 -->
-      <div class="chart-panel">
-        <div class="tool-section">
-          <div class="section-title">图表预览</div>
-          <div class="chart-container" id="chartContainer">
-            <div class="chart-placeholder" id="chartPlaceholder">
-              输入数据后点击"生成图表"
-              <br>
-              支持饼图和环形图
+              <!-- 数据预览 -->
+              <div class="data-preview" id="dataPreview" style="display: none">
+                <div style="margin-bottom: 8px; color: var(--color-text-muted)">数据预览：</div>
+                <div id="previewContent"></div>
+              </div>
             </div>
-            <canvas id="chartCanvas" style="display: none"></canvas>
-          </div>
-        </div>
 
-        <div class="btn-row">
-          <button class="btn btn-success" onclick="exportPNG()">💾 导出PNG</button>
-          <button class="btn btn-secondary" onclick="shareChart()">🔗 分享链接</button>
-        </div>
+            <!-- 右侧：图表展示 -->
+            <div class="chart-panel">
+              <div class="tool-section">
+                <div class="section-title">图表预览</div>
+                <div class="chart-container" id="chartContainer">
+                  <div class="chart-placeholder" id="chartPlaceholder">
+                    输入数据后点击"生成图表"
+                    <br />
+                    支持饼图和环形图
+                  </div>
+                  <canvas id="chartCanvas" style="display: none"></canvas>
+                </div>
+              </div>
+
+              <div class="btn-row">
+                <button class="btn btn-success" onclick="exportPNG()">💾 导出PNG</button>
+                <button class="btn btn-secondary" onclick="shareChart()">🔗 分享链接</button>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "饼图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/pie-chart.html"
-            }
-          ]
-        }
-
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "饼图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/pie-chart.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // 全局变量
+      let chartInstance = null;
+      const LS_KEY = "pie-chart-data";
 
-  // 全局变量
-        let chartInstance = null;
-        const LS_KEY = "pie-chart-data";
+      // 配色方案
+      const colorSchemes = {
+        default: [
+          "#00f5d4",
+          "#f72585",
+          "#fbbf24",
+          "#a855f7",
+          "#10b981",
+          "#3b82f6",
+          "#ef4444",
+          "#8b5cf6"
+        ],
+        pastel: [
+          "#a8e6cf",
+          "#dcedc1",
+          "#ffd3b6",
+          "#ffaaa5",
+          "#ff8b94",
+          "#b5ead7",
+          "#c7ceea",
+          "#e2f0cb"
+        ],
+        vibrant: [
+          "#ff6b6b",
+          "#feca57",
+          "#48dbfb",
+          "#ff9ff3",
+          "#54a0ff",
+          "#5f27cd",
+          "#00d2d3",
+          "#1dd1a1"
+        ],
+        ocean: [
+          "#0077b6",
+          "#00b4d8",
+          "#90e0ef",
+          "#caf0f8",
+          "#03045e",
+          "#023e8a",
+          "#0096c7",
+          "#48cae4"
+        ],
+        sunset: [
+          "#f72585",
+          "#b5179e",
+          "#7209b7",
+          "#560bad",
+          "#480ca8",
+          "#3a0ca3",
+          "#3f37c9",
+          "#4361ee"
+        ],
+        custom: [
+          "#00f5d4",
+          "#f72585",
+          "#fbbf24",
+          "#a855f7",
+          "#10b981",
+          "#3b82f6",
+          "#ef4444",
+          "#8b5cf6"
+        ]
+      };
 
-        // 配色方案
-        const colorSchemes = {
-          default: [
-            "#00f5d4",
-            "#f72585",
-            "#fbbf24",
-            "#a855f7",
-            "#10b981",
-            "#3b82f6",
-            "#ef4444",
-            "#8b5cf6"
-          ],
-          pastel: [
-            "#a8e6cf",
-            "#dcedc1",
-            "#ffd3b6",
-            "#ffaaa5",
-            "#ff8b94",
-            "#b5ead7",
-            "#c7ceea",
-            "#e2f0cb"
-          ],
-          vibrant: [
-            "#ff6b6b",
-            "#feca57",
-            "#48dbfb",
-            "#ff9ff3",
-            "#54a0ff",
-            "#5f27cd",
-            "#00d2d3",
-            "#1dd1a1"
-          ],
-          ocean: [
-            "#0077b6",
-            "#00b4d8",
-            "#90e0ef",
-            "#caf0f8",
-            "#03045e",
-            "#023e8a",
-            "#0096c7",
-            "#48cae4"
-          ],
-          sunset: [
-            "#f72585",
-            "#b5179e",
-            "#7209b7",
-            "#560bad",
-            "#480ca8",
-            "#3a0ca3",
-            "#3f37c9",
-            "#4361ee"
-          ],
-          custom: [
-            "#00f5d4",
-            "#f72585",
-            "#fbbf24",
-            "#a855f7",
-            "#10b981",
-            "#3b82f6",
-            "#ef4444",
-            "#8b5cf6"
-          ]
-        };
-
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          // 重新生成图表以适应主题
-          if (chartInstance) {
-            generateChart();
-          }
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        // 重新生成图表以适应主题
+        if (chartInstance) {
+          generateChart();
         }
+      }
 
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // 切换复选框
-        function toggleCheckbox(id) {
-          const checkbox = document.getElementById(id);
-          checkbox.checked = !checkbox.checked;
-          if (chartInstance) {
-            generateChart();
-          }
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // 加载示例数据
-        function loadSampleData() {
-          const sampleData = "销售额,35\n市场营销,25\n研发,20\n运营,12\n其他,8";
-          document.getElementById("input").value = sampleData;
-          document.getElementById("chartTitle").value = "部门预算分配";
-          showToast("已加载示例数据");
+      // 切换复选框
+      function toggleCheckbox(id) {
+        const checkbox = document.getElementById(id);
+        checkbox.checked = !checkbox.checked;
+        if (chartInstance) {
+          generateChart();
+        }
+      }
+
+      // 加载示例数据
+      function loadSampleData() {
+        const sampleData = "销售额,35\n市场营销,25\n研发,20\n运营,12\n其他,8";
+        document.getElementById("input").value = sampleData;
+        document.getElementById("chartTitle").value = "部门预算分配";
+        showToast("已加载示例数据");
+        updateDataPreview();
+      }
+
+      // 粘贴数据
+      async function pasteData() {
+        try {
+          const text = await navigator.clipboard.readText();
+          document.getElementById("input").value = text;
+          showToast("已粘贴数据");
           updateDataPreview();
+        } catch (e) {
+          showToast("无法访问剪贴板", true);
         }
+      }
 
-        // 粘贴数据
-        async function pasteData() {
-          try {
-            const text = await navigator.clipboard.readText();
-            document.getElementById("input").value = text;
-            showToast("已粘贴数据");
-            updateDataPreview();
-          } catch (e) {
-            showToast("无法访问剪贴板", true);
+      // 解析数据
+      function parseData(input) {
+        const lines = input.trim().split("\n");
+        const labels = [];
+        const values = [];
+        const errors = [];
+
+        lines.forEach((line, index) => {
+          const trimmed = line.trim();
+          if (!trimmed) return;
+
+          // 支持多种分隔符：逗号、制表符、空格
+          const parts = trimmed.split(/[,\t]+/);
+          if (parts.length < 2) {
+            errors.push("第 " + (index + 1) + ' 行格式错误: "' + trimmed + '"');
+            return;
           }
+
+          const label = parts[0].trim();
+          const value = parseFloat(parts[1].trim());
+
+          if (isNaN(value) || value < 0) {
+            errors.push("第 " + (index + 1) + ' 行数值无效: "' + parts[1] + '"');
+            return;
+          }
+
+          labels.push(label);
+          values.push(value);
+        });
+
+        return { labels: labels, values: values, errors: errors };
+      }
+
+      // 更新数据预览
+      function updateDataPreview() {
+        const input = document.getElementById("input").value;
+        const preview = document.getElementById("dataPreview");
+        const content = document.getElementById("previewContent");
+
+        if (!input.trim()) {
+          preview.style.display = "none";
+          return;
         }
 
-        // 解析数据
-        function parseData(input) {
-          const lines = input.trim().split("\n");
-          const labels = [];
-          const values = [];
-          const errors = [];
+        const parsed = parseData(input);
+        const labels = parsed.labels;
+        const values = parsed.values;
+        const errors = parsed.errors;
 
-          lines.forEach((line, index) => {
-            const trimmed = line.trim();
-            if (!trimmed) return;
+        if (labels.length === 0) {
+          preview.style.display = "none";
+          return;
+        }
 
-            // 支持多种分隔符：逗号、制表符、空格
-            const parts = trimmed.split(/[,\t]+/);
-            if (parts.length < 2) {
-              errors.push("第 " + (index + 1) + ' 行格式错误: "' + trimmed + '"');
-              return;
-            }
+        const total = values.reduce(function (a, b) {
+          return a + b;
+        }, 0);
 
-            const label = parts[0].trim();
-            const value = parseFloat(parts[1].trim());
+        // Clear existing content
+        while (content.firstChild) {
+          content.removeChild(content.firstChild);
+        }
 
-            if (isNaN(value) || value < 0) {
-              errors.push("第 " + (index + 1) + ' 行数值无效: "' + parts[1] + '"');
-              return;
-            }
+        labels.forEach(function (label, i) {
+          const percentage = ((values[i] / total) * 100).toFixed(1);
+          const item = document.createElement("div");
+          item.className = "data-preview-item";
 
-            labels.push(label);
-            values.push(value);
+          const labelSpan = document.createElement("span");
+          labelSpan.className = "data-preview-label";
+          labelSpan.textContent = label;
+
+          const valueSpan = document.createElement("span");
+          valueSpan.className = "data-preview-value";
+          valueSpan.textContent = values[i] + " (" + percentage + "%)";
+
+          item.appendChild(labelSpan);
+          item.appendChild(valueSpan);
+          content.appendChild(item);
+        });
+
+        if (errors.length > 0) {
+          const errorDiv = document.createElement("div");
+          errorDiv.style.color = "var(--accent-red)";
+          errorDiv.style.marginTop = "8px";
+          errorDiv.textContent = errors.join("; ");
+          content.appendChild(errorDiv);
+        }
+
+        preview.style.display = "block";
+      }
+
+      // 获取颜色
+      function getColors(count) {
+        const scheme = document.getElementById("colorScheme").value;
+        let baseColors = colorSchemes[scheme] || colorSchemes.default;
+
+        if (scheme === "custom") {
+          baseColors = [];
+          const pickers = document.querySelectorAll("#colorPickers input[type='color']");
+          pickers.forEach(function (picker) {
+            baseColors.push(picker.value);
           });
-
-          return { labels: labels, values: values, errors: errors };
         }
 
-        // 更新数据预览
-        function updateDataPreview() {
-          const input = document.getElementById("input").value;
-          const preview = document.getElementById("dataPreview");
-          const content = document.getElementById("previewContent");
+        // 如果数据项超过颜色数量，循环使用颜色
+        const colors = [];
+        for (let i = 0; i < count; i++) {
+          colors.push(baseColors[i % baseColors.length]);
+        }
+        return colors;
+      }
 
-          if (!input.trim()) {
-            preview.style.display = "none";
-            return;
-          }
-
-          const parsed = parseData(input);
-          const labels = parsed.labels;
-          const values = parsed.values;
-          const errors = parsed.errors;
-
-          if (labels.length === 0) {
-            preview.style.display = "none";
-            return;
-          }
-
-          const total = values.reduce(function (a, b) {
-            return a + b;
-          }, 0);
-
-          // Clear existing content
-          while (content.firstChild) {
-            content.removeChild(content.firstChild);
-          }
-
-          labels.forEach(function (label, i) {
-            const percentage = ((values[i] / total) * 100).toFixed(1);
-            const item = document.createElement("div");
-            item.className = "data-preview-item";
-
-            const labelSpan = document.createElement("span");
-            labelSpan.className = "data-preview-label";
-            labelSpan.textContent = label;
-
-            const valueSpan = document.createElement("span");
-            valueSpan.className = "data-preview-value";
-            valueSpan.textContent = values[i] + " (" + percentage + "%)";
-
-            item.appendChild(labelSpan);
-            item.appendChild(valueSpan);
-            content.appendChild(item);
-          });
-
-          if (errors.length > 0) {
-            const errorDiv = document.createElement("div");
-            errorDiv.style.color = "var(--accent-red)";
-            errorDiv.style.marginTop = "8px";
-            errorDiv.textContent = errors.join("; ");
-            content.appendChild(errorDiv);
-          }
-
-          preview.style.display = "block";
+      // 生成图表
+      function generateChart() {
+        const input = document.getElementById("input").value;
+        if (!input.trim()) {
+          showToast("请输入数据", true);
+          return;
         }
 
-        // 获取颜色
-        function getColors(count) {
-          const scheme = document.getElementById("colorScheme").value;
-          let baseColors = colorSchemes[scheme] || colorSchemes.default;
+        const parsed = parseData(input);
+        const labels = parsed.labels;
+        const values = parsed.values;
+        const errors = parsed.errors;
 
-          if (scheme === "custom") {
-            baseColors = [];
-            const pickers = document.querySelectorAll("#colorPickers input[type='color']");
-            pickers.forEach(function (picker) {
-              baseColors.push(picker.value);
-            });
-          }
-
-          // 如果数据项超过颜色数量，循环使用颜色
-          const colors = [];
-          for (let i = 0; i < count; i++) {
-            colors.push(baseColors[i % baseColors.length]);
-          }
-          return colors;
+        if (labels.length === 0) {
+          showToast("没有有效数据", true);
+          return;
         }
 
-        // 生成图表
-        function generateChart() {
-          const input = document.getElementById("input").value;
-          if (!input.trim()) {
-            showToast("请输入数据", true);
-            return;
-          }
+        if (errors.length > 0) {
+          showToast(errors.length + " 行数据有问题，已跳过", true);
+        }
 
-          const parsed = parseData(input);
-          const labels = parsed.labels;
-          const values = parsed.values;
-          const errors = parsed.errors;
+        // 获取配置
+        const chartType = document.getElementById("chartType").value;
+        const chartTitle = document.getElementById("chartTitle").value;
+        const showLabels = document.getElementById("showLabels").checked;
+        const showPercentage = document.getElementById("showPercentage").checked;
+        const showLegend = document.getElementById("showLegend").checked;
+        const showValues = document.getElementById("showValues").checked;
+        const colors = getColors(labels.length);
 
-          if (labels.length === 0) {
-            showToast("没有有效数据", true);
-            return;
-          }
+        // 销毁旧图表
+        if (chartInstance) {
+          chartInstance.destroy();
+        }
 
-          if (errors.length > 0) {
-            showToast(errors.length + " 行数据有问题，已跳过", true);
-          }
+        // 显示画布，隐藏占位符
+        const canvas = document.getElementById("chartCanvas");
+        const placeholder = document.getElementById("chartPlaceholder");
+        canvas.style.display = "block";
+        placeholder.style.display = "none";
 
-          // 获取配置
-          const chartType = document.getElementById("chartType").value;
-          const chartTitle = document.getElementById("chartTitle").value;
-          const showLabels = document.getElementById("showLabels").checked;
-          const showPercentage = document.getElementById("showPercentage").checked;
-          const showLegend = document.getElementById("showLegend").checked;
-          const showValues = document.getElementById("showValues").checked;
-          const colors = getColors(labels.length);
+        // 获取主题色
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
 
-          // 销毁旧图表
-          if (chartInstance) {
-            chartInstance.destroy();
-          }
+        // 计算总和用于百分比
+        const total = values.reduce(function (a, b) {
+          return a + b;
+        }, 0);
 
-          // 显示画布，隐藏占位符
-          const canvas = document.getElementById("chartCanvas");
-          const placeholder = document.getElementById("chartPlaceholder");
-          canvas.style.display = "block";
-          placeholder.style.display = "none";
-
-          // 获取主题色
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
-
-          // 计算总和用于百分比
-          const total = values.reduce(function (a, b) {
-            return a + b;
-          }, 0);
-
-          // 创建图表
-          const ctx = canvas.getContext("2d");
-          chartInstance = new Chart(ctx, {
-            type: chartType,
-            data: {
-              labels: labels,
-              datasets: [
+        // 创建图表
+        const ctx = canvas.getContext("2d");
+        chartInstance = new Chart(ctx, {
+          type: chartType,
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                data: values,
+                backgroundColor: colors,
+                borderColor: isDark ? "#1a1a24" : "#fff",
+                borderWidth: 2,
+                hoverOffset: 10
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+              title: {
+                display: !!chartTitle,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "bold",
+                  family: "'Space Grotesk', sans-serif"
+                },
+                padding: { bottom: 20 }
+              },
+              legend: {
+                display: showLegend,
+                position: "bottom",
+                labels: {
+                  color: textColor,
+                  padding: 15,
+                  font: {
+                    family: "'JetBrains Mono', monospace",
+                    size: 12
+                  },
+                  usePointStyle: true,
+                  pointStyle: "circle"
+                }
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    const value = context.raw;
+                    const percentage = ((value / total) * 100).toFixed(1);
+                    let label = context.label || "";
+                    if (showValues && showPercentage) {
+                      return label + ": " + value + " (" + percentage + "%)";
+                    } else if (showValues) {
+                      return label + ": " + value;
+                    } else if (showPercentage) {
+                      return label + ": " + percentage + "%";
+                    }
+                    return label;
+                  }
+                }
+              },
+              datalabels: false
+            },
+            layout: {
+              padding: 20
+            }
+          },
+          plugins: showLabels
+            ? [
                 {
-                  data: values,
-                  backgroundColor: colors,
-                  borderColor: isDark ? "#1a1a24" : "#fff",
-                  borderWidth: 2,
-                  hoverOffset: 10
+                  id: "customLabels",
+                  afterDraw: function (chart) {
+                    const ctx = chart.ctx;
+                    ctx.save();
+                    ctx.textAlign = "center";
+                    ctx.textBaseline = "middle";
+                    ctx.font = "12px 'JetBrains Mono', monospace";
+                    ctx.fillStyle = textColor;
+
+                    chart.data.datasets.forEach(function (dataset, datasetIndex) {
+                      const meta = chart.getDatasetMeta(datasetIndex);
+                      meta.data.forEach(function (element, index) {
+                        const value = dataset.data[index];
+                        const percentage = ((value / total) * 100).toFixed(1);
+
+                        // 只显示大于3%的标签，避免重叠
+                        if (parseFloat(percentage) < 3) return;
+
+                        const midAngle = (element.startAngle + element.endAngle) / 2;
+                        const radius = (element.outerRadius + element.innerRadius) / 2;
+                        const x = element.x + Math.cos(midAngle) * radius * 0.7;
+                        const y = element.y + Math.sin(midAngle) * radius * 0.7;
+
+                        let labelText = "";
+                        if (showPercentage && showValues) {
+                          labelText = percentage + "%";
+                        } else if (showPercentage) {
+                          labelText = percentage + "%";
+                        } else if (showValues) {
+                          labelText = String(value);
+                        }
+
+                        if (labelText) {
+                          // 绘制背景
+                          const textWidth = ctx.measureText(labelText).width;
+                          ctx.fillStyle = isDark
+                            ? "rgba(26, 26, 36, 0.8)"
+                            : "rgba(255, 255, 255, 0.8)";
+                          ctx.fillRect(x - textWidth / 2 - 4, y - 8, textWidth + 8, 16);
+
+                          // 绘制文字
+                          ctx.fillStyle = textColor;
+                          ctx.fillText(labelText, x, y);
+                        }
+                      });
+                    });
+                    ctx.restore();
+                  }
                 }
               ]
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: true,
-              plugins: {
-                title: {
-                  display: !!chartTitle,
-                  text: chartTitle,
-                  color: textColor,
-                  font: {
-                    size: 16,
-                    weight: "bold",
-                    family: "'Space Grotesk', sans-serif"
-                  },
-                  padding: { bottom: 20 }
-                },
-                legend: {
-                  display: showLegend,
-                  position: "bottom",
-                  labels: {
-                    color: textColor,
-                    padding: 15,
-                    font: {
-                      family: "'JetBrains Mono', monospace",
-                      size: 12
-                    },
-                    usePointStyle: true,
-                    pointStyle: "circle"
-                  }
-                },
-                tooltip: {
-                  callbacks: {
-                    label: function (context) {
-                      const value = context.raw;
-                      const percentage = ((value / total) * 100).toFixed(1);
-                      let label = context.label || "";
-                      if (showValues && showPercentage) {
-                        return label + ": " + value + " (" + percentage + "%)";
-                      } else if (showValues) {
-                        return label + ": " + value;
-                      } else if (showPercentage) {
-                        return label + ": " + percentage + "%";
-                      }
-                      return label;
-                    }
-                  }
-                },
-                datalabels: false
-              },
-              layout: {
-                padding: 20
-              }
-            },
-            plugins: showLabels
-              ? [
-                  {
-                    id: "customLabels",
-                    afterDraw: function (chart) {
-                      const ctx = chart.ctx;
-                      ctx.save();
-                      ctx.textAlign = "center";
-                      ctx.textBaseline = "middle";
-                      ctx.font = "12px 'JetBrains Mono', monospace";
-                      ctx.fillStyle = textColor;
-
-                      chart.data.datasets.forEach(function (dataset, datasetIndex) {
-                        const meta = chart.getDatasetMeta(datasetIndex);
-                        meta.data.forEach(function (element, index) {
-                          const value = dataset.data[index];
-                          const percentage = ((value / total) * 100).toFixed(1);
-
-                          // 只显示大于3%的标签，避免重叠
-                          if (parseFloat(percentage) < 3) return;
-
-                          const midAngle = (element.startAngle + element.endAngle) / 2;
-                          const radius = (element.outerRadius + element.innerRadius) / 2;
-                          const x = element.x + Math.cos(midAngle) * radius * 0.7;
-                          const y = element.y + Math.sin(midAngle) * radius * 0.7;
-
-                          let labelText = "";
-                          if (showPercentage && showValues) {
-                            labelText = percentage + "%";
-                          } else if (showPercentage) {
-                            labelText = percentage + "%";
-                          } else if (showValues) {
-                            labelText = String(value);
-                          }
-
-                          if (labelText) {
-                            // 绘制背景
-                            const textWidth = ctx.measureText(labelText).width;
-                            ctx.fillStyle = isDark
-                              ? "rgba(26, 26, 36, 0.8)"
-                              : "rgba(255, 255, 255, 0.8)";
-                            ctx.fillRect(x - textWidth / 2 - 4, y - 8, textWidth + 8, 16);
-
-                            // 绘制文字
-                            ctx.fillStyle = textColor;
-                            ctx.fillText(labelText, x, y);
-                          }
-                        });
-                      });
-                      ctx.restore();
-                    }
-                  }
-                ]
-              : []
-          });
-
-          // 保存到 localStorage
-          saveToLocalStorage();
-          updateDataPreview();
-          showToast("图表已生成");
-        }
-
-        // 导出PNG
-        function exportPNG() {
-          if (!chartInstance) {
-            showToast("请先生成图表", true);
-            return;
-          }
-
-          const canvas = document.getElementById("chartCanvas");
-
-          // 创建临时画布添加白色背景（用于导出）
-          const tempCanvas = document.createElement("canvas");
-          const tempCtx = tempCanvas.getContext("2d");
-          tempCanvas.width = canvas.width;
-          tempCanvas.height = canvas.height;
-
-          // 填充背景色
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          tempCtx.fillStyle = isDark ? "#1a1a24" : "#ffffff";
-          tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
-
-          // 绘制图表
-          tempCtx.drawImage(canvas, 0, 0);
-
-          // 下载
-          const link = document.createElement("a");
-          const title = document.getElementById("chartTitle").value || "pie-chart";
-          link.download = title.replace(/[^a-zA-Z0-9\u4e00-\u9fa5]/g, "_") + ".png";
-          link.href = tempCanvas.toDataURL("image/png", 1.0);
-          link.click();
-
-          showToast("图片已导出");
-        }
-
-        // 分享链接
-        function shareChart() {
-          const input = document.getElementById("input").value;
-          if (!input.trim()) {
-            showToast("请先输入数据", true);
-            return;
-          }
-
-          const config = {
-            data: input,
-            title: document.getElementById("chartTitle").value,
-            type: document.getElementById("chartType").value,
-            scheme: document.getElementById("colorScheme").value,
-            showLabels: document.getElementById("showLabels").checked,
-            showPercentage: document.getElementById("showPercentage").checked,
-            showLegend: document.getElementById("showLegend").checked,
-            showValues: document.getElementById("showValues").checked
-          };
-
-          const hash = btoa(encodeURIComponent(JSON.stringify(config)));
-          const url = window.location.origin + window.location.pathname + "#" + hash;
-
-          navigator.clipboard.writeText(url).then(function () {
-            showToast("分享链接已复制");
-          });
-        }
-
-        // 从URL加载
-        function loadFromUrl() {
-          if (window.location.hash) {
-            try {
-              const hash = window.location.hash.slice(1);
-              const config = JSON.parse(decodeURIComponent(atob(hash)));
-
-              document.getElementById("input").value = config.data || "";
-              document.getElementById("chartTitle").value = config.title || "";
-              document.getElementById("chartType").value = config.type || "pie";
-              document.getElementById("colorScheme").value = config.scheme || "default";
-              document.getElementById("showLabels").checked = config.showLabels !== false;
-              document.getElementById("showPercentage").checked = config.showPercentage !== false;
-              document.getElementById("showLegend").checked = config.showLegend !== false;
-              document.getElementById("showValues").checked = config.showValues === true;
-
-              updateColorPickers();
-              if (config.data) {
-                generateChart();
-              }
-              return true;
-            } catch (e) {
-              // 忽略解析错误
-            }
-          }
-          return false;
-        }
+            : []
+        });
 
         // 保存到 localStorage
-        function saveToLocalStorage() {
-          const config = {
-            data: document.getElementById("input").value,
-            title: document.getElementById("chartTitle").value,
-            type: document.getElementById("chartType").value,
-            scheme: document.getElementById("colorScheme").value,
-            showLabels: document.getElementById("showLabels").checked,
-            showPercentage: document.getElementById("showPercentage").checked,
-            showLegend: document.getElementById("showLegend").checked,
-            showValues: document.getElementById("showValues").checked
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(config));
+        saveToLocalStorage();
+        updateDataPreview();
+        showToast("图表已生成");
+      }
+
+      // 导出PNG
+      function exportPNG() {
+        if (!chartInstance) {
+          showToast("请先生成图表", true);
+          return;
         }
 
-        // 从 localStorage 加载
-        function loadFromLocalStorage() {
-          const saved = localStorage.getItem(LS_KEY);
-          if (saved) {
-            try {
-              const config = JSON.parse(saved);
-              document.getElementById("input").value = config.data || "";
-              document.getElementById("chartTitle").value = config.title || "";
-              document.getElementById("chartType").value = config.type || "pie";
-              document.getElementById("colorScheme").value = config.scheme || "default";
-              document.getElementById("showLabels").checked = config.showLabels !== false;
-              document.getElementById("showPercentage").checked = config.showPercentage !== false;
-              document.getElementById("showLegend").checked = config.showLegend !== false;
-              document.getElementById("showValues").checked = config.showValues === true;
-              updateDataPreview();
-              return true;
-            } catch (e) {
-              // 忽略解析错误
-            }
-          }
-          return false;
+        const canvas = document.getElementById("chartCanvas");
+
+        // 创建临时画布添加白色背景（用于导出）
+        const tempCanvas = document.createElement("canvas");
+        const tempCtx = tempCanvas.getContext("2d");
+        tempCanvas.width = canvas.width;
+        tempCanvas.height = canvas.height;
+
+        // 填充背景色
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        tempCtx.fillStyle = isDark ? "#1a1a24" : "#ffffff";
+        tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
+
+        // 绘制图表
+        tempCtx.drawImage(canvas, 0, 0);
+
+        // 下载
+        const link = document.createElement("a");
+        const title = document.getElementById("chartTitle").value || "pie-chart";
+        link.download = title.replace(/[^a-zA-Z0-9\u4e00-\u9fa5]/g, "_") + ".png";
+        link.href = tempCanvas.toDataURL("image/png", 1.0);
+        link.click();
+
+        showToast("图片已导出");
+      }
+
+      // 分享链接
+      function shareChart() {
+        const input = document.getElementById("input").value;
+        if (!input.trim()) {
+          showToast("请先输入数据", true);
+          return;
         }
 
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("input").value = "";
-          document.getElementById("chartTitle").value = "";
-          document.getElementById("chartType").value = "pie";
-          document.getElementById("colorScheme").value = "default";
-          document.getElementById("showLabels").checked = true;
-          document.getElementById("showPercentage").checked = true;
-          document.getElementById("showLegend").checked = true;
-          document.getElementById("showValues").checked = false;
+        const config = {
+          data: input,
+          title: document.getElementById("chartTitle").value,
+          type: document.getElementById("chartType").value,
+          scheme: document.getElementById("colorScheme").value,
+          showLabels: document.getElementById("showLabels").checked,
+          showPercentage: document.getElementById("showPercentage").checked,
+          showLegend: document.getElementById("showLegend").checked,
+          showValues: document.getElementById("showValues").checked
+        };
 
-          if (chartInstance) {
-            chartInstance.destroy();
-            chartInstance = null;
-          }
+        const hash = btoa(encodeURIComponent(JSON.stringify(config)));
+        const url = window.location.origin + window.location.pathname + "#" + hash;
 
-          document.getElementById("chartCanvas").style.display = "none";
-          document.getElementById("chartPlaceholder").style.display = "block";
-          document.getElementById("dataPreview").style.display = "none";
-
-          localStorage.removeItem(LS_KEY);
-          window.location.hash = "";
-
-          updateColorPickers();
-          showToast("已清空");
-        }
-
-        // 更新颜色选择器
-        function updateColorPickers() {
-          const scheme = document.getElementById("colorScheme").value;
-          const section = document.getElementById("customColorsSection");
-          const container = document.getElementById("colorPickers");
-
-          if (scheme === "custom") {
-            section.style.display = "block";
-            // Clear existing pickers
-            while (container.firstChild) {
-              container.removeChild(container.firstChild);
-            }
-
-            const baseColors = colorSchemes.custom;
-            for (let i = 0; i < 8; i++) {
-              const item = document.createElement("div");
-              item.className = "color-item";
-
-              const colorInput = document.createElement("input");
-              colorInput.type = "color";
-              colorInput.value = baseColors[i];
-              colorInput.setAttribute("data-index", i);
-              colorInput.addEventListener("change", function () {
-                updateCustomColor(parseInt(this.getAttribute("data-index")), this.value);
-              });
-
-              const span = document.createElement("span");
-              span.textContent = String(i + 1);
-
-              item.appendChild(colorInput);
-              item.appendChild(span);
-              container.appendChild(item);
-            }
-          } else {
-            section.style.display = "none";
-          }
-        }
-
-        // 更新自定义颜色
-        function updateCustomColor(index, color) {
-          colorSchemes.custom[index] = color;
-          if (chartInstance) {
-            generateChart();
-          }
-        }
-
-        // 显示提示
-        function showToast(msg, isError) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (isError ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // 事件监听
-        document.getElementById("input").addEventListener("input", updateDataPreview);
-        document.getElementById("colorScheme").addEventListener("change", function () {
-          updateColorPickers();
-          if (chartInstance) {
-            generateChart();
-          }
+        navigator.clipboard.writeText(url).then(function () {
+          showToast("分享链接已复制");
         });
-        document.getElementById("chartType").addEventListener("change", function () {
-          if (chartInstance) {
-            generateChart();
-          }
-        });
+      }
 
-        // 初始化
-        (function init() {
-          // 优先从 URL 加载
-          if (!loadFromUrl()) {
-            // 否则从 localStorage 加载
-            loadFromLocalStorage();
+      // 从URL加载
+      function loadFromUrl() {
+        if (window.location.hash) {
+          try {
+            const hash = window.location.hash.slice(1);
+            const config = JSON.parse(decodeURIComponent(atob(hash)));
+
+            document.getElementById("input").value = config.data || "";
+            document.getElementById("chartTitle").value = config.title || "";
+            document.getElementById("chartType").value = config.type || "pie";
+            document.getElementById("colorScheme").value = config.scheme || "default";
+            document.getElementById("showLabels").checked = config.showLabels !== false;
+            document.getElementById("showPercentage").checked = config.showPercentage !== false;
+            document.getElementById("showLegend").checked = config.showLegend !== false;
+            document.getElementById("showValues").checked = config.showValues === true;
+
+            updateColorPickers();
+            if (config.data) {
+              generateChart();
+            }
+            return true;
+          } catch (e) {
+            // 忽略解析错误
           }
-          updateColorPickers();
-        })();
-</script>
-    
+        }
+        return false;
+      }
+
+      // 保存到 localStorage
+      function saveToLocalStorage() {
+        const config = {
+          data: document.getElementById("input").value,
+          title: document.getElementById("chartTitle").value,
+          type: document.getElementById("chartType").value,
+          scheme: document.getElementById("colorScheme").value,
+          showLabels: document.getElementById("showLabels").checked,
+          showPercentage: document.getElementById("showPercentage").checked,
+          showLegend: document.getElementById("showLegend").checked,
+          showValues: document.getElementById("showValues").checked
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(config));
+      }
+
+      // 从 localStorage 加载
+      function loadFromLocalStorage() {
+        const saved = localStorage.getItem(LS_KEY);
+        if (saved) {
+          try {
+            const config = JSON.parse(saved);
+            document.getElementById("input").value = config.data || "";
+            document.getElementById("chartTitle").value = config.title || "";
+            document.getElementById("chartType").value = config.type || "pie";
+            document.getElementById("colorScheme").value = config.scheme || "default";
+            document.getElementById("showLabels").checked = config.showLabels !== false;
+            document.getElementById("showPercentage").checked = config.showPercentage !== false;
+            document.getElementById("showLegend").checked = config.showLegend !== false;
+            document.getElementById("showValues").checked = config.showValues === true;
+            updateDataPreview();
+            return true;
+          } catch (e) {
+            // 忽略解析错误
+          }
+        }
+        return false;
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("input").value = "";
+        document.getElementById("chartTitle").value = "";
+        document.getElementById("chartType").value = "pie";
+        document.getElementById("colorScheme").value = "default";
+        document.getElementById("showLabels").checked = true;
+        document.getElementById("showPercentage").checked = true;
+        document.getElementById("showLegend").checked = true;
+        document.getElementById("showValues").checked = false;
+
+        if (chartInstance) {
+          chartInstance.destroy();
+          chartInstance = null;
+        }
+
+        document.getElementById("chartCanvas").style.display = "none";
+        document.getElementById("chartPlaceholder").style.display = "block";
+        document.getElementById("dataPreview").style.display = "none";
+
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+
+        updateColorPickers();
+        showToast("已清空");
+      }
+
+      // 更新颜色选择器
+      function updateColorPickers() {
+        const scheme = document.getElementById("colorScheme").value;
+        const section = document.getElementById("customColorsSection");
+        const container = document.getElementById("colorPickers");
+
+        if (scheme === "custom") {
+          section.style.display = "block";
+          // Clear existing pickers
+          while (container.firstChild) {
+            container.removeChild(container.firstChild);
+          }
+
+          const baseColors = colorSchemes.custom;
+          for (let i = 0; i < 8; i++) {
+            const item = document.createElement("div");
+            item.className = "color-item";
+
+            const colorInput = document.createElement("input");
+            colorInput.type = "color";
+            colorInput.value = baseColors[i];
+            colorInput.setAttribute("data-index", i);
+            colorInput.addEventListener("change", function () {
+              updateCustomColor(parseInt(this.getAttribute("data-index")), this.value);
+            });
+
+            const span = document.createElement("span");
+            span.textContent = String(i + 1);
+
+            item.appendChild(colorInput);
+            item.appendChild(span);
+            container.appendChild(item);
+          }
+        } else {
+          section.style.display = "none";
+        }
+      }
+
+      // 更新自定义颜色
+      function updateCustomColor(index, color) {
+        colorSchemes.custom[index] = color;
+        if (chartInstance) {
+          generateChart();
+        }
+      }
+
+      // 显示提示
+      function showToast(msg, isError) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (isError ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // 事件监听
+      document.getElementById("input").addEventListener("input", updateDataPreview);
+      document.getElementById("colorScheme").addEventListener("change", function () {
+        updateColorPickers();
+        if (chartInstance) {
+          generateChart();
+        }
+      });
+      document.getElementById("chartType").addEventListener("change", function () {
+        if (chartInstance) {
+          generateChart();
+        }
+      });
+
+      // 初始化
+      (function init() {
+        // 优先从 URL 加载
+        if (!loadFromUrl()) {
+          // 否则从 localStorage 加载
+          loadFromLocalStorage();
+        }
+        updateColorPickers();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/pivot-table.html
+++ b/tools/data/pivot-table.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Pivot Table - WebUtils" />
-    <meta property="og:description" content="Pivot Table，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Pivot Table，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/pivot-table.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Pivot Table - WebUtils" />
-    <meta name="twitter:description" content="Pivot Table，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Pivot Table，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Pivot Table",
-      "item": "https://tools.realtime-ai.chat/tools/data/pivot-table.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Pivot Table",
+            "item": "https://tools.realtime-ai.chat/tools/data/pivot-table.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Pivot Table - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Pivot Table - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,452 +94,458 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .input-row {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  @media (max-width: 800px) {
-    .input-row {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
+      .input-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 12px;
+      }
 
-  @media (max-width: 500px) {
-    .input-row {
-      grid-template-columns: 1fr;
-    }
-  }
+      @media (max-width: 800px) {
+        .input-row {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      @media (max-width: 500px) {
+        .input-row {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-success {
-    background: var(--accent-green);
-    color: white;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
+      .btn-success {
+        background: var(--accent-green);
+        color: white;
+      }
 
-  .pivot-wrapper {
-    overflow-x: auto;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-  }
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
 
-  .pivot-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
+      .pivot-wrapper {
+        overflow-x: auto;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+      }
 
-  .pivot-table th,
-  .pivot-table td {
-    padding: 10px 14px;
-    border: 1px solid var(--border-subtle);
-    text-align: right;
-  }
+      .pivot-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
 
-  .pivot-table th {
-    background: var(--color-bg-surface);
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-    text-transform: uppercase;
-    font-size: 0.8rem;
-    letter-spacing: 0.5px;
-  }
+      .pivot-table th,
+      .pivot-table td {
+        padding: 10px 14px;
+        border: 1px solid var(--border-subtle);
+        text-align: right;
+      }
 
-  .pivot-table th.row-header {
-    text-align: left;
-    background: var(--color-bg-card);
-  }
+      .pivot-table th {
+        background: var(--color-bg-surface);
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.8rem;
+        letter-spacing: 0.5px;
+      }
 
-  .pivot-table td.row-header {
-    text-align: left;
-    font-weight: 500;
-    background: var(--color-bg-surface);
-  }
+      .pivot-table th.row-header {
+        text-align: left;
+        background: var(--color-bg-card);
+      }
 
-  .pivot-table td.total-cell {
-    background: rgba(0, 245, 212, 0.1);
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
+      .pivot-table td.row-header {
+        text-align: left;
+        font-weight: 500;
+        background: var(--color-bg-surface);
+      }
 
-  .pivot-table tr:hover td {
-    background: var(--color-bg-surface);
-  }
+      .pivot-table td.total-cell {
+        background: rgba(0, 245, 212, 0.1);
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
 
-  .pivot-table tr:hover td.total-cell {
-    background: rgba(0, 245, 212, 0.15);
-  }
+      .pivot-table tr:hover td {
+        background: var(--color-bg-surface);
+      }
 
-  .empty-message {
-    text-align: center;
-    padding: 40px;
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-  }
+      .pivot-table tr:hover td.total-cell {
+        background: rgba(0, 245, 212, 0.15);
+      }
 
-  .stats-row {
-    display: flex;
-    gap: 16px;
-    margin-top: 12px;
-    flex-wrap: wrap;
-  }
+      .empty-message {
+        text-align: center;
+        padding: 40px;
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+      }
 
-  .stat-item {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-  }
+      .stats-row {
+        display: flex;
+        gap: 16px;
+        margin-top: 12px;
+        flex-wrap: wrap;
+      }
 
-  .stat-item span {
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-  }
+      .stat-item {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .stat-item span {
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">数据透视表</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📊</span>
-        数据透视表
-      </h1>
-      <p>创建数据透视表，汇总和分析CSV数据</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">数据透视表</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📊</span>
+              数据透视表
+            </h1>
+            <p>创建数据透视表，汇总和分析CSV数据</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- 数据输入区 -->
-    <div class="tool-section">
-      <div class="section-title">CSV 数据输入</div>
-      <div class="input-group">
-        <label class="input-label">CSV 数据 (第一行为表头)</label>
-        <textarea id="csvInput" placeholder="date,region,product,quantity,amount
+        <main class="main-content">
+          <!-- 数据输入区 -->
+          <div class="tool-section">
+            <div class="section-title">CSV 数据输入</div>
+            <div class="input-group">
+              <label class="input-label">CSV 数据 (第一行为表头)</label>
+              <textarea
+                id="csvInput"
+                placeholder="date,region,product,quantity,amount
 2024-01,North,Apple,100,1000
 2024-01,North,Banana,80,640
 2024-01,South,Apple,120,1200
@@ -541,778 +553,777 @@
 2024-02,North,Apple,110,1100
 2024-02,North,Banana,85,680
 2024-02,South,Apple,130,1300
-2024-02,South,Banana,95,760"></textarea>
-        <div class="input-hint">第一行为表头，逗号分隔。支持粘贴Excel数据</div>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-secondary" onclick="pasteFromClipboard()">📋 粘贴</button>
-        <button class="btn btn-secondary" onclick="parseCSV()">📝 解析数据</button>
-        <button class="btn btn-secondary" onclick="loadSample()">📄 示例数据</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+2024-02,South,Banana,95,760"
+              ></textarea>
+              <div class="input-hint">第一行为表头，逗号分隔。支持粘贴Excel数据</div>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-secondary" onclick="pasteFromClipboard()">📋 粘贴</button>
+              <button class="btn btn-secondary" onclick="parseCSV()">📝 解析数据</button>
+              <button class="btn btn-secondary" onclick="loadSample()">📄 示例数据</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+            </div>
+          </div>
+
+          <!-- 透视表设置 -->
+          <div class="tool-section">
+            <div class="section-title">透视表设置</div>
+            <div class="input-row">
+              <div class="input-group">
+                <label class="input-label">行字段 (分组行)</label>
+                <select id="rowField">
+                  <option value="">-- 选择 --</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">列字段 (分组列)</label>
+                <select id="colField">
+                  <option value="">-- 选择 --</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">值字段</label>
+                <select id="valueField">
+                  <option value="">-- 选择 --</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">聚合函数</label>
+                <select id="aggFunc">
+                  <option value="sum">SUM 求和</option>
+                  <option value="count">COUNT 计数</option>
+                  <option value="avg">AVG 平均值</option>
+                  <option value="min">MIN 最小值</option>
+                  <option value="max">MAX 最大值</option>
+                </select>
+              </div>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="generatePivot()">📊 生成透视表</button>
+            </div>
+          </div>
+
+          <!-- 结果显示 -->
+          <div class="tool-section">
+            <div class="section-title">透视表结果</div>
+            <div class="pivot-wrapper" id="pivotWrapper">
+              <div class="empty-message">解析数据并设置字段后生成透视表</div>
+            </div>
+            <div class="stats-row" id="statsRow" style="display: none">
+              <div class="stat-item">
+                行数:
+                <span id="statRows">0</span>
+              </div>
+              <div class="stat-item">
+                列数:
+                <span id="statCols">0</span>
+              </div>
+              <div class="stat-item">
+                总计:
+                <span id="statGrand">0</span>
+              </div>
+            </div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-secondary" onclick="copyAsCSV()">📋 复制CSV</button>
+              <button class="btn btn-secondary" onclick="copyAsHTML()">📄 复制HTML</button>
+              <button class="btn btn-secondary" onclick="shareResult()">🔗 分享</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- 透视表设置 -->
-    <div class="tool-section">
-      <div class="section-title">透视表设置</div>
-      <div class="input-row">
-        <div class="input-group">
-          <label class="input-label">行字段 (分组行)</label>
-          <select id="rowField">
-            <option value="">-- 选择 --</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">列字段 (分组列)</label>
-          <select id="colField">
-            <option value="">-- 选择 --</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">值字段</label>
-          <select id="valueField">
-            <option value="">-- 选择 --</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">聚合函数</label>
-          <select id="aggFunc">
-            <option value="sum">SUM 求和</option>
-            <option value="count">COUNT 计数</option>
-            <option value="avg">AVG 平均值</option>
-            <option value="min">MIN 最小值</option>
-            <option value="max">MAX 最大值</option>
-          </select>
-        </div>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="generatePivot()">📊 生成透视表</button>
-      </div>
-    </div>
-
-    <!-- 结果显示 -->
-    <div class="tool-section">
-      <div class="section-title">透视表结果</div>
-      <div class="pivot-wrapper" id="pivotWrapper">
-        <div class="empty-message">解析数据并设置字段后生成透视表</div>
-      </div>
-      <div class="stats-row" id="statsRow" style="display: none">
-        <div class="stat-item">
-          行数:
-          <span id="statRows">0</span>
-        </div>
-        <div class="stat-item">
-          列数:
-          <span id="statCols">0</span>
-        </div>
-        <div class="stat-item">
-          总计:
-          <span id="statGrand">0</span>
-        </div>
-      </div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-secondary" onclick="copyAsCSV()">📋 复制CSV</button>
-        <button class="btn btn-secondary" onclick="copyAsHTML()">📄 复制HTML</button>
-        <button class="btn btn-secondary" onclick="shareResult()">🔗 分享</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "数据透视表",
-              "item": "https://tools.realtime-ai.chat/tools/data/pivot-table.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "数据透视表",
+            "item": "https://tools.realtime-ai.chat/tools/data/pivot-table.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // 全局变量
+      var LS_KEY = "pivot-table-data";
+      var parsedData = [];
+      var headers = [];
+      var pivotResult = null;
 
-  // 全局变量
-        var LS_KEY = "pivot-table-data";
-        var parsedData = [];
-        var headers = [];
-        var pivotResult = null;
+      // 主题切换
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // 主题切换
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // 加载主题
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // 解析CSV文本
+      function parseCSVText(text) {
+        var lines = text.trim().split("\n");
+        if (lines.length < 2) {
+          return { headers: [], data: [] };
         }
 
-        // 加载主题
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+        // 检测分隔符（逗号或制表符）
+        var delimiter = ",";
+        if (lines[0].indexOf("\t") !== -1) {
+          delimiter = "\t";
+        }
 
-        // 解析CSV文本
-        function parseCSVText(text) {
-          var lines = text.trim().split("\n");
-          if (lines.length < 2) {
-            return { headers: [], data: [] };
-          }
+        var h = lines[0].split(delimiter).map(function (s) {
+          return s.trim().replace(/^["']|["']$/g, "");
+        });
 
-          // 检测分隔符（逗号或制表符）
-          var delimiter = ",";
-          if (lines[0].indexOf("\t") !== -1) {
-            delimiter = "\t";
-          }
+        var d = [];
+        for (var i = 1; i < lines.length; i++) {
+          var line = lines[i].trim();
+          if (!line) continue;
 
-          var h = lines[0].split(delimiter).map(function (s) {
-            return s.trim().replace(/^["']|["']$/g, "");
+          var values = line.split(delimiter).map(function (v) {
+            return v.trim().replace(/^["']|["']$/g, "");
           });
 
-          var d = [];
-          for (var i = 1; i < lines.length; i++) {
-            var line = lines[i].trim();
-            if (!line) continue;
-
-            var values = line.split(delimiter).map(function (v) {
-              return v.trim().replace(/^["']|["']$/g, "");
-            });
-
-            if (values.length === h.length) {
-              var row = {};
-              for (var j = 0; j < h.length; j++) {
-                row[h[j]] = values[j];
-              }
-              d.push(row);
+          if (values.length === h.length) {
+            var row = {};
+            for (var j = 0; j < h.length; j++) {
+              row[h[j]] = values[j];
             }
+            d.push(row);
           }
-          return { headers: h, data: d };
         }
-
-        // 从剪贴板粘贴
-        function pasteFromClipboard() {
-          navigator.clipboard
-            .readText()
-            .then(function (text) {
-              if (text) {
-                document.getElementById("csvInput").value = text;
-                showToast("已从剪贴板粘贴");
-                parseCSV();
-              }
-            })
-            .catch(function () {
-              showToast("无法读取剪贴板", "error");
-            });
-        }
-
-        // 解析CSV数据
-        function parseCSV() {
-          var text = document.getElementById("csvInput").value;
-          if (!text.trim()) {
-            showToast("请输入CSV数据", "error");
-            return;
-          }
-
-          var result = parseCSVText(text);
-          headers = result.headers;
-          parsedData = result.data;
-
-          if (headers.length === 0) {
-            showToast("无法解析CSV数据", "error");
-            return;
-          }
-
-          updateSelects();
-          showToast("解析成功，共 " + parsedData.length + " 行数据");
-          saveToStorage();
-        }
-
-        // 更新下拉选择框
-        function updateSelects() {
-          var selects = ["rowField", "colField", "valueField"];
-          selects.forEach(function (id) {
-            var select = document.getElementById(id);
-            var currentValue = select.value;
-            select.textContent = "";
-
-            var defaultOpt = document.createElement("option");
-            defaultOpt.value = "";
-            defaultOpt.textContent = "-- 选择 --";
-            select.appendChild(defaultOpt);
-
-            headers.forEach(function (h) {
-              var opt = document.createElement("option");
-              opt.value = h;
-              opt.textContent = h;
-              select.appendChild(opt);
-            });
-
-            // 恢复之前选择的值（如果仍然有效）
-            if (currentValue && headers.indexOf(currentValue) !== -1) {
-              select.value = currentValue;
-            }
-          });
-        }
-
-        // 生成透视表
-        function generatePivot() {
-          if (parsedData.length === 0) {
-            showToast("请先解析CSV数据", "error");
-            return;
-          }
-
-          var rowField = document.getElementById("rowField").value;
-          var colField = document.getElementById("colField").value;
-          var valueField = document.getElementById("valueField").value;
-          var aggFunc = document.getElementById("aggFunc").value;
-
-          if (!rowField || !colField || !valueField) {
-            showToast("请选择所有字段", "error");
-            return;
-          }
-
-          // 收集唯一的行值和列值
-          var rowValues = [];
-          var colValues = [];
-          var rowSet = {};
-          var colSet = {};
-
-          parsedData.forEach(function (row) {
-            var rv = row[rowField];
-            var cv = row[colField];
-            if (!rowSet[rv]) {
-              rowSet[rv] = true;
-              rowValues.push(rv);
-            }
-            if (!colSet[cv]) {
-              colSet[cv] = true;
-              colValues.push(cv);
-            }
-          });
-
-          // 初始化透视数据结构
-          var pivot = {};
-          rowValues.forEach(function (r) {
-            pivot[r] = {};
-            colValues.forEach(function (c) {
-              pivot[r][c] = [];
-            });
-          });
-
-          // 填充数据
-          parsedData.forEach(function (row) {
-            var rv = row[rowField];
-            var cv = row[colField];
-            var val = parseFloat(row[valueField]);
-            if (!isNaN(val)) {
-              pivot[rv][cv].push(val);
-            }
-          });
-
-          // 聚合函数
-          var aggFuncs = {
-            sum: function (arr) {
-              return arr.reduce(function (a, b) {
-                return a + b;
-              }, 0);
-            },
-            count: function (arr) {
-              return arr.length;
-            },
-            avg: function (arr) {
-              if (arr.length === 0) return 0;
-              var sum = arr.reduce(function (a, b) {
-                return a + b;
-              }, 0);
-              return sum / arr.length;
-            },
-            min: function (arr) {
-              if (arr.length === 0) return 0;
-              return Math.min.apply(null, arr);
-            },
-            max: function (arr) {
-              if (arr.length === 0) return 0;
-              return Math.max.apply(null, arr);
-            }
-          };
-
-          var agg = aggFuncs[aggFunc];
-
-          // 计算结果
-          var result = {
-            rowField: rowField,
-            colField: colField,
-            valueField: valueField,
-            aggFunc: aggFunc,
-            rows: rowValues,
-            cols: colValues,
-            data: {},
-            rowTotals: {},
-            colTotals: {},
-            grandTotal: 0
-          };
-
-          var grandArr = [];
-
-          rowValues.forEach(function (r) {
-            result.data[r] = {};
-            var rowArr = [];
-
-            colValues.forEach(function (c) {
-              var val = agg(pivot[r][c]);
-              result.data[r][c] = val;
-              rowArr = rowArr.concat(pivot[r][c]);
-            });
-
-            result.rowTotals[r] = agg(rowArr);
-            grandArr = grandArr.concat(rowArr);
-          });
-
-          colValues.forEach(function (c) {
-            var colArr = [];
-            rowValues.forEach(function (r) {
-              colArr = colArr.concat(pivot[r][c]);
-            });
-            result.colTotals[c] = agg(colArr);
-          });
-
-          result.grandTotal = agg(grandArr);
-          pivotResult = result;
-
-          renderPivot();
-          updateStats();
-          showToast("透视表生成成功");
-          saveToStorage();
-        }
-
-        // 渲染透视表
-        function renderPivot() {
-          var wrapper = document.getElementById("pivotWrapper");
-          wrapper.textContent = "";
-
-          if (!pivotResult) {
-            var msg = document.createElement("div");
-            msg.className = "empty-message";
-            msg.textContent = "解析数据并设置字段后生成透视表";
-            wrapper.appendChild(msg);
-            return;
-          }
-
-          var table = document.createElement("table");
-          table.className = "pivot-table";
-
-          // 表头
-          var thead = document.createElement("thead");
-          var headerRow = document.createElement("tr");
-
-          var cornerTh = document.createElement("th");
-          cornerTh.className = "row-header";
-          cornerTh.textContent = pivotResult.rowField + " \\ " + pivotResult.colField;
-          headerRow.appendChild(cornerTh);
-
-          pivotResult.cols.forEach(function (c) {
-            var th = document.createElement("th");
-            th.textContent = c;
-            headerRow.appendChild(th);
-          });
-
-          var totalTh = document.createElement("th");
-          totalTh.textContent = "行合计";
-          headerRow.appendChild(totalTh);
-          thead.appendChild(headerRow);
-          table.appendChild(thead);
-
-          // 表体
-          var tbody = document.createElement("tbody");
-
-          pivotResult.rows.forEach(function (r) {
-            var tr = document.createElement("tr");
-
-            var rowTh = document.createElement("td");
-            rowTh.className = "row-header";
-            rowTh.textContent = r;
-            tr.appendChild(rowTh);
-
-            pivotResult.cols.forEach(function (c) {
-              var td = document.createElement("td");
-              td.textContent = formatNumber(pivotResult.data[r][c]);
-              tr.appendChild(td);
-            });
-
-            var totalTd = document.createElement("td");
-            totalTd.className = "total-cell";
-            totalTd.textContent = formatNumber(pivotResult.rowTotals[r]);
-            tr.appendChild(totalTd);
-
-            tbody.appendChild(tr);
-          });
-
-          // 列合计行
-          var totalRow = document.createElement("tr");
-
-          var totalLabel = document.createElement("td");
-          totalLabel.className = "row-header total-cell";
-          totalLabel.textContent = "列合计";
-          totalRow.appendChild(totalLabel);
-
-          pivotResult.cols.forEach(function (c) {
-            var td = document.createElement("td");
-            td.className = "total-cell";
-            td.textContent = formatNumber(pivotResult.colTotals[c]);
-            totalRow.appendChild(td);
-          });
-
-          var grandTd = document.createElement("td");
-          grandTd.className = "total-cell";
-          grandTd.textContent = formatNumber(pivotResult.grandTotal);
-          grandTd.style.fontWeight = "700";
-          totalRow.appendChild(grandTd);
-
-          tbody.appendChild(totalRow);
-          table.appendChild(tbody);
-          wrapper.appendChild(table);
-        }
-
-        // 格式化数字
-        function formatNumber(num) {
-          if (num === 0) return "0";
-          if (Number.isInteger(num)) return num.toLocaleString();
-          return num.toLocaleString(undefined, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-          });
-        }
-
-        // 更新统计信息
-        function updateStats() {
-          var statsRow = document.getElementById("statsRow");
-          if (!pivotResult) {
-            statsRow.style.display = "none";
-            return;
-          }
-
-          statsRow.style.display = "flex";
-          document.getElementById("statRows").textContent = pivotResult.rows.length;
-          document.getElementById("statCols").textContent = pivotResult.cols.length;
-          document.getElementById("statGrand").textContent = formatNumber(pivotResult.grandTotal);
-        }
-
-        // 复制为CSV格式
-        function copyAsCSV() {
-          if (!pivotResult) {
-            showToast("无结果可复制", "error");
-            return;
-          }
-
-          var lines = [];
-
-          // 表头
-          var header = [pivotResult.rowField].concat(pivotResult.cols).concat(["行合计"]);
-          lines.push(header.join(","));
-
-          // 数据行
-          pivotResult.rows.forEach(function (r) {
-            var row = ['"' + r + '"'];
-            pivotResult.cols.forEach(function (c) {
-              row.push(pivotResult.data[r][c]);
-            });
-            row.push(pivotResult.rowTotals[r]);
-            lines.push(row.join(","));
-          });
-
-          // 合计行
-          var totalRow = ["列合计"];
-          pivotResult.cols.forEach(function (c) {
-            totalRow.push(pivotResult.colTotals[c]);
-          });
-          totalRow.push(pivotResult.grandTotal);
-          lines.push(totalRow.join(","));
-
-          navigator.clipboard.writeText(lines.join("\n")).then(function () {
-            showToast("CSV已复制到剪贴板");
-          });
-        }
-
-        // 复制为HTML表格
-        function copyAsHTML() {
-          if (!pivotResult) {
-            showToast("无结果可复制", "error");
-            return;
-          }
-
-          var html = '<table border="1" style="border-collapse: collapse;">\n';
-
-          // 表头
-          html += "  <thead>\n    <tr>\n";
-          html +=
-            "      <th>" +
-            escapeHtml(pivotResult.rowField + " \\ " + pivotResult.colField) +
-            "</th>\n";
-          pivotResult.cols.forEach(function (c) {
-            html += "      <th>" + escapeHtml(c) + "</th>\n";
-          });
-          html += "      <th>行合计</th>\n";
-          html += "    </tr>\n  </thead>\n";
-
-          // 表体
-          html += "  <tbody>\n";
-          pivotResult.rows.forEach(function (r) {
-            html += "    <tr>\n";
-            html += "      <td>" + escapeHtml(r) + "</td>\n";
-            pivotResult.cols.forEach(function (c) {
-              html +=
-                '      <td style="text-align: right;">' +
-                formatNumber(pivotResult.data[r][c]) +
-                "</td>\n";
-            });
-            html +=
-              '      <td style="text-align: right; font-weight: bold;">' +
-              formatNumber(pivotResult.rowTotals[r]) +
-              "</td>\n";
-            html += "    </tr>\n";
-          });
-
-          // 合计行
-          html += "    <tr>\n";
-          html += "      <td><strong>列合计</strong></td>\n";
-          pivotResult.cols.forEach(function (c) {
-            html +=
-              '      <td style="text-align: right; font-weight: bold;">' +
-              formatNumber(pivotResult.colTotals[c]) +
-              "</td>\n";
-          });
-          html +=
-            '      <td style="text-align: right; font-weight: bold;">' +
-            formatNumber(pivotResult.grandTotal) +
-            "</td>\n";
-          html += "    </tr>\n";
-          html += "  </tbody>\n</table>";
-
-          navigator.clipboard.writeText(html).then(function () {
-            showToast("HTML表格已复制到剪贴板");
-          });
-        }
-
-        // HTML转义
-        function escapeHtml(text) {
-          var div = document.createElement("div");
-          div.textContent = text;
-          return div.innerHTML;
-        }
-
-        // 分享结果
-        function shareResult() {
-          var data = {
-            csv: document.getElementById("csvInput").value,
-            rowField: document.getElementById("rowField").value,
-            colField: document.getElementById("colField").value,
-            valueField: document.getElementById("valueField").value,
-            aggFunc: document.getElementById("aggFunc").value
-          };
-
-          var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-          var url = window.location.href.split("#")[0] + "#" + encoded;
-
-          navigator.clipboard
-            .writeText(url)
-            .then(function () {
-              showToast("分享链接已复制到剪贴板");
-            })
-            .catch(function () {
-              showToast("复制失败，请手动复制地址栏链接", "error");
-            });
-        }
-
-        // 从URL加载
-        function loadFromUrl() {
-          var hash = window.location.hash.slice(1);
-          if (!hash) return false;
-
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
-
-            if (data.csv) {
-              document.getElementById("csvInput").value = data.csv;
+        return { headers: h, data: d };
+      }
+
+      // 从剪贴板粘贴
+      function pasteFromClipboard() {
+        navigator.clipboard
+          .readText()
+          .then(function (text) {
+            if (text) {
+              document.getElementById("csvInput").value = text;
+              showToast("已从剪贴板粘贴");
               parseCSV();
             }
-            if (data.rowField) document.getElementById("rowField").value = data.rowField;
-            if (data.colField) document.getElementById("colField").value = data.colField;
-            if (data.valueField) document.getElementById("valueField").value = data.valueField;
-            if (data.aggFunc) document.getElementById("aggFunc").value = data.aggFunc;
+          })
+          .catch(function () {
+            showToast("无法读取剪贴板", "error");
+          });
+      }
 
-            // 自动生成透视表
-            if (data.rowField && data.colField && data.valueField) {
-              setTimeout(generatePivot, 100);
-            }
-            return true;
-          } catch (e) {
-            return false;
-          }
+      // 解析CSV数据
+      function parseCSV() {
+        var text = document.getElementById("csvInput").value;
+        if (!text.trim()) {
+          showToast("请输入CSV数据", "error");
+          return;
         }
 
-        // 保存到localStorage
-        function saveToStorage() {
-          var data = {
-            csv: document.getElementById("csvInput").value,
-            rowField: document.getElementById("rowField").value,
-            colField: document.getElementById("colField").value,
-            valueField: document.getElementById("valueField").value,
-            aggFunc: document.getElementById("aggFunc").value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
+        var result = parseCSVText(text);
+        headers = result.headers;
+        parsedData = result.data;
+
+        if (headers.length === 0) {
+          showToast("无法解析CSV数据", "error");
+          return;
         }
 
-        // 从localStorage加载
-        function loadFromStorage() {
-          // 如果有URL hash，优先使用URL
-          if (window.location.hash) return;
+        updateSelects();
+        showToast("解析成功，共 " + parsedData.length + " 行数据");
+        saveToStorage();
+      }
 
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
+      // 更新下拉选择框
+      function updateSelects() {
+        var selects = ["rowField", "colField", "valueField"];
+        selects.forEach(function (id) {
+          var select = document.getElementById(id);
+          var currentValue = select.value;
+          select.textContent = "";
 
-          try {
-            var data = JSON.parse(saved);
+          var defaultOpt = document.createElement("option");
+          defaultOpt.value = "";
+          defaultOpt.textContent = "-- 选择 --";
+          select.appendChild(defaultOpt);
 
-            if (data.csv) {
-              document.getElementById("csvInput").value = data.csv;
-              var result = parseCSVText(data.csv);
-              headers = result.headers;
-              parsedData = result.data;
-              if (headers.length > 0) {
-                updateSelects();
-              }
-            }
-            if (data.rowField) document.getElementById("rowField").value = data.rowField;
-            if (data.colField) document.getElementById("colField").value = data.colField;
-            if (data.valueField) document.getElementById("valueField").value = data.valueField;
-            if (data.aggFunc) document.getElementById("aggFunc").value = data.aggFunc;
-          } catch (e) {
-            // 忽略解析错误
-          }
-        }
-
-        // 加载示例数据
-        function loadSample() {
-          var sampleCSV =
-            "date,region,product,quantity,amount\n" +
-            "2024-01,North,Apple,100,1000\n" +
-            "2024-01,North,Banana,80,640\n" +
-            "2024-01,South,Apple,120,1200\n" +
-            "2024-01,South,Banana,90,720\n" +
-            "2024-02,North,Apple,110,1100\n" +
-            "2024-02,North,Banana,85,680\n" +
-            "2024-02,South,Apple,130,1300\n" +
-            "2024-02,South,Banana,95,760\n" +
-            "2024-03,North,Apple,105,1050\n" +
-            "2024-03,North,Banana,75,600\n" +
-            "2024-03,South,Apple,125,1250\n" +
-            "2024-03,South,Banana,88,704";
-
-          document.getElementById("csvInput").value = sampleCSV;
-          parseCSV();
-
-          document.getElementById("rowField").value = "region";
-          document.getElementById("colField").value = "product";
-          document.getElementById("valueField").value = "amount";
-          document.getElementById("aggFunc").value = "sum";
-
-          generatePivot();
-        }
-
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("csvInput").value = "";
-          document.getElementById("rowField").value = "";
-          document.getElementById("colField").value = "";
-          document.getElementById("valueField").value = "";
-          document.getElementById("aggFunc").value = "sum";
-
-          // 重置下拉框
-          var selects = ["rowField", "colField", "valueField"];
-          selects.forEach(function (id) {
-            var select = document.getElementById(id);
-            select.textContent = "";
+          headers.forEach(function (h) {
             var opt = document.createElement("option");
-            opt.value = "";
-            opt.textContent = "-- 选择 --";
+            opt.value = h;
+            opt.textContent = h;
             select.appendChild(opt);
           });
 
-          // 清空结果
-          var wrapper = document.getElementById("pivotWrapper");
-          wrapper.textContent = "";
+          // 恢复之前选择的值（如果仍然有效）
+          if (currentValue && headers.indexOf(currentValue) !== -1) {
+            select.value = currentValue;
+          }
+        });
+      }
+
+      // 生成透视表
+      function generatePivot() {
+        if (parsedData.length === 0) {
+          showToast("请先解析CSV数据", "error");
+          return;
+        }
+
+        var rowField = document.getElementById("rowField").value;
+        var colField = document.getElementById("colField").value;
+        var valueField = document.getElementById("valueField").value;
+        var aggFunc = document.getElementById("aggFunc").value;
+
+        if (!rowField || !colField || !valueField) {
+          showToast("请选择所有字段", "error");
+          return;
+        }
+
+        // 收集唯一的行值和列值
+        var rowValues = [];
+        var colValues = [];
+        var rowSet = {};
+        var colSet = {};
+
+        parsedData.forEach(function (row) {
+          var rv = row[rowField];
+          var cv = row[colField];
+          if (!rowSet[rv]) {
+            rowSet[rv] = true;
+            rowValues.push(rv);
+          }
+          if (!colSet[cv]) {
+            colSet[cv] = true;
+            colValues.push(cv);
+          }
+        });
+
+        // 初始化透视数据结构
+        var pivot = {};
+        rowValues.forEach(function (r) {
+          pivot[r] = {};
+          colValues.forEach(function (c) {
+            pivot[r][c] = [];
+          });
+        });
+
+        // 填充数据
+        parsedData.forEach(function (row) {
+          var rv = row[rowField];
+          var cv = row[colField];
+          var val = parseFloat(row[valueField]);
+          if (!isNaN(val)) {
+            pivot[rv][cv].push(val);
+          }
+        });
+
+        // 聚合函数
+        var aggFuncs = {
+          sum: function (arr) {
+            return arr.reduce(function (a, b) {
+              return a + b;
+            }, 0);
+          },
+          count: function (arr) {
+            return arr.length;
+          },
+          avg: function (arr) {
+            if (arr.length === 0) return 0;
+            var sum = arr.reduce(function (a, b) {
+              return a + b;
+            }, 0);
+            return sum / arr.length;
+          },
+          min: function (arr) {
+            if (arr.length === 0) return 0;
+            return Math.min.apply(null, arr);
+          },
+          max: function (arr) {
+            if (arr.length === 0) return 0;
+            return Math.max.apply(null, arr);
+          }
+        };
+
+        var agg = aggFuncs[aggFunc];
+
+        // 计算结果
+        var result = {
+          rowField: rowField,
+          colField: colField,
+          valueField: valueField,
+          aggFunc: aggFunc,
+          rows: rowValues,
+          cols: colValues,
+          data: {},
+          rowTotals: {},
+          colTotals: {},
+          grandTotal: 0
+        };
+
+        var grandArr = [];
+
+        rowValues.forEach(function (r) {
+          result.data[r] = {};
+          var rowArr = [];
+
+          colValues.forEach(function (c) {
+            var val = agg(pivot[r][c]);
+            result.data[r][c] = val;
+            rowArr = rowArr.concat(pivot[r][c]);
+          });
+
+          result.rowTotals[r] = agg(rowArr);
+          grandArr = grandArr.concat(rowArr);
+        });
+
+        colValues.forEach(function (c) {
+          var colArr = [];
+          rowValues.forEach(function (r) {
+            colArr = colArr.concat(pivot[r][c]);
+          });
+          result.colTotals[c] = agg(colArr);
+        });
+
+        result.grandTotal = agg(grandArr);
+        pivotResult = result;
+
+        renderPivot();
+        updateStats();
+        showToast("透视表生成成功");
+        saveToStorage();
+      }
+
+      // 渲染透视表
+      function renderPivot() {
+        var wrapper = document.getElementById("pivotWrapper");
+        wrapper.textContent = "";
+
+        if (!pivotResult) {
           var msg = document.createElement("div");
           msg.className = "empty-message";
           msg.textContent = "解析数据并设置字段后生成透视表";
           wrapper.appendChild(msg);
-
-          // 隐藏统计
-          document.getElementById("statsRow").style.display = "none";
-
-          // 重置变量
-          parsedData = [];
-          headers = [];
-          pivotResult = null;
-
-          // 清除存储
-          localStorage.removeItem(LS_KEY);
-          window.location.hash = "";
-
-          showToast("已清空");
+          return;
         }
 
-        // 显示提示
-        function showToast(msg, type) {
-          type = type || "success";
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (type === "error" ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+        var table = document.createElement("table");
+        table.className = "pivot-table";
 
-        // 初始化
-        document.addEventListener("DOMContentLoaded", function () {
-          // 先尝试从URL加载
-          var loadedFromUrl = loadFromUrl();
+        // 表头
+        var thead = document.createElement("thead");
+        var headerRow = document.createElement("tr");
 
-          // 如果没有从URL加载，则从localStorage加载
-          if (!loadedFromUrl) {
-            loadFromStorage();
-          }
+        var cornerTh = document.createElement("th");
+        cornerTh.className = "row-header";
+        cornerTh.textContent = pivotResult.rowField + " \\ " + pivotResult.colField;
+        headerRow.appendChild(cornerTh);
 
-          // 自动保存
-          document.getElementById("csvInput").addEventListener("input", saveToStorage);
-          document.getElementById("rowField").addEventListener("change", saveToStorage);
-          document.getElementById("colField").addEventListener("change", saveToStorage);
-          document.getElementById("valueField").addEventListener("change", saveToStorage);
-          document.getElementById("aggFunc").addEventListener("change", saveToStorage);
+        pivotResult.cols.forEach(function (c) {
+          var th = document.createElement("th");
+          th.textContent = c;
+          headerRow.appendChild(th);
         });
-</script>
-    
+
+        var totalTh = document.createElement("th");
+        totalTh.textContent = "行合计";
+        headerRow.appendChild(totalTh);
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        // 表体
+        var tbody = document.createElement("tbody");
+
+        pivotResult.rows.forEach(function (r) {
+          var tr = document.createElement("tr");
+
+          var rowTh = document.createElement("td");
+          rowTh.className = "row-header";
+          rowTh.textContent = r;
+          tr.appendChild(rowTh);
+
+          pivotResult.cols.forEach(function (c) {
+            var td = document.createElement("td");
+            td.textContent = formatNumber(pivotResult.data[r][c]);
+            tr.appendChild(td);
+          });
+
+          var totalTd = document.createElement("td");
+          totalTd.className = "total-cell";
+          totalTd.textContent = formatNumber(pivotResult.rowTotals[r]);
+          tr.appendChild(totalTd);
+
+          tbody.appendChild(tr);
+        });
+
+        // 列合计行
+        var totalRow = document.createElement("tr");
+
+        var totalLabel = document.createElement("td");
+        totalLabel.className = "row-header total-cell";
+        totalLabel.textContent = "列合计";
+        totalRow.appendChild(totalLabel);
+
+        pivotResult.cols.forEach(function (c) {
+          var td = document.createElement("td");
+          td.className = "total-cell";
+          td.textContent = formatNumber(pivotResult.colTotals[c]);
+          totalRow.appendChild(td);
+        });
+
+        var grandTd = document.createElement("td");
+        grandTd.className = "total-cell";
+        grandTd.textContent = formatNumber(pivotResult.grandTotal);
+        grandTd.style.fontWeight = "700";
+        totalRow.appendChild(grandTd);
+
+        tbody.appendChild(totalRow);
+        table.appendChild(tbody);
+        wrapper.appendChild(table);
+      }
+
+      // 格式化数字
+      function formatNumber(num) {
+        if (num === 0) return "0";
+        if (Number.isInteger(num)) return num.toLocaleString();
+        return num.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        });
+      }
+
+      // 更新统计信息
+      function updateStats() {
+        var statsRow = document.getElementById("statsRow");
+        if (!pivotResult) {
+          statsRow.style.display = "none";
+          return;
+        }
+
+        statsRow.style.display = "flex";
+        document.getElementById("statRows").textContent = pivotResult.rows.length;
+        document.getElementById("statCols").textContent = pivotResult.cols.length;
+        document.getElementById("statGrand").textContent = formatNumber(pivotResult.grandTotal);
+      }
+
+      // 复制为CSV格式
+      function copyAsCSV() {
+        if (!pivotResult) {
+          showToast("无结果可复制", "error");
+          return;
+        }
+
+        var lines = [];
+
+        // 表头
+        var header = [pivotResult.rowField].concat(pivotResult.cols).concat(["行合计"]);
+        lines.push(header.join(","));
+
+        // 数据行
+        pivotResult.rows.forEach(function (r) {
+          var row = ['"' + r + '"'];
+          pivotResult.cols.forEach(function (c) {
+            row.push(pivotResult.data[r][c]);
+          });
+          row.push(pivotResult.rowTotals[r]);
+          lines.push(row.join(","));
+        });
+
+        // 合计行
+        var totalRow = ["列合计"];
+        pivotResult.cols.forEach(function (c) {
+          totalRow.push(pivotResult.colTotals[c]);
+        });
+        totalRow.push(pivotResult.grandTotal);
+        lines.push(totalRow.join(","));
+
+        navigator.clipboard.writeText(lines.join("\n")).then(function () {
+          showToast("CSV已复制到剪贴板");
+        });
+      }
+
+      // 复制为HTML表格
+      function copyAsHTML() {
+        if (!pivotResult) {
+          showToast("无结果可复制", "error");
+          return;
+        }
+
+        var html = '<table border="1" style="border-collapse: collapse;">\n';
+
+        // 表头
+        html += "  <thead>\n    <tr>\n";
+        html +=
+          "      <th>" +
+          escapeHtml(pivotResult.rowField + " \\ " + pivotResult.colField) +
+          "</th>\n";
+        pivotResult.cols.forEach(function (c) {
+          html += "      <th>" + escapeHtml(c) + "</th>\n";
+        });
+        html += "      <th>行合计</th>\n";
+        html += "    </tr>\n  </thead>\n";
+
+        // 表体
+        html += "  <tbody>\n";
+        pivotResult.rows.forEach(function (r) {
+          html += "    <tr>\n";
+          html += "      <td>" + escapeHtml(r) + "</td>\n";
+          pivotResult.cols.forEach(function (c) {
+            html +=
+              '      <td style="text-align: right;">' +
+              formatNumber(pivotResult.data[r][c]) +
+              "</td>\n";
+          });
+          html +=
+            '      <td style="text-align: right; font-weight: bold;">' +
+            formatNumber(pivotResult.rowTotals[r]) +
+            "</td>\n";
+          html += "    </tr>\n";
+        });
+
+        // 合计行
+        html += "    <tr>\n";
+        html += "      <td><strong>列合计</strong></td>\n";
+        pivotResult.cols.forEach(function (c) {
+          html +=
+            '      <td style="text-align: right; font-weight: bold;">' +
+            formatNumber(pivotResult.colTotals[c]) +
+            "</td>\n";
+        });
+        html +=
+          '      <td style="text-align: right; font-weight: bold;">' +
+          formatNumber(pivotResult.grandTotal) +
+          "</td>\n";
+        html += "    </tr>\n";
+        html += "  </tbody>\n</table>";
+
+        navigator.clipboard.writeText(html).then(function () {
+          showToast("HTML表格已复制到剪贴板");
+        });
+      }
+
+      // HTML转义
+      function escapeHtml(text) {
+        var div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
+
+      // 分享结果
+      function shareResult() {
+        var data = {
+          csv: document.getElementById("csvInput").value,
+          rowField: document.getElementById("rowField").value,
+          colField: document.getElementById("colField").value,
+          valueField: document.getElementById("valueField").value,
+          aggFunc: document.getElementById("aggFunc").value
+        };
+
+        var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+        var url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(function () {
+            showToast("分享链接已复制到剪贴板");
+          })
+          .catch(function () {
+            showToast("复制失败，请手动复制地址栏链接", "error");
+          });
+      }
+
+      // 从URL加载
+      function loadFromUrl() {
+        var hash = window.location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+
+          if (data.csv) {
+            document.getElementById("csvInput").value = data.csv;
+            parseCSV();
+          }
+          if (data.rowField) document.getElementById("rowField").value = data.rowField;
+          if (data.colField) document.getElementById("colField").value = data.colField;
+          if (data.valueField) document.getElementById("valueField").value = data.valueField;
+          if (data.aggFunc) document.getElementById("aggFunc").value = data.aggFunc;
+
+          // 自动生成透视表
+          if (data.rowField && data.colField && data.valueField) {
+            setTimeout(generatePivot, 100);
+          }
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 保存到localStorage
+      function saveToStorage() {
+        var data = {
+          csv: document.getElementById("csvInput").value,
+          rowField: document.getElementById("rowField").value,
+          colField: document.getElementById("colField").value,
+          valueField: document.getElementById("valueField").value,
+          aggFunc: document.getElementById("aggFunc").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // 从localStorage加载
+      function loadFromStorage() {
+        // 如果有URL hash，优先使用URL
+        if (window.location.hash) return;
+
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          if (data.csv) {
+            document.getElementById("csvInput").value = data.csv;
+            var result = parseCSVText(data.csv);
+            headers = result.headers;
+            parsedData = result.data;
+            if (headers.length > 0) {
+              updateSelects();
+            }
+          }
+          if (data.rowField) document.getElementById("rowField").value = data.rowField;
+          if (data.colField) document.getElementById("colField").value = data.colField;
+          if (data.valueField) document.getElementById("valueField").value = data.valueField;
+          if (data.aggFunc) document.getElementById("aggFunc").value = data.aggFunc;
+        } catch (e) {
+          // 忽略解析错误
+        }
+      }
+
+      // 加载示例数据
+      function loadSample() {
+        var sampleCSV =
+          "date,region,product,quantity,amount\n" +
+          "2024-01,North,Apple,100,1000\n" +
+          "2024-01,North,Banana,80,640\n" +
+          "2024-01,South,Apple,120,1200\n" +
+          "2024-01,South,Banana,90,720\n" +
+          "2024-02,North,Apple,110,1100\n" +
+          "2024-02,North,Banana,85,680\n" +
+          "2024-02,South,Apple,130,1300\n" +
+          "2024-02,South,Banana,95,760\n" +
+          "2024-03,North,Apple,105,1050\n" +
+          "2024-03,North,Banana,75,600\n" +
+          "2024-03,South,Apple,125,1250\n" +
+          "2024-03,South,Banana,88,704";
+
+        document.getElementById("csvInput").value = sampleCSV;
+        parseCSV();
+
+        document.getElementById("rowField").value = "region";
+        document.getElementById("colField").value = "product";
+        document.getElementById("valueField").value = "amount";
+        document.getElementById("aggFunc").value = "sum";
+
+        generatePivot();
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("csvInput").value = "";
+        document.getElementById("rowField").value = "";
+        document.getElementById("colField").value = "";
+        document.getElementById("valueField").value = "";
+        document.getElementById("aggFunc").value = "sum";
+
+        // 重置下拉框
+        var selects = ["rowField", "colField", "valueField"];
+        selects.forEach(function (id) {
+          var select = document.getElementById(id);
+          select.textContent = "";
+          var opt = document.createElement("option");
+          opt.value = "";
+          opt.textContent = "-- 选择 --";
+          select.appendChild(opt);
+        });
+
+        // 清空结果
+        var wrapper = document.getElementById("pivotWrapper");
+        wrapper.textContent = "";
+        var msg = document.createElement("div");
+        msg.className = "empty-message";
+        msg.textContent = "解析数据并设置字段后生成透视表";
+        wrapper.appendChild(msg);
+
+        // 隐藏统计
+        document.getElementById("statsRow").style.display = "none";
+
+        // 重置变量
+        parsedData = [];
+        headers = [];
+        pivotResult = null;
+
+        // 清除存储
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+
+        showToast("已清空");
+      }
+
+      // 显示提示
+      function showToast(msg, type) {
+        type = type || "success";
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // 初始化
+      document.addEventListener("DOMContentLoaded", function () {
+        // 先尝试从URL加载
+        var loadedFromUrl = loadFromUrl();
+
+        // 如果没有从URL加载，则从localStorage加载
+        if (!loadedFromUrl) {
+          loadFromStorage();
+        }
+
+        // 自动保存
+        document.getElementById("csvInput").addEventListener("input", saveToStorage);
+        document.getElementById("rowField").addEventListener("change", saveToStorage);
+        document.getElementById("colField").addEventListener("change", saveToStorage);
+        document.getElementById("valueField").addEventListener("change", saveToStorage);
+        document.getElementById("aggFunc").addEventListener("change", saveToStorage);
+      });
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/scatter-plot.html
+++ b/tools/data/scatter-plot.html
@@ -14,7 +14,10 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Scatter Plot - WebUtils" />
-    <meta property="og:description" content="Scatter Plot，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Scatter Plot，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/scatter-plot.html" />
     <meta property="og:site_name" content="WebUtils" />
@@ -27,7 +30,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Scatter Plot - WebUtils" />
-    <meta name="twitter:description" content="Scatter Plot，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Scatter Plot，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Scatter Plot",
-      "item": "https://tools.realtime-ai.chat/tools/data/scatter-plot.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Scatter Plot",
+            "item": "https://tools.realtime-ai.chat/tools/data/scatter-plot.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Scatter Plot - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Scatter Plot - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1060 +94,1067 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
 
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1.5fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1.5fr;
+        gap: 24px;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="color"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="color"] {
-    height: 42px;
-    padding: 4px;
-    cursor: pointer;
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="color"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="color"] {
+        height: 42px;
+        padding: 4px;
+        cursor: pointer;
+      }
 
-  textarea {
-    min-height: 180px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-success {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
+      .btn-success {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+      }
 
-  .chart-container {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    min-height: 400px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-  }
+      .btn-success:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
 
-  .chart-placeholder {
-    color: var(--color-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    text-align: center;
-  }
+      .chart-container {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+        min-height: 400px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
 
-  #chartCanvas {
-    max-width: 100%;
-    max-height: 100%;
-  }
+      .chart-placeholder {
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        text-align: center;
+      }
 
-  .series-list {
-    max-height: 200px;
-    overflow-y: auto;
-    margin-bottom: 16px;
-  }
+      #chartCanvas {
+        max-width: 100%;
+        max-height: 100%;
+      }
 
-  .series-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 8px;
-  }
+      .series-list {
+        max-height: 200px;
+        overflow-y: auto;
+        margin-bottom: 16px;
+      }
 
-  .series-color {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
+      .series-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        margin-bottom: 8px;
+      }
 
-  .series-name {
-    flex: 1;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-primary);
-  }
+      .series-color {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
 
-  .series-count {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-  }
+      .series-name {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-primary);
+      }
 
-  .series-remove {
-    background: none;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 1rem;
-    padding: 4px;
-    opacity: 0.7;
-    transition: opacity 0.2s;
-  }
+      .series-count {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+      }
 
-  .series-remove:hover {
-    opacity: 1;
-  }
+      .series-remove {
+        background: none;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 1rem;
+        padding: 4px;
+        opacity: 0.7;
+        transition: opacity 0.2s;
+      }
 
-  .config-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
+      .series-remove:hover {
+        opacity: 1;
+      }
 
-  .help-text {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .config-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .help-text {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .toast.error {
+        background: var(--accent-red);
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .config-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .config-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">散点图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">⚫</span>
-        散点图生成器
-      </h1>
-      <p>创建散点图，支持多数据系列、自定义样式和图片导出</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <div class="tool-layout">
-      <!-- Left Panel: Input & Config -->
-      <div class="left-panel">
-        <div class="tool-section">
-          <div class="section-title">数据输入</div>
-          <div class="input-group">
-            <label class="input-label">系列名称</label>
-            <input type="text" id="seriesName" placeholder="数据系列 1" value="数据系列 1">
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">散点图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">⚫</span>
+              散点图生成器
+            </h1>
+            <p>创建散点图，支持多数据系列、自定义样式和图片导出</p>
           </div>
-          <div class="input-group">
-            <label class="input-label">数据点 (每行一个: X,Y)</label>
-            <textarea id="dataInput" placeholder="1,2
+        </header>
+
+        <main class="main-content">
+          <div class="tool-layout">
+            <!-- Left Panel: Input & Config -->
+            <div class="left-panel">
+              <div class="tool-section">
+                <div class="section-title">数据输入</div>
+                <div class="input-group">
+                  <label class="input-label">系列名称</label>
+                  <input type="text" id="seriesName" placeholder="数据系列 1" value="数据系列 1" />
+                </div>
+                <div class="input-group">
+                  <label class="input-label">数据点 (每行一个: X,Y)</label>
+                  <textarea
+                    id="dataInput"
+                    placeholder="1,2
 3,5
 4,8
 6,3
-8,10"></textarea>
-            <div class="help-text">格式: X,Y (每行一个数据点，用逗号分隔)</div>
-          </div>
-          <div class="config-grid">
-            <div class="input-group">
-              <label class="input-label">点颜色</label>
-              <input type="color" id="pointColor" value="#00f5d4">
-            </div>
-            <div class="input-group">
-              <label class="input-label">点大小</label>
-              <input type="number" id="pointSize" value="8" min="2" max="30">
-            </div>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-primary" onclick="addSeries()">➕ 添加系列</button>
-            <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
-          </div>
-        </div>
+8,10"
+                  ></textarea>
+                  <div class="help-text">格式: X,Y (每行一个数据点，用逗号分隔)</div>
+                </div>
+                <div class="config-grid">
+                  <div class="input-group">
+                    <label class="input-label">点颜色</label>
+                    <input type="color" id="pointColor" value="#00f5d4" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">点大小</label>
+                    <input type="number" id="pointSize" value="8" min="2" max="30" />
+                  </div>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-primary" onclick="addSeries()">➕ 添加系列</button>
+                  <button class="btn btn-secondary" onclick="pasteData()">📋 粘贴</button>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">数据系列</div>
-          <div class="series-list" id="seriesList">
-            <div class="chart-placeholder">暂无数据系列，请添加数据</div>
-          </div>
-          <div class="btn-row">
-            <button class="btn btn-secondary" onclick="clearAllSeries()">🗑️ 清空所有</button>
-          </div>
-        </div>
+              <div class="tool-section">
+                <div class="section-title">数据系列</div>
+                <div class="series-list" id="seriesList">
+                  <div class="chart-placeholder">暂无数据系列，请添加数据</div>
+                </div>
+                <div class="btn-row">
+                  <button class="btn btn-secondary" onclick="clearAllSeries()">🗑️ 清空所有</button>
+                </div>
+              </div>
 
-        <div class="tool-section">
-          <div class="section-title">图表设置</div>
-          <div class="input-group">
-            <label class="input-label">图表标题</label>
-            <input type="text" id="chartTitle" placeholder="散点图" value="散点图">
-          </div>
-          <div class="config-grid">
-            <div class="input-group">
-              <label class="input-label">X轴标签</label>
-              <input type="text" id="xAxisLabel" placeholder="X 轴" value="X 轴">
+              <div class="tool-section">
+                <div class="section-title">图表设置</div>
+                <div class="input-group">
+                  <label class="input-label">图表标题</label>
+                  <input type="text" id="chartTitle" placeholder="散点图" value="散点图" />
+                </div>
+                <div class="config-grid">
+                  <div class="input-group">
+                    <label class="input-label">X轴标签</label>
+                    <input type="text" id="xAxisLabel" placeholder="X 轴" value="X 轴" />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">Y轴标签</label>
+                    <input type="text" id="yAxisLabel" placeholder="Y 轴" value="Y 轴" />
+                  </div>
+                </div>
+                <div class="btn-row" style="margin-top: 16px">
+                  <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
+                </div>
+              </div>
             </div>
-            <div class="input-group">
-              <label class="input-label">Y轴标签</label>
-              <input type="text" id="yAxisLabel" placeholder="Y 轴" value="Y 轴">
-            </div>
-          </div>
-          <div class="btn-row" style="margin-top: 16px">
-            <button class="btn btn-primary" onclick="generateChart()">📊 生成图表</button>
-          </div>
-        </div>
-      </div>
 
-      <!-- Right Panel: Chart -->
-      <div class="right-panel">
-        <div class="tool-section" style="height: 100%">
-          <div class="section-title">图表预览</div>
-          <div class="chart-container" id="chartContainer">
-            <canvas id="chartCanvas"></canvas>
-            <div class="chart-placeholder" id="chartPlaceholder">添加数据并点击"生成图表"预览</div>
+            <!-- Right Panel: Chart -->
+            <div class="right-panel">
+              <div class="tool-section" style="height: 100%">
+                <div class="section-title">图表预览</div>
+                <div class="chart-container" id="chartContainer">
+                  <canvas id="chartCanvas"></canvas>
+                  <div class="chart-placeholder" id="chartPlaceholder">
+                    添加数据并点击"生成图表"预览
+                  </div>
+                </div>
+                <div class="btn-row" style="margin-top: 16px">
+                  <button class="btn btn-success" onclick="exportPNG()">💾 导出 PNG</button>
+                  <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="btn-row" style="margin-top: 16px">
-            <button class="btn btn-success" onclick="exportPNG()">💾 导出 PNG</button>
-            <button class="btn btn-secondary" onclick="shareChart()">🔗 分享</button>
-          </div>
-        </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "散点图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/data/scatter-plot.html"
-            }
-          ]
-        }
-
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "散点图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/data/scatter-plot.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      const LS_KEY = "scatter-plot-data";
+      let dataSeries = [];
+      let chart = null;
+      let seriesIdCounter = 0;
 
-  const LS_KEY = "scatter-plot-data";
-        let dataSeries = [];
-        let chart = null;
-        let seriesIdCounter = 0;
+      // 预设颜色
+      const PRESET_COLORS = [
+        "#00f5d4",
+        "#f72585",
+        "#fbbf24",
+        "#10b981",
+        "#a855f7",
+        "#3b82f6",
+        "#ef4444",
+        "#06b6d4"
+      ];
 
-        // 预设颜色
-        const PRESET_COLORS = [
-          "#00f5d4",
-          "#f72585",
-          "#fbbf24",
-          "#10b981",
-          "#a855f7",
-          "#3b82f6",
-          "#ef4444",
-          "#06b6d4"
-        ];
-
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-          if (chart) {
-            updateChartTheme();
-          }
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+        if (chart) {
+          updateChartTheme();
         }
+      }
 
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // 更新图表主题
-        function updateChartTheme() {
-          if (!chart) return;
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
-          const gridColor = isDark ? "#2a2a3a" : "#e5e5e5";
-
-          chart.options.plugins.title.color = textColor;
-          chart.options.plugins.legend.labels.color = textColor;
-          chart.options.scales.x.title.color = textColor;
-          chart.options.scales.y.title.color = textColor;
-          chart.options.scales.x.ticks.color = textColor;
-          chart.options.scales.y.ticks.color = textColor;
-          chart.options.scales.x.grid.color = gridColor;
-          chart.options.scales.y.grid.color = gridColor;
-          chart.update();
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // 解析数据
-        function parseData(input) {
-          const lines = input.trim().split("\n");
-          const points = [];
-          const errors = [];
+      // 更新图表主题
+      function updateChartTheme() {
+        if (!chart) return;
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
+        const gridColor = isDark ? "#2a2a3a" : "#e5e5e5";
 
-          lines.forEach((line, idx) => {
-            line = line.trim();
-            if (!line) return;
+        chart.options.plugins.title.color = textColor;
+        chart.options.plugins.legend.labels.color = textColor;
+        chart.options.scales.x.title.color = textColor;
+        chart.options.scales.y.title.color = textColor;
+        chart.options.scales.x.ticks.color = textColor;
+        chart.options.scales.y.ticks.color = textColor;
+        chart.options.scales.x.grid.color = gridColor;
+        chart.options.scales.y.grid.color = gridColor;
+        chart.update();
+      }
 
-            const parts = line.split(/[,\t\s]+/);
-            if (parts.length >= 2) {
-              const x = parseFloat(parts[0]);
-              const y = parseFloat(parts[1]);
-              if (!isNaN(x) && !isNaN(y)) {
-                points.push({ x, y });
-              } else {
-                errors.push("第 " + (idx + 1) + " 行: 无效数字");
-              }
+      // 解析数据
+      function parseData(input) {
+        const lines = input.trim().split("\n");
+        const points = [];
+        const errors = [];
+
+        lines.forEach((line, idx) => {
+          line = line.trim();
+          if (!line) return;
+
+          const parts = line.split(/[,\t\s]+/);
+          if (parts.length >= 2) {
+            const x = parseFloat(parts[0]);
+            const y = parseFloat(parts[1]);
+            if (!isNaN(x) && !isNaN(y)) {
+              points.push({ x, y });
             } else {
-              errors.push("第 " + (idx + 1) + " 行: 格式错误，需要 X,Y");
+              errors.push("第 " + (idx + 1) + " 行: 无效数字");
             }
-          });
-
-          return { points, errors };
-        }
-
-        // 添加数据系列
-        function addSeries() {
-          const input = document.getElementById("dataInput").value;
-          const name =
-            document.getElementById("seriesName").value.trim() ||
-            "数据系列 " + (dataSeries.length + 1);
-          const color = document.getElementById("pointColor").value;
-          const pointSize = parseInt(document.getElementById("pointSize").value) || 8;
-
-          if (!input.trim()) {
-            showToast("请输入数据", true);
-            return;
-          }
-
-          const { points, errors } = parseData(input);
-
-          if (errors.length > 0) {
-            showToast("数据解析错误: " + errors[0], true);
-            return;
-          }
-
-          if (points.length === 0) {
-            showToast("未找到有效数据点", true);
-            return;
-          }
-
-          dataSeries.push({
-            id: ++seriesIdCounter,
-            name: name,
-            color: color,
-            pointSize: pointSize,
-            data: points
-          });
-
-          // 更新UI
-          renderSeriesList();
-          saveToStorage();
-
-          // 清空输入并设置下一个系列的默认值
-          document.getElementById("dataInput").value = "";
-          document.getElementById("seriesName").value = "数据系列 " + (dataSeries.length + 1);
-          document.getElementById("pointColor").value =
-            PRESET_COLORS[dataSeries.length % PRESET_COLORS.length];
-
-          showToast('已添加 "' + name + '" (' + points.length + " 个点)");
-        }
-
-        // 创建系列项元素（安全的DOM方式）
-        function createSeriesItem(series) {
-          const item = document.createElement("div");
-          item.className = "series-item";
-
-          const colorDiv = document.createElement("div");
-          colorDiv.className = "series-color";
-          colorDiv.style.background = series.color;
-
-          const nameSpan = document.createElement("span");
-          nameSpan.className = "series-name";
-          nameSpan.textContent = series.name;
-
-          const countSpan = document.createElement("span");
-          countSpan.className = "series-count";
-          countSpan.textContent = series.data.length + " 点";
-
-          const removeBtn = document.createElement("button");
-          removeBtn.className = "series-remove";
-          removeBtn.title = "删除";
-          removeBtn.textContent = "✕";
-          removeBtn.onclick = function () {
-            removeSeries(series.id);
-          };
-
-          item.appendChild(colorDiv);
-          item.appendChild(nameSpan);
-          item.appendChild(countSpan);
-          item.appendChild(removeBtn);
-
-          return item;
-        }
-
-        // 渲染系列列表
-        function renderSeriesList() {
-          const container = document.getElementById("seriesList");
-          container.textContent = "";
-
-          if (dataSeries.length === 0) {
-            const placeholder = document.createElement("div");
-            placeholder.className = "chart-placeholder";
-            placeholder.textContent = "暂无数据系列，请添加数据";
-            container.appendChild(placeholder);
-            return;
-          }
-
-          dataSeries.forEach(function (series) {
-            container.appendChild(createSeriesItem(series));
-          });
-        }
-
-        // 删除系列
-        function removeSeries(id) {
-          dataSeries = dataSeries.filter(function (s) {
-            return s.id !== id;
-          });
-          renderSeriesList();
-          saveToStorage();
-          if (dataSeries.length > 0) {
-            generateChart();
           } else {
-            clearChart();
+            errors.push("第 " + (idx + 1) + " 行: 格式错误，需要 X,Y");
           }
-          showToast("已删除系列");
+        });
+
+        return { points, errors };
+      }
+
+      // 添加数据系列
+      function addSeries() {
+        const input = document.getElementById("dataInput").value;
+        const name =
+          document.getElementById("seriesName").value.trim() ||
+          "数据系列 " + (dataSeries.length + 1);
+        const color = document.getElementById("pointColor").value;
+        const pointSize = parseInt(document.getElementById("pointSize").value) || 8;
+
+        if (!input.trim()) {
+          showToast("请输入数据", true);
+          return;
         }
 
-        // 清空所有系列
-        function clearAllSeries() {
-          dataSeries = [];
-          seriesIdCounter = 0;
-          renderSeriesList();
+        const { points, errors } = parseData(input);
+
+        if (errors.length > 0) {
+          showToast("数据解析错误: " + errors[0], true);
+          return;
+        }
+
+        if (points.length === 0) {
+          showToast("未找到有效数据点", true);
+          return;
+        }
+
+        dataSeries.push({
+          id: ++seriesIdCounter,
+          name: name,
+          color: color,
+          pointSize: pointSize,
+          data: points
+        });
+
+        // 更新UI
+        renderSeriesList();
+        saveToStorage();
+
+        // 清空输入并设置下一个系列的默认值
+        document.getElementById("dataInput").value = "";
+        document.getElementById("seriesName").value = "数据系列 " + (dataSeries.length + 1);
+        document.getElementById("pointColor").value =
+          PRESET_COLORS[dataSeries.length % PRESET_COLORS.length];
+
+        showToast('已添加 "' + name + '" (' + points.length + " 个点)");
+      }
+
+      // 创建系列项元素（安全的DOM方式）
+      function createSeriesItem(series) {
+        const item = document.createElement("div");
+        item.className = "series-item";
+
+        const colorDiv = document.createElement("div");
+        colorDiv.className = "series-color";
+        colorDiv.style.background = series.color;
+
+        const nameSpan = document.createElement("span");
+        nameSpan.className = "series-name";
+        nameSpan.textContent = series.name;
+
+        const countSpan = document.createElement("span");
+        countSpan.className = "series-count";
+        countSpan.textContent = series.data.length + " 点";
+
+        const removeBtn = document.createElement("button");
+        removeBtn.className = "series-remove";
+        removeBtn.title = "删除";
+        removeBtn.textContent = "✕";
+        removeBtn.onclick = function () {
+          removeSeries(series.id);
+        };
+
+        item.appendChild(colorDiv);
+        item.appendChild(nameSpan);
+        item.appendChild(countSpan);
+        item.appendChild(removeBtn);
+
+        return item;
+      }
+
+      // 渲染系列列表
+      function renderSeriesList() {
+        const container = document.getElementById("seriesList");
+        container.textContent = "";
+
+        if (dataSeries.length === 0) {
+          const placeholder = document.createElement("div");
+          placeholder.className = "chart-placeholder";
+          placeholder.textContent = "暂无数据系列，请添加数据";
+          container.appendChild(placeholder);
+          return;
+        }
+
+        dataSeries.forEach(function (series) {
+          container.appendChild(createSeriesItem(series));
+        });
+      }
+
+      // 删除系列
+      function removeSeries(id) {
+        dataSeries = dataSeries.filter(function (s) {
+          return s.id !== id;
+        });
+        renderSeriesList();
+        saveToStorage();
+        if (dataSeries.length > 0) {
+          generateChart();
+        } else {
           clearChart();
-          saveToStorage();
-          document.getElementById("seriesName").value = "数据系列 1";
-          document.getElementById("pointColor").value = PRESET_COLORS[0];
-          showToast("已清空所有数据");
+        }
+        showToast("已删除系列");
+      }
+
+      // 清空所有系列
+      function clearAllSeries() {
+        dataSeries = [];
+        seriesIdCounter = 0;
+        renderSeriesList();
+        clearChart();
+        saveToStorage();
+        document.getElementById("seriesName").value = "数据系列 1";
+        document.getElementById("pointColor").value = PRESET_COLORS[0];
+        showToast("已清空所有数据");
+      }
+
+      // 清空图表
+      function clearChart() {
+        if (chart) {
+          chart.destroy();
+          chart = null;
+        }
+        document.getElementById("chartPlaceholder").style.display = "block";
+      }
+
+      // 生成图表
+      function generateChart() {
+        if (dataSeries.length === 0) {
+          showToast("请先添加数据系列", true);
+          return;
         }
 
-        // 清空图表
-        function clearChart() {
-          if (chart) {
-            chart.destroy();
-            chart = null;
-          }
-          document.getElementById("chartPlaceholder").style.display = "block";
+        const isDark = document.body.getAttribute("data-theme") !== "light";
+        const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
+        const gridColor = isDark ? "#2a2a3a" : "#e5e5e5";
+
+        const chartTitle = document.getElementById("chartTitle").value || "散点图";
+        const xAxisLabel = document.getElementById("xAxisLabel").value || "X 轴";
+        const yAxisLabel = document.getElementById("yAxisLabel").value || "Y 轴";
+
+        // 隐藏占位符
+        document.getElementById("chartPlaceholder").style.display = "none";
+
+        // 销毁旧图表
+        if (chart) {
+          chart.destroy();
         }
 
-        // 生成图表
-        function generateChart() {
-          if (dataSeries.length === 0) {
-            showToast("请先添加数据系列", true);
-            return;
-          }
+        const ctx = document.getElementById("chartCanvas").getContext("2d");
 
-          const isDark = document.body.getAttribute("data-theme") !== "light";
-          const textColor = isDark ? "#e8e8ed" : "#1a1a1a";
-          const gridColor = isDark ? "#2a2a3a" : "#e5e5e5";
+        const datasets = dataSeries.map(function (series) {
+          return {
+            label: series.name,
+            data: series.data,
+            backgroundColor: series.color,
+            borderColor: series.color,
+            pointRadius: series.pointSize,
+            pointHoverRadius: series.pointSize + 3
+          };
+        });
 
-          const chartTitle = document.getElementById("chartTitle").value || "散点图";
-          const xAxisLabel = document.getElementById("xAxisLabel").value || "X 轴";
-          const yAxisLabel = document.getElementById("yAxisLabel").value || "Y 轴";
-
-          // 隐藏占位符
-          document.getElementById("chartPlaceholder").style.display = "none";
-
-          // 销毁旧图表
-          if (chart) {
-            chart.destroy();
-          }
-
-          const ctx = document.getElementById("chartCanvas").getContext("2d");
-
-          const datasets = dataSeries.map(function (series) {
-            return {
-              label: series.name,
-              data: series.data,
-              backgroundColor: series.color,
-              borderColor: series.color,
-              pointRadius: series.pointSize,
-              pointHoverRadius: series.pointSize + 3
-            };
-          });
-
-          chart = new Chart(ctx, {
-            type: "scatter",
-            data: { datasets: datasets },
-            options: {
-              responsive: true,
-              maintainAspectRatio: true,
-              plugins: {
-                title: {
-                  display: true,
-                  text: chartTitle,
+        chart = new Chart(ctx, {
+          type: "scatter",
+          data: { datasets: datasets },
+          options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+              title: {
+                display: true,
+                text: chartTitle,
+                color: textColor,
+                font: {
+                  size: 16,
+                  weight: "bold",
+                  family: "'Space Grotesk', sans-serif"
+                }
+              },
+              legend: {
+                display: dataSeries.length > 1,
+                position: "top",
+                labels: {
                   color: textColor,
                   font: {
-                    size: 16,
-                    weight: "bold",
+                    family: "'JetBrains Mono', monospace"
+                  },
+                  usePointStyle: true,
+                  pointStyle: "circle"
+                }
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    return (
+                      context.dataset.label +
+                      ": (" +
+                      context.parsed.x +
+                      ", " +
+                      context.parsed.y +
+                      ")"
+                    );
+                  }
+                }
+              }
+            },
+            scales: {
+              x: {
+                title: {
+                  display: true,
+                  text: xAxisLabel,
+                  color: textColor,
+                  font: {
                     family: "'Space Grotesk', sans-serif"
                   }
                 },
-                legend: {
-                  display: dataSeries.length > 1,
-                  position: "top",
-                  labels: {
-                    color: textColor,
-                    font: {
-                      family: "'JetBrains Mono', monospace"
-                    },
-                    usePointStyle: true,
-                    pointStyle: "circle"
-                  }
+                ticks: {
+                  color: textColor
                 },
-                tooltip: {
-                  callbacks: {
-                    label: function (context) {
-                      return (
-                        context.dataset.label +
-                        ": (" +
-                        context.parsed.x +
-                        ", " +
-                        context.parsed.y +
-                        ")"
-                      );
-                    }
-                  }
+                grid: {
+                  color: gridColor
                 }
               },
-              scales: {
-                x: {
-                  title: {
-                    display: true,
-                    text: xAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif"
-                    }
-                  },
-                  ticks: {
-                    color: textColor
-                  },
-                  grid: {
-                    color: gridColor
+              y: {
+                title: {
+                  display: true,
+                  text: yAxisLabel,
+                  color: textColor,
+                  font: {
+                    family: "'Space Grotesk', sans-serif"
                   }
                 },
-                y: {
-                  title: {
-                    display: true,
-                    text: yAxisLabel,
-                    color: textColor,
-                    font: {
-                      family: "'Space Grotesk', sans-serif"
-                    }
-                  },
-                  ticks: {
-                    color: textColor
-                  },
-                  grid: {
-                    color: gridColor
-                  }
+                ticks: {
+                  color: textColor
+                },
+                grid: {
+                  color: gridColor
                 }
               }
             }
-          });
-
-          saveToStorage();
-          showToast("图表已生成");
-        }
-
-        // 导出为PNG
-        function exportPNG() {
-          if (!chart) {
-            showToast("请先生成图表", true);
-            return;
           }
+        });
 
-          const canvas = document.getElementById("chartCanvas");
-          const link = document.createElement("a");
-          link.download = "scatter-plot.png";
-          link.href = canvas.toDataURL("image/png", 1.0);
-          link.click();
-          showToast("图片已导出");
+        saveToStorage();
+        showToast("图表已生成");
+      }
+
+      // 导出为PNG
+      function exportPNG() {
+        if (!chart) {
+          showToast("请先生成图表", true);
+          return;
         }
 
-        // 粘贴数据
-        async function pasteData() {
-          try {
-            const text = await navigator.clipboard.readText();
-            document.getElementById("dataInput").value = text;
-            showToast("已粘贴数据");
-          } catch (err) {
-            showToast("无法访问剪贴板", true);
+        const canvas = document.getElementById("chartCanvas");
+        const link = document.createElement("a");
+        link.download = "scatter-plot.png";
+        link.href = canvas.toDataURL("image/png", 1.0);
+        link.click();
+        showToast("图片已导出");
+      }
+
+      // 粘贴数据
+      async function pasteData() {
+        try {
+          const text = await navigator.clipboard.readText();
+          document.getElementById("dataInput").value = text;
+          showToast("已粘贴数据");
+        } catch (err) {
+          showToast("无法访问剪贴板", true);
+        }
+      }
+
+      // 分享图表
+      function shareChart() {
+        const state = {
+          series: dataSeries,
+          config: {
+            title: document.getElementById("chartTitle").value,
+            xLabel: document.getElementById("xAxisLabel").value,
+            yLabel: document.getElementById("yAxisLabel").value
           }
-        }
+        };
 
-        // 分享图表
-        function shareChart() {
-          const state = {
-            series: dataSeries,
-            config: {
-              title: document.getElementById("chartTitle").value,
-              xLabel: document.getElementById("xAxisLabel").value,
-              yLabel: document.getElementById("yAxisLabel").value
+        const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
+        const url = window.location.origin + window.location.pathname + "#" + encoded;
+
+        navigator.clipboard.writeText(url).then(function () {
+          showToast("分享链接已复制到剪贴板");
+        });
+      }
+
+      // 从URL加载
+      function loadFromUrl() {
+        const hash = window.location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          const state = JSON.parse(decodeURIComponent(atob(hash)));
+          if (state.series && state.series.length > 0) {
+            dataSeries = state.series;
+            seriesIdCounter = Math.max.apply(
+              null,
+              dataSeries
+                .map(function (s) {
+                  return s.id || 0;
+                })
+                .concat([0])
+            );
+
+            if (state.config) {
+              document.getElementById("chartTitle").value = state.config.title || "散点图";
+              document.getElementById("xAxisLabel").value = state.config.xLabel || "X 轴";
+              document.getElementById("yAxisLabel").value = state.config.yLabel || "Y 轴";
             }
-          };
 
-          const encoded = btoa(encodeURIComponent(JSON.stringify(state)));
-          const url = window.location.origin + window.location.pathname + "#" + encoded;
-
-          navigator.clipboard.writeText(url).then(function () {
-            showToast("分享链接已复制到剪贴板");
-          });
+            renderSeriesList();
+            generateChart();
+            return true;
+          }
+        } catch (e) {
+          console.error("Failed to load from URL:", e);
         }
+        return false;
+      }
 
-        // 从URL加载
-        function loadFromUrl() {
-          const hash = window.location.hash.slice(1);
-          if (!hash) return false;
+      // 保存到localStorage
+      function saveToStorage() {
+        const state = {
+          series: dataSeries,
+          config: {
+            title: document.getElementById("chartTitle").value,
+            xLabel: document.getElementById("xAxisLabel").value,
+            yLabel: document.getElementById("yAxisLabel").value
+          }
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
 
-          try {
-            const state = JSON.parse(decodeURIComponent(atob(hash)));
-            if (state.series && state.series.length > 0) {
-              dataSeries = state.series;
-              seriesIdCounter = Math.max.apply(
-                null,
-                dataSeries
-                  .map(function (s) {
-                    return s.id || 0;
-                  })
-                  .concat([0])
-              );
+      // 从localStorage加载
+      function loadFromStorage() {
+        const saved = localStorage.getItem(LS_KEY);
+        if (!saved) return false;
 
-              if (state.config) {
-                document.getElementById("chartTitle").value = state.config.title || "散点图";
-                document.getElementById("xAxisLabel").value = state.config.xLabel || "X 轴";
-                document.getElementById("yAxisLabel").value = state.config.yLabel || "Y 轴";
-              }
+        try {
+          const state = JSON.parse(saved);
+          if (state.series && state.series.length > 0) {
+            dataSeries = state.series;
+            seriesIdCounter = Math.max.apply(
+              null,
+              dataSeries
+                .map(function (s) {
+                  return s.id || 0;
+                })
+                .concat([0])
+            );
 
-              renderSeriesList();
-              generateChart();
-              return true;
+            if (state.config) {
+              document.getElementById("chartTitle").value = state.config.title || "散点图";
+              document.getElementById("xAxisLabel").value = state.config.xLabel || "X 轴";
+              document.getElementById("yAxisLabel").value = state.config.yLabel || "Y 轴";
             }
-          } catch (e) {
-            console.error("Failed to load from URL:", e);
+
+            renderSeriesList();
+            return true;
           }
-          return false;
+        } catch (e) {
+          console.error("Failed to load from storage:", e);
+        }
+        return false;
+      }
+
+      // 显示提示
+      function showToast(msg, isError) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (isError ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // 初始化
+      (function init() {
+        // 优先从URL加载，其次从localStorage
+        if (!loadFromUrl()) {
+          loadFromStorage();
         }
 
-        // 保存到localStorage
-        function saveToStorage() {
-          const state = {
-            series: dataSeries,
-            config: {
-              title: document.getElementById("chartTitle").value,
-              xLabel: document.getElementById("xAxisLabel").value,
-              yLabel: document.getElementById("yAxisLabel").value
-            }
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
+        // 设置默认颜色
+        if (dataSeries.length === 0) {
+          document.getElementById("pointColor").value = PRESET_COLORS[0];
+        } else {
+          document.getElementById("seriesName").value = "数据系列 " + (dataSeries.length + 1);
+          document.getElementById("pointColor").value =
+            PRESET_COLORS[dataSeries.length % PRESET_COLORS.length];
         }
+      })();
+    </script>
 
-        // 从localStorage加载
-        function loadFromStorage() {
-          const saved = localStorage.getItem(LS_KEY);
-          if (!saved) return false;
-
-          try {
-            const state = JSON.parse(saved);
-            if (state.series && state.series.length > 0) {
-              dataSeries = state.series;
-              seriesIdCounter = Math.max.apply(
-                null,
-                dataSeries
-                  .map(function (s) {
-                    return s.id || 0;
-                  })
-                  .concat([0])
-              );
-
-              if (state.config) {
-                document.getElementById("chartTitle").value = state.config.title || "散点图";
-                document.getElementById("xAxisLabel").value = state.config.xLabel || "X 轴";
-                document.getElementById("yAxisLabel").value = state.config.yLabel || "Y 轴";
-              }
-
-              renderSeriesList();
-              return true;
-            }
-          } catch (e) {
-            console.error("Failed to load from storage:", e);
-          }
-          return false;
-        }
-
-        // 显示提示
-        function showToast(msg, isError) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (isError ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // 初始化
-        (function init() {
-          // 优先从URL加载，其次从localStorage
-          if (!loadFromUrl()) {
-            loadFromStorage();
-          }
-
-          // 设置默认颜色
-          if (dataSeries.length === 0) {
-            document.getElementById("pointColor").value = PRESET_COLORS[0];
-          } else {
-            document.getElementById("seriesName").value = "数据系列 " + (dataSeries.length + 1);
-            document.getElementById("pointColor").value =
-              PRESET_COLORS[dataSeries.length % PRESET_COLORS.length];
-          }
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</body>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  </body>
 </html>

--- a/tools/data/sql-query-builder.html
+++ b/tools/data/sql-query-builder.html
@@ -6,7 +6,10 @@
     <title>Sql Query Builder - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="sql query builder" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Sql Query Builder - WebUtils" />
-    <meta property="og:description" content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/data/sql-query-builder.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Sql Query Builder - WebUtils" />
-    <meta name="twitter:description" content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Sql Query Builder，在线使用，数据工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "数据工具",
-      "item": "https://tools.realtime-ai.chat/tools/data/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Sql Query Builder",
-      "item": "https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/tools/data/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Sql Query Builder",
+            "item": "https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Sql Query Builder - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Sql Query Builder - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1342 +100,1377 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0 245 212 / 15%);
-    --glow-green: rgb(16 185 129 / 15%);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
 
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0 245 212 / 15%);
+        --glow-green: rgb(16 185 129 / 15%);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  @media (max-width: 900px) {
-    .tool-layout {
-      grid-template-columns: 1fr;
-    }
-  }
+      .tool-layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      @media (max-width: 900px) {
+        .tool-layout {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  .input-hint {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-hint {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      select {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  .input-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .input-row-3 {
-    display: grid;
-    grid-template-columns: 1fr 1fr auto;
-    gap: 12px;
-    align-items: end;
-  }
+      .input-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
 
-  @media (max-width: 500px) {
-    .input-row,
-    .input-row-3 {
-      grid-template-columns: 1fr;
-    }
-  }
+      .input-row-3 {
+        display: grid;
+        grid-template-columns: 1fr 1fr auto;
+        gap: 12px;
+        align-items: end;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      @media (max-width: 500px) {
+        .input-row,
+        .input-row-3 {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-small {
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: 0;
-    min-width: auto;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .operation-tabs {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-  }
+      .btn-small {
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: 0;
+        min-width: auto;
+      }
 
-  .op-tab {
-    padding: 10px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    background: var(--bg-input);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+      .operation-tabs {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
 
-  .op-tab:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .op-tab {
+        padding: 10px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: var(--bg-input);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
 
-  .op-tab.active {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-    border-color: var(--color-accent-cyan);
-  }
+      .op-tab:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  .checkbox-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 16px;
-  }
+      .op-tab.active {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+        border-color: var(--color-accent-cyan);
+      }
 
-  .checkbox-group input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--color-accent-cyan);
-    cursor: pointer;
-  }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
 
-  .checkbox-group label {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    user-select: none;
-  }
+      .checkbox-group input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--color-accent-cyan);
+        cursor: pointer;
+      }
 
-  .condition-list {
-    margin-bottom: 16px;
-  }
+      .checkbox-group label {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        user-select: none;
+      }
 
-  .condition-item {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr auto;
-    gap: 8px;
-    margin-bottom: 8px;
-    align-items: center;
-  }
+      .condition-list {
+        margin-bottom: 16px;
+      }
 
-  .condition-item input,
-  .condition-item select {
-    min-width: 0;
-  }
+      .condition-item {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr auto;
+        gap: 8px;
+        margin-bottom: 8px;
+        align-items: center;
+      }
 
-  .column-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 16px;
-    min-height: 32px;
-  }
+      .condition-item input,
+      .condition-item select {
+        min-width: 0;
+      }
 
-  .column-chip {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: 20px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-  }
+      .column-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 16px;
+        min-height: 32px;
+      }
 
-  .column-chip .remove {
-    cursor: pointer;
-    color: var(--color-text-muted);
-    font-size: 1rem;
-    line-height: 1;
-  }
+      .column-chip {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: 20px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+      }
 
-  .column-chip .remove:hover {
-    color: var(--accent-red);
-  }
+      .column-chip .remove {
+        cursor: pointer;
+        color: var(--color-text-muted);
+        font-size: 1rem;
+        line-height: 1;
+      }
 
-  .sql-output {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-accent-cyan);
-    min-height: 180px;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    line-height: 1.8;
-  }
+      .column-chip .remove:hover {
+        color: var(--accent-red);
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .sql-output {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-accent-cyan);
+        min-height: 180px;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        line-height: 1.8;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  .toast.error {
-    background: var(--accent-red);
-    color: white;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  .empty-state {
-    color: var(--color-text-muted);
-    font-size: 0.85rem;
-    font-style: italic;
-  }
+      .toast.error {
+        background: var(--accent-red);
+        color: white;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .empty-state {
+        color: var(--color-text-muted);
+        font-size: 0.85rem;
+        font-style: italic;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    .condition-item {
-      grid-template-columns: 1fr;
-      gap: 4px;
-    }
-  }
-</style>
+        .btn {
+          width: 100%;
+        }
+
+        .condition-item {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">SQL查询构建器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔧</span>
-        SQL查询构建器
-      </h1>
-      <p>可视化构建SQL查询语句，支持SELECT、INSERT、UPDATE、DELETE</p>
-    </div>
-  </header>
-  <main class="main-content">
-    <div class="tool-layout">
-      <div class="input-panel">
-        <!-- 操作类型选择 -->
-        <div class="tool-section">
-          <div class="section-title">操作类型</div>
-          <div class="operation-tabs">
-            <button class="op-tab active" data-op="select" onclick="selectOperation('select')">
-              SELECT
-            </button>
-            <button class="op-tab" data-op="insert" onclick="selectOperation('insert')">
-              INSERT
-            </button>
-            <button class="op-tab" data-op="update" onclick="selectOperation('update')">
-              UPDATE
-            </button>
-            <button class="op-tab" data-op="delete" onclick="selectOperation('delete')">
-              DELETE
-            </button>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">SQL查询构建器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔧</span>
+              SQL查询构建器
+            </h1>
+            <p>可视化构建SQL查询语句，支持SELECT、INSERT、UPDATE、DELETE</p>
           </div>
-        </div>
+        </header>
+        <main class="main-content">
+          <div class="tool-layout">
+            <div class="input-panel">
+              <!-- 操作类型选择 -->
+              <div class="tool-section">
+                <div class="section-title">操作类型</div>
+                <div class="operation-tabs">
+                  <button
+                    class="op-tab active"
+                    data-op="select"
+                    onclick="selectOperation('select')"
+                  >
+                    SELECT
+                  </button>
+                  <button class="op-tab" data-op="insert" onclick="selectOperation('insert')">
+                    INSERT
+                  </button>
+                  <button class="op-tab" data-op="update" onclick="selectOperation('update')">
+                    UPDATE
+                  </button>
+                  <button class="op-tab" data-op="delete" onclick="selectOperation('delete')">
+                    DELETE
+                  </button>
+                </div>
+              </div>
 
-        <!-- 表设置 -->
-        <div class="tool-section">
-          <div class="section-title">表设置</div>
-          <div class="input-group">
-            <label class="input-label">表名</label>
-            <input type="text" id="tableName" placeholder="users" value="users" oninput="generateSQL()">
-          </div>
-        </div>
+              <!-- 表设置 -->
+              <div class="tool-section">
+                <div class="section-title">表设置</div>
+                <div class="input-group">
+                  <label class="input-label">表名</label>
+                  <input
+                    type="text"
+                    id="tableName"
+                    placeholder="users"
+                    value="users"
+                    oninput="generateSQL()"
+                  />
+                </div>
+              </div>
 
-        <!-- DISTINCT选项 (SELECT) -->
-        <div class="tool-section" id="distinctSection">
-          <div class="checkbox-group">
-            <input type="checkbox" id="distinctCheck" onchange="generateSQL()">
-            <label for="distinctCheck">使用 DISTINCT (去重)</label>
-          </div>
-        </div>
+              <!-- DISTINCT选项 (SELECT) -->
+              <div class="tool-section" id="distinctSection">
+                <div class="checkbox-group">
+                  <input type="checkbox" id="distinctCheck" onchange="generateSQL()" />
+                  <label for="distinctCheck">使用 DISTINCT (去重)</label>
+                </div>
+              </div>
 
-        <!-- 列选择 (SELECT/INSERT) -->
-        <div class="tool-section" id="columnsSection">
-          <div class="section-title">列 (Columns)</div>
-          <div class="input-row-3">
-            <div class="input-group" style="margin-bottom: 0">
-              <label class="input-label">列名</label>
-              <input type="text" id="columnInput" placeholder="column_name">
+              <!-- 列选择 (SELECT/INSERT) -->
+              <div class="tool-section" id="columnsSection">
+                <div class="section-title">列 (Columns)</div>
+                <div class="input-row-3">
+                  <div class="input-group" style="margin-bottom: 0">
+                    <label class="input-label">列名</label>
+                    <input type="text" id="columnInput" placeholder="column_name" />
+                  </div>
+                  <div class="input-group" id="aliasGroup" style="margin-bottom: 0">
+                    <label class="input-label">别名 (可选)</label>
+                    <input type="text" id="aliasInput" placeholder="alias" />
+                  </div>
+                  <button class="btn btn-secondary btn-small" onclick="addColumn()">+ 添加</button>
+                </div>
+                <div class="column-list" id="columnList">
+                  <span class="empty-state">留空表示 SELECT *</span>
+                </div>
+              </div>
+
+              <!-- 值设置 (INSERT/UPDATE) -->
+              <div class="tool-section" id="valuesSection" style="display: none">
+                <div class="section-title">字段值 (SET)</div>
+                <div id="valuesList"></div>
+                <button
+                  class="btn btn-secondary btn-small"
+                  onclick="addValue()"
+                  style="margin-top: 8px"
+                >
+                  + 添加字段
+                </button>
+              </div>
+
+              <!-- WHERE条件 -->
+              <div class="tool-section" id="conditionsSection">
+                <div class="section-title">WHERE 条件</div>
+                <div class="condition-list" id="conditionList">
+                  <span class="empty-state">无条件 (可选)</span>
+                </div>
+                <button class="btn btn-secondary btn-small" onclick="addCondition()">
+                  + 添加条件
+                </button>
+              </div>
+
+              <!-- ORDER BY (SELECT) -->
+              <div class="tool-section" id="orderSection">
+                <div class="section-title">排序 (ORDER BY)</div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="input-label">排序列</label>
+                    <input
+                      type="text"
+                      id="orderBy"
+                      placeholder="column_name"
+                      oninput="generateSQL()"
+                    />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">顺序</label>
+                    <select id="orderDir" onchange="generateSQL()">
+                      <option value="">-- 选择 --</option>
+                      <option value="ASC">ASC 升序</option>
+                      <option value="DESC">DESC 降序</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <!-- LIMIT (SELECT) -->
+              <div class="tool-section" id="limitSection">
+                <div class="section-title">限制 (LIMIT)</div>
+                <div class="input-row">
+                  <div class="input-group">
+                    <label class="input-label">LIMIT</label>
+                    <input
+                      type="number"
+                      id="limitVal"
+                      placeholder="10"
+                      min="0"
+                      oninput="generateSQL()"
+                    />
+                  </div>
+                  <div class="input-group">
+                    <label class="input-label">OFFSET</label>
+                    <input
+                      type="number"
+                      id="offsetVal"
+                      placeholder="0"
+                      min="0"
+                      oninput="generateSQL()"
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
-            <div class="input-group" id="aliasGroup" style="margin-bottom: 0">
-              <label class="input-label">别名 (可选)</label>
-              <input type="text" id="aliasInput" placeholder="alias">
-            </div>
-            <button class="btn btn-secondary btn-small" onclick="addColumn()">+ 添加</button>
-          </div>
-          <div class="column-list" id="columnList">
-            <span class="empty-state">留空表示 SELECT *</span>
-          </div>
-        </div>
 
-        <!-- 值设置 (INSERT/UPDATE) -->
-        <div class="tool-section" id="valuesSection" style="display: none">
-          <div class="section-title">字段值 (SET)</div>
-          <div id="valuesList"></div>
-          <button class="btn btn-secondary btn-small" onclick="addValue()" style="margin-top: 8px">
-            + 添加字段
-          </button>
-        </div>
-
-        <!-- WHERE条件 -->
-        <div class="tool-section" id="conditionsSection">
-          <div class="section-title">WHERE 条件</div>
-          <div class="condition-list" id="conditionList">
-            <span class="empty-state">无条件 (可选)</span>
-          </div>
-          <button class="btn btn-secondary btn-small" onclick="addCondition()">+ 添加条件</button>
-        </div>
-
-        <!-- ORDER BY (SELECT) -->
-        <div class="tool-section" id="orderSection">
-          <div class="section-title">排序 (ORDER BY)</div>
-          <div class="input-row">
-            <div class="input-group">
-              <label class="input-label">排序列</label>
-              <input type="text" id="orderBy" placeholder="column_name" oninput="generateSQL()">
-            </div>
-            <div class="input-group">
-              <label class="input-label">顺序</label>
-              <select id="orderDir" onchange="generateSQL()">
-                <option value="">-- 选择 --</option>
-                <option value="ASC">ASC 升序</option>
-                <option value="DESC">DESC 降序</option>
-              </select>
+            <!-- 输出面板 -->
+            <div class="output-panel">
+              <div class="tool-section">
+                <div class="section-title">生成的 SQL</div>
+                <div class="sql-output" id="sqlOutput"></div>
+                <div class="btn-row" style="margin-top: 16px">
+                  <button class="btn btn-primary" onclick="copySQL()">📋 复制 SQL</button>
+                  <button class="btn btn-secondary" onclick="shareQuery()">🔗 分享</button>
+                  <button class="btn btn-secondary" onclick="clearAll()">🔄 重置</button>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-
-        <!-- LIMIT (SELECT) -->
-        <div class="tool-section" id="limitSection">
-          <div class="section-title">限制 (LIMIT)</div>
-          <div class="input-row">
-            <div class="input-group">
-              <label class="input-label">LIMIT</label>
-              <input type="number" id="limitVal" placeholder="10" min="0" oninput="generateSQL()">
-            </div>
-            <div class="input-group">
-              <label class="input-label">OFFSET</label>
-              <input type="number" id="offsetVal" placeholder="0" min="0" oninput="generateSQL()">
-            </div>
-          </div>
-        </div>
+        </main>
       </div>
+    </div>
 
-      <!-- 输出面板 -->
-      <div class="output-panel">
-        <div class="tool-section">
-          <div class="section-title">生成的 SQL</div>
-          <div class="sql-output" id="sqlOutput"></div>
-          <div class="btn-row" style="margin-top: 16px">
-            <button class="btn btn-primary" onclick="copySQL()">📋 复制 SQL</button>
-            <button class="btn btn-secondary" onclick="shareQuery()">🔗 分享</button>
-            <button class="btn btn-secondary" onclick="clearAll()">🔄 重置</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "数据工具",
-              "item": "https://tools.realtime-ai.chat/#data"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "SQL查询构建器",
-              "item": "https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "数据工具",
+            "item": "https://tools.realtime-ai.chat/#data"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "SQL查询构建器",
+            "item": "https://tools.realtime-ai.chat/tools/data/sql-query-builder.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // 状态管理
+      var currentOp = "select";
+      var columns = [];
+      var conditions = [];
+      var values = [];
+      var LS_KEY = "sql-query-builder-data";
 
-  // 状态管理
-        var currentOp = "select";
-        var columns = [];
-        var conditions = [];
-        var values = [];
-        var LS_KEY = "sql-query-builder-data";
+      // 主题切换
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // 主题切换
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // 加载主题
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
-
-        // 加载主题
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        // 操作类型切换
-        function selectOperation(op) {
-          currentOp = op;
-          var tabs = document.querySelectorAll(".op-tab");
-          tabs.forEach(function (tab) {
-            tab.classList.toggle("active", tab.getAttribute("data-op") === op);
-          });
-
-          // 控制各区块显示
-          document.getElementById("distinctSection").style.display =
-            op === "select" ? "block" : "none";
-          document.getElementById("columnsSection").style.display =
-            op === "select" || op === "insert" ? "block" : "none";
-          document.getElementById("aliasGroup").style.display = op === "select" ? "block" : "none";
-          document.getElementById("valuesSection").style.display =
-            op === "insert" || op === "update" ? "block" : "none";
-          document.getElementById("conditionsSection").style.display =
-            op !== "insert" ? "block" : "none";
-          document.getElementById("orderSection").style.display = op === "select" ? "block" : "none";
-          document.getElementById("limitSection").style.display = op === "select" ? "block" : "none";
-
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 添加列
-        function addColumn() {
-          var input = document.getElementById("columnInput");
-          var aliasInput = document.getElementById("aliasInput");
-          var col = input.value.trim();
-          var aliasGroupVisible = document.getElementById("aliasGroup").style.display !== "none";
-          var alias = aliasGroupVisible ? aliasInput.value.trim() : "";
-
-          if (!col) {
-            showToast("请输入列名", "error");
-            return;
-          }
-
-          columns.push({ name: col, alias: alias });
-          input.value = "";
-          if (aliasInput) aliasInput.value = "";
-          input.focus();
-
-          renderColumns();
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 移除列
-        function removeColumn(index) {
-          columns.splice(index, 1);
-          renderColumns();
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 渲染列列表
-        function renderColumns() {
-          var list = document.getElementById("columnList");
-          list.textContent = "";
-
-          if (columns.length === 0) {
-            var empty = document.createElement("span");
-            empty.className = "empty-state";
-            empty.textContent = currentOp === "select" ? "留空表示 SELECT *" : "请添加列";
-            list.appendChild(empty);
-            return;
-          }
-
-          columns.forEach(function (col, i) {
-            var chip = document.createElement("div");
-            chip.className = "column-chip";
-
-            var span = document.createElement("span");
-            var displayText = typeof col === "string" ? col : col.name;
-            if (col.alias && currentOp === "select") {
-              displayText += " AS " + col.alias;
-            }
-            span.textContent = displayText;
-
-            var remove = document.createElement("span");
-            remove.className = "remove";
-            remove.textContent = "×";
-            remove.onclick = function () {
-              removeColumn(i);
-            };
-
-            chip.appendChild(span);
-            chip.appendChild(remove);
-            list.appendChild(chip);
-          });
-        }
-
-        // 添加WHERE条件
-        function addCondition() {
-          conditions.push({ column: "", operator: "=", value: "" });
-          renderConditions();
-          saveToStorage();
-        }
-
-        // 移除条件
-        function removeCondition(index) {
-          conditions.splice(index, 1);
-          renderConditions();
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 更新条件
-        function updateCondition(index, field, value) {
-          conditions[index][field] = value;
-          // 当操作符改变时，重新渲染以更新值输入框的状态
-          if (field === "operator") {
-            renderConditions();
-          }
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 渲染条件列表
-        function renderConditions() {
-          var list = document.getElementById("conditionList");
-          list.textContent = "";
-
-          if (conditions.length === 0) {
-            var empty = document.createElement("span");
-            empty.className = "empty-state";
-            empty.textContent = "无条件 (可选)";
-            list.appendChild(empty);
-            return;
-          }
-
-          conditions.forEach(function (cond, i) {
-            var item = document.createElement("div");
-            item.className = "condition-item";
-
-            // 列名输入
-            var colInput = document.createElement("input");
-            colInput.type = "text";
-            colInput.placeholder = "列名";
-            colInput.value = cond.column;
-            colInput.oninput = function () {
-              updateCondition(i, "column", this.value);
-            };
-
-            // 操作符选择
-            var opSelect = document.createElement("select");
-            var operators = [
-              "=",
-              "!=",
-              "<>",
-              ">",
-              "<",
-              ">=",
-              "<=",
-              "LIKE",
-              "NOT LIKE",
-              "IN",
-              "NOT IN",
-              "BETWEEN",
-              "IS NULL",
-              "IS NOT NULL"
-            ];
-            operators.forEach(function (op) {
-              var opt = document.createElement("option");
-              opt.value = op;
-              opt.textContent = op;
-              if (op === cond.operator) opt.selected = true;
-              opSelect.appendChild(opt);
-            });
-            opSelect.onchange = function () {
-              updateCondition(i, "operator", this.value);
-            };
-
-            // 值输入
-            var valInput = document.createElement("input");
-            valInput.type = "text";
-            if (cond.operator === "IN" || cond.operator === "NOT IN") {
-              valInput.placeholder = "val1, val2, ...";
-            } else if (cond.operator === "BETWEEN") {
-              valInput.placeholder = "min, max";
-            } else {
-              valInput.placeholder = "值";
-            }
-            valInput.value = cond.value;
-            valInput.oninput = function () {
-              updateCondition(i, "value", this.value);
-            };
-            // IS NULL 和 IS NOT NULL 不需要值
-            if (cond.operator === "IS NULL" || cond.operator === "IS NOT NULL") {
-              valInput.disabled = true;
-              valInput.placeholder = "N/A";
-              valInput.value = "";
-            }
-
-            // 删除按钮
-            var removeBtn = document.createElement("button");
-            removeBtn.className = "btn btn-secondary btn-small";
-            removeBtn.textContent = "×";
-            removeBtn.onclick = function () {
-              removeCondition(i);
-            };
-
-            item.appendChild(colInput);
-            item.appendChild(opSelect);
-            item.appendChild(valInput);
-            item.appendChild(removeBtn);
-            list.appendChild(item);
-          });
-        }
-
-        // 添加字段值 (INSERT/UPDATE)
-        function addValue() {
-          values.push({ column: "", value: "" });
-          renderValues();
-          saveToStorage();
-        }
-
-        // 移除值
-        function removeValue(index) {
-          values.splice(index, 1);
-          renderValues();
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 更新值
-        function updateValue(index, field, val) {
-          values[index][field] = val;
-          generateSQL();
-          saveToStorage();
-        }
-
-        // 渲染值列表
-        function renderValues() {
-          var list = document.getElementById("valuesList");
-          list.textContent = "";
-
-          if (values.length === 0) {
-            var empty = document.createElement("span");
-            empty.className = "empty-state";
-            empty.textContent = "请添加字段和值";
-            list.appendChild(empty);
-            return;
-          }
-
-          values.forEach(function (v, i) {
-            var item = document.createElement("div");
-            item.className = "condition-item";
-
-            var colInput = document.createElement("input");
-            colInput.type = "text";
-            colInput.placeholder = "列名";
-            colInput.value = v.column;
-            colInput.oninput = function () {
-              updateValue(i, "column", this.value);
-            };
-
-            var eqSpan = document.createElement("span");
-            eqSpan.textContent = "=";
-            eqSpan.style.color = "var(--color-text-muted)";
-            eqSpan.style.fontFamily = "var(--font-mono)";
-            eqSpan.style.fontWeight = "600";
-
-            var valInput = document.createElement("input");
-            valInput.type = "text";
-            valInput.placeholder = "值";
-            valInput.value = v.value;
-            valInput.oninput = function () {
-              updateValue(i, "value", this.value);
-            };
-
-            var removeBtn = document.createElement("button");
-            removeBtn.className = "btn btn-secondary btn-small";
-            removeBtn.textContent = "×";
-            removeBtn.onclick = function () {
-              removeValue(i);
-            };
-
-            item.appendChild(colInput);
-            item.appendChild(eqSpan);
-            item.appendChild(valInput);
-            item.appendChild(removeBtn);
-            list.appendChild(item);
-          });
-        }
-
-        // 转义值
-        function escapeValue(val) {
-          if (val === "" || val === null || val === undefined) return "''";
-          // 检查是否为数字
-          var trimmed = val.toString().trim();
-          if (trimmed !== "" && !isNaN(trimmed) && !isNaN(parseFloat(trimmed))) {
-            return trimmed;
-          }
-          // 检查是否为NULL
-          if (trimmed.toUpperCase() === "NULL") {
-            return "NULL";
-          }
-          // 转义单引号
-          return "'" + val.replace(/'/g, "''") + "'";
-        }
-
-        // 生成SQL
-        function generateSQL() {
-          var table = document.getElementById("tableName").value.trim() || "table_name";
-          var sql = "";
-
-          switch (currentOp) {
-            case "select":
-              var distinct = document.getElementById("distinctCheck").checked;
-              var cols =
-                columns.length > 0
-                  ? columns
-                      .map(function (c) {
-                        if (typeof c === "string") return c;
-                        return c.alias ? c.name + " AS " + c.alias : c.name;
-                      })
-                      .join(", ")
-                  : "*";
-
-              sql = "SELECT ";
-              if (distinct) sql += "DISTINCT ";
-              sql += cols + "\nFROM " + table;
-
-              // WHERE
-              if (conditions.length > 0) {
-                var whereParts = conditions
-                  .filter(function (c) {
-                    return c.column;
-                  })
-                  .map(function (c) {
-                    if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
-                      return c.column + " " + c.operator;
-                    }
-                    if (c.operator === "IN" || c.operator === "NOT IN") {
-                      var vals = c.value
-                        .split(",")
-                        .map(function (v) {
-                          return escapeValue(v.trim());
-                        })
-                        .join(", ");
-                      return c.column + " " + c.operator + " (" + vals + ")";
-                    }
-                    if (c.operator === "BETWEEN") {
-                      var parts = c.value.split(",").map(function (v) {
-                        return escapeValue(v.trim());
-                      });
-                      if (parts.length >= 2) {
-                        return c.column + " BETWEEN " + parts[0] + " AND " + parts[1];
-                      }
-                      return (
-                        c.column + " BETWEEN " + escapeValue(c.value) + " AND " + escapeValue(c.value)
-                      );
-                    }
-                    return c.column + " " + c.operator + " " + escapeValue(c.value);
-                  });
-                if (whereParts.length > 0) {
-                  sql += "\nWHERE " + whereParts.join("\n  AND ");
-                }
-              }
-
-              // ORDER BY
-              var orderBy = document.getElementById("orderBy").value.trim();
-              var orderDir = document.getElementById("orderDir").value;
-              if (orderBy) {
-                sql += "\nORDER BY " + orderBy;
-                if (orderDir) sql += " " + orderDir;
-              }
-
-              // LIMIT
-              var limit = document.getElementById("limitVal").value.trim();
-              var offset = document.getElementById("offsetVal").value.trim();
-              if (limit) {
-                sql += "\nLIMIT " + limit;
-                if (offset && parseInt(offset) > 0) {
-                  sql += " OFFSET " + offset;
-                }
-              }
-              break;
-
-            case "insert":
-              var insertCols =
-                columns.length > 0
-                  ? columns.map(function (c) {
-                      return typeof c === "string" ? c : c.name;
-                    })
-                  : values
-                      .filter(function (v) {
-                        return v.column;
-                      })
-                      .map(function (v) {
-                        return v.column;
-                      });
-
-              var insertVals = values
-                .filter(function (v) {
-                  return v.column;
-                })
-                .map(function (v) {
-                  return escapeValue(v.value);
-                });
-
-              if (insertCols.length > 0 && insertVals.length > 0) {
-                sql =
-                  "INSERT INTO " +
-                  table +
-                  " (" +
-                  insertCols.join(", ") +
-                  ")\nVALUES (" +
-                  insertVals.join(", ") +
-                  ")";
-              } else {
-                sql = "INSERT INTO " + table + " (column1, column2)\nVALUES ('value1', 'value2')";
-              }
-              break;
-
-            case "update":
-              var setParts = values
-                .filter(function (v) {
-                  return v.column;
-                })
-                .map(function (v) {
-                  return v.column + " = " + escapeValue(v.value);
-                });
-
-              sql = "UPDATE " + table;
-              if (setParts.length > 0) {
-                sql += "\nSET " + setParts.join(",\n    ");
-              } else {
-                sql += "\nSET column1 = 'value1'";
-              }
-
-              // WHERE
-              if (conditions.length > 0) {
-                var whereParts2 = conditions
-                  .filter(function (c) {
-                    return c.column;
-                  })
-                  .map(function (c) {
-                    if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
-                      return c.column + " " + c.operator;
-                    }
-                    if (c.operator === "IN" || c.operator === "NOT IN") {
-                      var vals = c.value
-                        .split(",")
-                        .map(function (v) {
-                          return escapeValue(v.trim());
-                        })
-                        .join(", ");
-                      return c.column + " " + c.operator + " (" + vals + ")";
-                    }
-                    return c.column + " " + c.operator + " " + escapeValue(c.value);
-                  });
-                if (whereParts2.length > 0) {
-                  sql += "\nWHERE " + whereParts2.join("\n  AND ");
-                }
-              }
-              break;
-
-            case "delete":
-              sql = "DELETE FROM " + table;
-
-              // WHERE
-              if (conditions.length > 0) {
-                var whereParts3 = conditions
-                  .filter(function (c) {
-                    return c.column;
-                  })
-                  .map(function (c) {
-                    if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
-                      return c.column + " " + c.operator;
-                    }
-                    if (c.operator === "IN" || c.operator === "NOT IN") {
-                      var vals = c.value
-                        .split(",")
-                        .map(function (v) {
-                          return escapeValue(v.trim());
-                        })
-                        .join(", ");
-                      return c.column + " " + c.operator + " (" + vals + ")";
-                    }
-                    return c.column + " " + c.operator + " " + escapeValue(c.value);
-                  });
-                if (whereParts3.length > 0) {
-                  sql += "\nWHERE " + whereParts3.join("\n  AND ");
-                }
-              }
-              break;
-          }
-
-          sql += ";";
-
-          // 显示SQL（使用textContent避免XSS）
-          document.getElementById("sqlOutput").textContent = sql;
-        }
-
-        // 复制SQL
-        function copySQL() {
-          var sql = document.getElementById("sqlOutput").textContent;
-          navigator.clipboard
-            .writeText(sql)
-            .then(function () {
-              showToast("已复制到剪贴板");
-            })
-            .catch(function () {
-              showToast("复制失败", "error");
-            });
-        }
-
-        // 分享查询
-        function shareQuery() {
-          var data = {
-            op: currentOp,
-            table: document.getElementById("tableName").value,
-            distinct: document.getElementById("distinctCheck").checked,
-            columns: columns,
-            conditions: conditions,
-            values: values,
-            orderBy: document.getElementById("orderBy").value,
-            orderDir: document.getElementById("orderDir").value,
-            limit: document.getElementById("limitVal").value,
-            offset: document.getElementById("offsetVal").value
-          };
-
-          var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-          var url = window.location.href.split("#")[0] + "#" + encoded;
-
-          navigator.clipboard
-            .writeText(url)
-            .then(function () {
-              showToast("分享链接已复制");
-            })
-            .catch(function () {
-              showToast("复制失败", "error");
-            });
-        }
-
-        // 从URL加载
-        function loadFromUrl() {
-          var hash = window.location.hash.slice(1);
-          if (!hash) return false;
-
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
-            restoreState(data);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 保存到localStorage
-        function saveToStorage() {
-          var data = {
-            op: currentOp,
-            table: document.getElementById("tableName").value,
-            distinct: document.getElementById("distinctCheck").checked,
-            columns: columns,
-            conditions: conditions,
-            values: values,
-            orderBy: document.getElementById("orderBy").value,
-            orderDir: document.getElementById("orderDir").value,
-            limit: document.getElementById("limitVal").value,
-            offset: document.getElementById("offsetVal").value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // 从localStorage加载
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return false;
-
-          try {
-            var data = JSON.parse(saved);
-            restoreState(data);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
-
-        // 恢复状态
-        function restoreState(data) {
-          if (data.table) document.getElementById("tableName").value = data.table;
-          if (data.distinct !== undefined)
-            document.getElementById("distinctCheck").checked = data.distinct;
-          if (data.columns) columns = data.columns;
-          if (data.conditions) conditions = data.conditions;
-          if (data.values) values = data.values;
-          if (data.orderBy) document.getElementById("orderBy").value = data.orderBy;
-          if (data.orderDir) document.getElementById("orderDir").value = data.orderDir;
-          if (data.limit) document.getElementById("limitVal").value = data.limit;
-          if (data.offset) document.getElementById("offsetVal").value = data.offset;
-
-          renderColumns();
-          renderConditions();
-          renderValues();
-
-          if (data.op) {
-            selectOperation(data.op);
-          } else {
-            generateSQL();
-          }
-        }
-
-        // 清空所有
-        function clearAll() {
-          columns = [];
-          conditions = [];
-          values = [];
-
-          document.getElementById("tableName").value = "users";
-          document.getElementById("distinctCheck").checked = false;
-          document.getElementById("orderBy").value = "";
-          document.getElementById("orderDir").value = "";
-          document.getElementById("limitVal").value = "";
-          document.getElementById("offsetVal").value = "";
-          document.getElementById("columnInput").value = "";
-          document.getElementById("aliasInput").value = "";
-
-          renderColumns();
-          renderConditions();
-          renderValues();
-          selectOperation("select");
-
-          localStorage.removeItem(LS_KEY);
-          window.location.hash = "";
-
-          showToast("已重置");
-        }
-
-        // 显示提示
-        function showToast(msg, type) {
-          type = type || "success";
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (type === "error" ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // 初始化
-        document.addEventListener("DOMContentLoaded", function () {
-          // 回车添加列
-          document.getElementById("columnInput").addEventListener("keypress", function (e) {
-            if (e.key === "Enter") addColumn();
-          });
-          document.getElementById("aliasInput").addEventListener("keypress", function (e) {
-            if (e.key === "Enter") addColumn();
-          });
-
-          // 从URL加载优先
-          if (!loadFromUrl()) {
-            loadFromStorage();
-          }
-
-          // 初始渲染
-          renderColumns();
-          renderConditions();
-          renderValues();
-          generateSQL();
+      })();
+
+      // 操作类型切换
+      function selectOperation(op) {
+        currentOp = op;
+        var tabs = document.querySelectorAll(".op-tab");
+        tabs.forEach(function (tab) {
+          tab.classList.toggle("active", tab.getAttribute("data-op") === op);
         });
-</script>
-    
+
+        // 控制各区块显示
+        document.getElementById("distinctSection").style.display =
+          op === "select" ? "block" : "none";
+        document.getElementById("columnsSection").style.display =
+          op === "select" || op === "insert" ? "block" : "none";
+        document.getElementById("aliasGroup").style.display = op === "select" ? "block" : "none";
+        document.getElementById("valuesSection").style.display =
+          op === "insert" || op === "update" ? "block" : "none";
+        document.getElementById("conditionsSection").style.display =
+          op !== "insert" ? "block" : "none";
+        document.getElementById("orderSection").style.display = op === "select" ? "block" : "none";
+        document.getElementById("limitSection").style.display = op === "select" ? "block" : "none";
+
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 添加列
+      function addColumn() {
+        var input = document.getElementById("columnInput");
+        var aliasInput = document.getElementById("aliasInput");
+        var col = input.value.trim();
+        var aliasGroupVisible = document.getElementById("aliasGroup").style.display !== "none";
+        var alias = aliasGroupVisible ? aliasInput.value.trim() : "";
+
+        if (!col) {
+          showToast("请输入列名", "error");
+          return;
+        }
+
+        columns.push({ name: col, alias: alias });
+        input.value = "";
+        if (aliasInput) aliasInput.value = "";
+        input.focus();
+
+        renderColumns();
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 移除列
+      function removeColumn(index) {
+        columns.splice(index, 1);
+        renderColumns();
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 渲染列列表
+      function renderColumns() {
+        var list = document.getElementById("columnList");
+        list.textContent = "";
+
+        if (columns.length === 0) {
+          var empty = document.createElement("span");
+          empty.className = "empty-state";
+          empty.textContent = currentOp === "select" ? "留空表示 SELECT *" : "请添加列";
+          list.appendChild(empty);
+          return;
+        }
+
+        columns.forEach(function (col, i) {
+          var chip = document.createElement("div");
+          chip.className = "column-chip";
+
+          var span = document.createElement("span");
+          var displayText = typeof col === "string" ? col : col.name;
+          if (col.alias && currentOp === "select") {
+            displayText += " AS " + col.alias;
+          }
+          span.textContent = displayText;
+
+          var remove = document.createElement("span");
+          remove.className = "remove";
+          remove.textContent = "×";
+          remove.onclick = function () {
+            removeColumn(i);
+          };
+
+          chip.appendChild(span);
+          chip.appendChild(remove);
+          list.appendChild(chip);
+        });
+      }
+
+      // 添加WHERE条件
+      function addCondition() {
+        conditions.push({ column: "", operator: "=", value: "" });
+        renderConditions();
+        saveToStorage();
+      }
+
+      // 移除条件
+      function removeCondition(index) {
+        conditions.splice(index, 1);
+        renderConditions();
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 更新条件
+      function updateCondition(index, field, value) {
+        conditions[index][field] = value;
+        // 当操作符改变时，重新渲染以更新值输入框的状态
+        if (field === "operator") {
+          renderConditions();
+        }
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 渲染条件列表
+      function renderConditions() {
+        var list = document.getElementById("conditionList");
+        list.textContent = "";
+
+        if (conditions.length === 0) {
+          var empty = document.createElement("span");
+          empty.className = "empty-state";
+          empty.textContent = "无条件 (可选)";
+          list.appendChild(empty);
+          return;
+        }
+
+        conditions.forEach(function (cond, i) {
+          var item = document.createElement("div");
+          item.className = "condition-item";
+
+          // 列名输入
+          var colInput = document.createElement("input");
+          colInput.type = "text";
+          colInput.placeholder = "列名";
+          colInput.value = cond.column;
+          colInput.oninput = function () {
+            updateCondition(i, "column", this.value);
+          };
+
+          // 操作符选择
+          var opSelect = document.createElement("select");
+          var operators = [
+            "=",
+            "!=",
+            "<>",
+            ">",
+            "<",
+            ">=",
+            "<=",
+            "LIKE",
+            "NOT LIKE",
+            "IN",
+            "NOT IN",
+            "BETWEEN",
+            "IS NULL",
+            "IS NOT NULL"
+          ];
+          operators.forEach(function (op) {
+            var opt = document.createElement("option");
+            opt.value = op;
+            opt.textContent = op;
+            if (op === cond.operator) opt.selected = true;
+            opSelect.appendChild(opt);
+          });
+          opSelect.onchange = function () {
+            updateCondition(i, "operator", this.value);
+          };
+
+          // 值输入
+          var valInput = document.createElement("input");
+          valInput.type = "text";
+          if (cond.operator === "IN" || cond.operator === "NOT IN") {
+            valInput.placeholder = "val1, val2, ...";
+          } else if (cond.operator === "BETWEEN") {
+            valInput.placeholder = "min, max";
+          } else {
+            valInput.placeholder = "值";
+          }
+          valInput.value = cond.value;
+          valInput.oninput = function () {
+            updateCondition(i, "value", this.value);
+          };
+          // IS NULL 和 IS NOT NULL 不需要值
+          if (cond.operator === "IS NULL" || cond.operator === "IS NOT NULL") {
+            valInput.disabled = true;
+            valInput.placeholder = "N/A";
+            valInput.value = "";
+          }
+
+          // 删除按钮
+          var removeBtn = document.createElement("button");
+          removeBtn.className = "btn btn-secondary btn-small";
+          removeBtn.textContent = "×";
+          removeBtn.onclick = function () {
+            removeCondition(i);
+          };
+
+          item.appendChild(colInput);
+          item.appendChild(opSelect);
+          item.appendChild(valInput);
+          item.appendChild(removeBtn);
+          list.appendChild(item);
+        });
+      }
+
+      // 添加字段值 (INSERT/UPDATE)
+      function addValue() {
+        values.push({ column: "", value: "" });
+        renderValues();
+        saveToStorage();
+      }
+
+      // 移除值
+      function removeValue(index) {
+        values.splice(index, 1);
+        renderValues();
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 更新值
+      function updateValue(index, field, val) {
+        values[index][field] = val;
+        generateSQL();
+        saveToStorage();
+      }
+
+      // 渲染值列表
+      function renderValues() {
+        var list = document.getElementById("valuesList");
+        list.textContent = "";
+
+        if (values.length === 0) {
+          var empty = document.createElement("span");
+          empty.className = "empty-state";
+          empty.textContent = "请添加字段和值";
+          list.appendChild(empty);
+          return;
+        }
+
+        values.forEach(function (v, i) {
+          var item = document.createElement("div");
+          item.className = "condition-item";
+
+          var colInput = document.createElement("input");
+          colInput.type = "text";
+          colInput.placeholder = "列名";
+          colInput.value = v.column;
+          colInput.oninput = function () {
+            updateValue(i, "column", this.value);
+          };
+
+          var eqSpan = document.createElement("span");
+          eqSpan.textContent = "=";
+          eqSpan.style.color = "var(--color-text-muted)";
+          eqSpan.style.fontFamily = "var(--font-mono)";
+          eqSpan.style.fontWeight = "600";
+
+          var valInput = document.createElement("input");
+          valInput.type = "text";
+          valInput.placeholder = "值";
+          valInput.value = v.value;
+          valInput.oninput = function () {
+            updateValue(i, "value", this.value);
+          };
+
+          var removeBtn = document.createElement("button");
+          removeBtn.className = "btn btn-secondary btn-small";
+          removeBtn.textContent = "×";
+          removeBtn.onclick = function () {
+            removeValue(i);
+          };
+
+          item.appendChild(colInput);
+          item.appendChild(eqSpan);
+          item.appendChild(valInput);
+          item.appendChild(removeBtn);
+          list.appendChild(item);
+        });
+      }
+
+      // 转义值
+      function escapeValue(val) {
+        if (val === "" || val === null || val === undefined) return "''";
+        // 检查是否为数字
+        var trimmed = val.toString().trim();
+        if (trimmed !== "" && !isNaN(trimmed) && !isNaN(parseFloat(trimmed))) {
+          return trimmed;
+        }
+        // 检查是否为NULL
+        if (trimmed.toUpperCase() === "NULL") {
+          return "NULL";
+        }
+        // 转义单引号
+        return "'" + val.replace(/'/g, "''") + "'";
+      }
+
+      // 生成SQL
+      function generateSQL() {
+        var table = document.getElementById("tableName").value.trim() || "table_name";
+        var sql = "";
+
+        switch (currentOp) {
+          case "select":
+            var distinct = document.getElementById("distinctCheck").checked;
+            var cols =
+              columns.length > 0
+                ? columns
+                    .map(function (c) {
+                      if (typeof c === "string") return c;
+                      return c.alias ? c.name + " AS " + c.alias : c.name;
+                    })
+                    .join(", ")
+                : "*";
+
+            sql = "SELECT ";
+            if (distinct) sql += "DISTINCT ";
+            sql += cols + "\nFROM " + table;
+
+            // WHERE
+            if (conditions.length > 0) {
+              var whereParts = conditions
+                .filter(function (c) {
+                  return c.column;
+                })
+                .map(function (c) {
+                  if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
+                    return c.column + " " + c.operator;
+                  }
+                  if (c.operator === "IN" || c.operator === "NOT IN") {
+                    var vals = c.value
+                      .split(",")
+                      .map(function (v) {
+                        return escapeValue(v.trim());
+                      })
+                      .join(", ");
+                    return c.column + " " + c.operator + " (" + vals + ")";
+                  }
+                  if (c.operator === "BETWEEN") {
+                    var parts = c.value.split(",").map(function (v) {
+                      return escapeValue(v.trim());
+                    });
+                    if (parts.length >= 2) {
+                      return c.column + " BETWEEN " + parts[0] + " AND " + parts[1];
+                    }
+                    return (
+                      c.column + " BETWEEN " + escapeValue(c.value) + " AND " + escapeValue(c.value)
+                    );
+                  }
+                  return c.column + " " + c.operator + " " + escapeValue(c.value);
+                });
+              if (whereParts.length > 0) {
+                sql += "\nWHERE " + whereParts.join("\n  AND ");
+              }
+            }
+
+            // ORDER BY
+            var orderBy = document.getElementById("orderBy").value.trim();
+            var orderDir = document.getElementById("orderDir").value;
+            if (orderBy) {
+              sql += "\nORDER BY " + orderBy;
+              if (orderDir) sql += " " + orderDir;
+            }
+
+            // LIMIT
+            var limit = document.getElementById("limitVal").value.trim();
+            var offset = document.getElementById("offsetVal").value.trim();
+            if (limit) {
+              sql += "\nLIMIT " + limit;
+              if (offset && parseInt(offset) > 0) {
+                sql += " OFFSET " + offset;
+              }
+            }
+            break;
+
+          case "insert":
+            var insertCols =
+              columns.length > 0
+                ? columns.map(function (c) {
+                    return typeof c === "string" ? c : c.name;
+                  })
+                : values
+                    .filter(function (v) {
+                      return v.column;
+                    })
+                    .map(function (v) {
+                      return v.column;
+                    });
+
+            var insertVals = values
+              .filter(function (v) {
+                return v.column;
+              })
+              .map(function (v) {
+                return escapeValue(v.value);
+              });
+
+            if (insertCols.length > 0 && insertVals.length > 0) {
+              sql =
+                "INSERT INTO " +
+                table +
+                " (" +
+                insertCols.join(", ") +
+                ")\nVALUES (" +
+                insertVals.join(", ") +
+                ")";
+            } else {
+              sql = "INSERT INTO " + table + " (column1, column2)\nVALUES ('value1', 'value2')";
+            }
+            break;
+
+          case "update":
+            var setParts = values
+              .filter(function (v) {
+                return v.column;
+              })
+              .map(function (v) {
+                return v.column + " = " + escapeValue(v.value);
+              });
+
+            sql = "UPDATE " + table;
+            if (setParts.length > 0) {
+              sql += "\nSET " + setParts.join(",\n    ");
+            } else {
+              sql += "\nSET column1 = 'value1'";
+            }
+
+            // WHERE
+            if (conditions.length > 0) {
+              var whereParts2 = conditions
+                .filter(function (c) {
+                  return c.column;
+                })
+                .map(function (c) {
+                  if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
+                    return c.column + " " + c.operator;
+                  }
+                  if (c.operator === "IN" || c.operator === "NOT IN") {
+                    var vals = c.value
+                      .split(",")
+                      .map(function (v) {
+                        return escapeValue(v.trim());
+                      })
+                      .join(", ");
+                    return c.column + " " + c.operator + " (" + vals + ")";
+                  }
+                  return c.column + " " + c.operator + " " + escapeValue(c.value);
+                });
+              if (whereParts2.length > 0) {
+                sql += "\nWHERE " + whereParts2.join("\n  AND ");
+              }
+            }
+            break;
+
+          case "delete":
+            sql = "DELETE FROM " + table;
+
+            // WHERE
+            if (conditions.length > 0) {
+              var whereParts3 = conditions
+                .filter(function (c) {
+                  return c.column;
+                })
+                .map(function (c) {
+                  if (c.operator === "IS NULL" || c.operator === "IS NOT NULL") {
+                    return c.column + " " + c.operator;
+                  }
+                  if (c.operator === "IN" || c.operator === "NOT IN") {
+                    var vals = c.value
+                      .split(",")
+                      .map(function (v) {
+                        return escapeValue(v.trim());
+                      })
+                      .join(", ");
+                    return c.column + " " + c.operator + " (" + vals + ")";
+                  }
+                  return c.column + " " + c.operator + " " + escapeValue(c.value);
+                });
+              if (whereParts3.length > 0) {
+                sql += "\nWHERE " + whereParts3.join("\n  AND ");
+              }
+            }
+            break;
+        }
+
+        sql += ";";
+
+        // 显示SQL（使用textContent避免XSS）
+        document.getElementById("sqlOutput").textContent = sql;
+      }
+
+      // 复制SQL
+      function copySQL() {
+        var sql = document.getElementById("sqlOutput").textContent;
+        navigator.clipboard
+          .writeText(sql)
+          .then(function () {
+            showToast("已复制到剪贴板");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      // 分享查询
+      function shareQuery() {
+        var data = {
+          op: currentOp,
+          table: document.getElementById("tableName").value,
+          distinct: document.getElementById("distinctCheck").checked,
+          columns: columns,
+          conditions: conditions,
+          values: values,
+          orderBy: document.getElementById("orderBy").value,
+          orderDir: document.getElementById("orderDir").value,
+          limit: document.getElementById("limitVal").value,
+          offset: document.getElementById("offsetVal").value
+        };
+
+        var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+        var url = window.location.href.split("#")[0] + "#" + encoded;
+
+        navigator.clipboard
+          .writeText(url)
+          .then(function () {
+            showToast("分享链接已复制");
+          })
+          .catch(function () {
+            showToast("复制失败", "error");
+          });
+      }
+
+      // 从URL加载
+      function loadFromUrl() {
+        var hash = window.location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          restoreState(data);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 保存到localStorage
+      function saveToStorage() {
+        var data = {
+          op: currentOp,
+          table: document.getElementById("tableName").value,
+          distinct: document.getElementById("distinctCheck").checked,
+          columns: columns,
+          conditions: conditions,
+          values: values,
+          orderBy: document.getElementById("orderBy").value,
+          orderDir: document.getElementById("orderDir").value,
+          limit: document.getElementById("limitVal").value,
+          offset: document.getElementById("offsetVal").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // 从localStorage加载
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return false;
+
+        try {
+          var data = JSON.parse(saved);
+          restoreState(data);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // 恢复状态
+      function restoreState(data) {
+        if (data.table) document.getElementById("tableName").value = data.table;
+        if (data.distinct !== undefined)
+          document.getElementById("distinctCheck").checked = data.distinct;
+        if (data.columns) columns = data.columns;
+        if (data.conditions) conditions = data.conditions;
+        if (data.values) values = data.values;
+        if (data.orderBy) document.getElementById("orderBy").value = data.orderBy;
+        if (data.orderDir) document.getElementById("orderDir").value = data.orderDir;
+        if (data.limit) document.getElementById("limitVal").value = data.limit;
+        if (data.offset) document.getElementById("offsetVal").value = data.offset;
+
+        renderColumns();
+        renderConditions();
+        renderValues();
+
+        if (data.op) {
+          selectOperation(data.op);
+        } else {
+          generateSQL();
+        }
+      }
+
+      // 清空所有
+      function clearAll() {
+        columns = [];
+        conditions = [];
+        values = [];
+
+        document.getElementById("tableName").value = "users";
+        document.getElementById("distinctCheck").checked = false;
+        document.getElementById("orderBy").value = "";
+        document.getElementById("orderDir").value = "";
+        document.getElementById("limitVal").value = "";
+        document.getElementById("offsetVal").value = "";
+        document.getElementById("columnInput").value = "";
+        document.getElementById("aliasInput").value = "";
+
+        renderColumns();
+        renderConditions();
+        renderValues();
+        selectOperation("select");
+
+        localStorage.removeItem(LS_KEY);
+        window.location.hash = "";
+
+        showToast("已重置");
+      }
+
+      // 显示提示
+      function showToast(msg, type) {
+        type = type || "success";
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // 初始化
+      document.addEventListener("DOMContentLoaded", function () {
+        // 回车添加列
+        document.getElementById("columnInput").addEventListener("keypress", function (e) {
+          if (e.key === "Enter") addColumn();
+        });
+        document.getElementById("aliasInput").addEventListener("keypress", function (e) {
+          if (e.key === "Enter") addColumn();
+        });
+
+        // 从URL加载优先
+        if (!loadFromUrl()) {
+          loadFromStorage();
+        }
+
+        // 初始渲染
+        renderColumns();
+        renderConditions();
+        renderValues();
+        generateSQL();
+      });
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/base64.html
+++ b/tools/dev/base64.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Base64 编解码",
-      "item": "https://tools.realtime-ai.chat/tools/dev/base64.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Base64 编解码",
+            "item": "https://tools.realtime-ai.chat/tools/dev/base64.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Base64 编解码 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Base64 编解码 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1137 +88,1144 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  textarea,
-  select {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-  }
+      input[type="text"],
+      input[type="number"],
+      textarea,
+      select {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+      }
 
-  input:focus,
-  textarea:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  textarea {
-    min-height: 300px;
-    resize: vertical;
-    line-height: 1.5;
-    font-family: var(--font-mono);
-  }
+      textarea {
+        min-height: 300px;
+        resize: vertical;
+        line-height: 1.5;
+        font-family: var(--font-mono);
+      }
 
-  .textarea-input {
-    flex: 1;
-    min-width: 200px;
-  }
+      .textarea-input {
+        flex: 1;
+        min-width: 200px;
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          Panels Layout
          ============================================ */
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-5);
-    margin-bottom: var(--space-5);
-  }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+        margin-bottom: var(--space-5);
+      }
 
-  @media (max-width: 768px) {
-    .panels {
-      grid-template-columns: 1fr;
-    }
-  }
+      @media (max-width: 768px) {
+        .panels {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .panel label {
-    display: block;
-    font-weight: 600;
-    margin-bottom: var(--space-3);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .panel label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: var(--space-3);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  /* ============================================
+      /* ============================================
          Status Messages
          ============================================ */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          File Section
          ============================================ */
-  .file-section {
-    margin-top: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-  }
+      .file-section {
+        margin-top: var(--space-5);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+      }
 
-  .file-section h3 {
-    font-size: 1rem;
-    margin: 0 0 var(--space-3);
-    color: var(--color-text-primary);
-  }
+      .file-section h3 {
+        font-size: 1rem;
+        margin: 0 0 var(--space-3);
+        color: var(--color-text-primary);
+      }
 
-  .file-input-wrapper {
-    position: relative;
-    display: inline-block;
-  }
+      .file-input-wrapper {
+        position: relative;
+        display: inline-block;
+      }
 
-  .file-input-wrapper input[type="file"] {
-    position: absolute;
-    left: 0;
-    top: 0;
-    opacity: 0;
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-  }
+      .file-input-wrapper input[type="file"] {
+        position: absolute;
+        left: 0;
+        top: 0;
+        opacity: 0;
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+      }
 
-  .file-name {
-    margin-left: var(--space-3);
-    color: var(--text-muted);
-    font-size: 0.875rem;
-  }
+      .file-name {
+        margin-left: var(--space-3);
+        color: var(--text-muted);
+        font-size: 0.875rem;
+      }
 
-  .info {
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    margin-top: var(--space-4);
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-  }
+      .info {
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        margin-top: var(--space-4);
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        line-height: 1.6;
+      }
 
-  /* ============================================
+      /* ============================================
          Footer
          ============================================ */
-  footer {
-    text-align: center;
-    margin-top: var(--space-8);
-    padding-top: var(--space-4);
-    color: var(--text-muted);
-    font-size: 0.875rem;
-  }
+      footer {
+        text-align: center;
+        margin-top: var(--space-8);
+        padding-top: var(--space-4);
+        color: var(--text-muted);
+        font-size: 0.875rem;
+      }
 
-  footer a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
+      footer a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
 
-  footer a:hover {
-    color: var(--color-accent-secondary);
-  }
+      footer a:hover {
+        color: var(--color-accent-secondary);
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .input-row {
-      flex-direction: column;
-    }
+        .input-row {
+          flex-direction: column;
+        }
 
-    textarea {
-      min-height: 200px;
-    }
+        textarea {
+          min-height: 200px;
+        }
 
-    .panels {
-      gap: var(--space-4);
-    }
-  }
+        .panels {
+          gap: var(--space-4);
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Encode/Decode Card -->
-    <div class="card">
-      <h2 class="card-title">编码 / 解码</h2>
+        <div class="container">
+          <!-- Encode/Decode Card -->
+          <div class="card">
+            <h2 class="card-title">编码 / 解码</h2>
 
-      <div class="input-group">
-        <label>操作</label>
-        <div class="input-row">
-          <button id="btnPaste">粘贴</button>
-          <button id="btnEncode" class="primary">编码 (Text → Base64)</button>
-          <button id="btnDecode" class="primary">解码 (Base64 → Text)</button>
-        </div>
-      </div>
+            <div class="input-group">
+              <label>操作</label>
+              <div class="input-row">
+                <button id="btnPaste">粘贴</button>
+                <button id="btnEncode" class="primary">编码 (Text → Base64)</button>
+                <button id="btnDecode" class="primary">解码 (Base64 → Text)</button>
+              </div>
+            </div>
 
-      <div class="panels">
-        <div class="panel">
-          <label for="input">输入</label>
-          <textarea id="input" placeholder="输入文本或 Base64 字符串..."></textarea>
-        </div>
-        <div class="panel">
-          <label for="output">输出</label>
-          <textarea id="output" readonly="" placeholder="结果将显示在这里..."></textarea>
-        </div>
-      </div>
+            <div class="panels">
+              <div class="panel">
+                <label for="input">输入</label>
+                <textarea id="input" placeholder="输入文本或 Base64 字符串..."></textarea>
+              </div>
+              <div class="panel">
+                <label for="output">输出</label>
+                <textarea id="output" readonly="" placeholder="结果将显示在这里..."></textarea>
+              </div>
+            </div>
 
-      <div id="status" class="status"></div>
+            <div id="status" class="status"></div>
 
-      <div class="input-group" style="margin-top: var(--space-5)">
-        <label>工具</label>
-        <div class="input-row">
-          <button id="btnCopy">复制输出</button>
-          <button id="btnShare">分享链接</button>
-          <button id="btnClear">清空</button>
+            <div class="input-group" style="margin-top: var(--space-5)">
+              <label>工具</label>
+              <div class="input-row">
+                <button id="btnCopy">复制输出</button>
+                <button id="btnShare">分享链接</button>
+                <button id="btnClear">清空</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- File Encoding Card -->
+          <div class="card">
+            <h2 class="card-title">文件编码</h2>
+
+            <div class="input-group">
+              <label>选择文件</label>
+              <div class="file-input-wrapper">
+                <button>选择文件</button>
+                <input type="file" id="fileInput" />
+              </div>
+              <span id="fileName" class="file-name"></span>
+            </div>
+
+            <div class="info">选择文件后将自动编码为 Base64，输出在编码卡片的右侧文本框</div>
+          </div>
+
+          <!-- Footer -->
+          <footer>
+            <a
+              href="https://github.com/chicogong/html-tools/blob/main/tools/dev/base64.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View source
+            </a>
+            · 纯前端工具 · 无服务器 ·
+            <a href="../../index.html">WebUtils</a>
+          </footer>
         </div>
-      </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>Base64 编解码工具安全吗？数据会上传服务器吗？</summary>
+            <p>
+              完全安全。所有 Base64
+              编码和解码都在你的浏览器本地完成，文本和文件内容不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>Base64 编码后数据会变大多少？</summary>
+            <p>
+              Base64 编码会将原始数据体积增加约 33%，因为每 3 字节原始数据会被转换为 4 个 ASCII
+              字符。例如 100 字节的文件编码后约为 136 字符。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>为什么解码失败，提示「无效的 Base64 字符串」？</summary>
+            <p>
+              常见原因包括：字符串中混入了空格或换行、使用了 URL-safe Base64（含 - 和 _
+              字符）而非标准 Base64（含 + 和 /）、末尾缺少填充字符 = 。请检查并修正输入后重试。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何对文件进行 Base64 编码？</summary>
+            <p>
+              在「文件编码」卡片中点击「选择文件」，选取任意文件后工具会自动将其编码为
+              Base64，结果显示在右侧输出框中，可直接复制使用。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>Base64 编码支持中文和 Unicode 字符吗？</summary>
+            <p>
+              支持。本工具在编码前会先进行 UTF-8 转换，确保中文、日文、emoji 等 Unicode
+              字符都能正确编码和还原，不会出现乱码。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
 
-    <!-- File Encoding Card -->
-    <div class="card">
-      <h2 class="card-title">文件编码</h2>
-
-      <div class="input-group">
-        <label>选择文件</label>
-        <div class="file-input-wrapper">
-          <button>选择文件</button>
-          <input type="file" id="fileInput">
-        </div>
-        <span id="fileName" class="file-name"></span>
-      </div>
-
-      <div class="info">选择文件后将自动编码为 Base64，输出在编码卡片的右侧文本框</div>
-    </div>
-
-    <!-- Footer -->
-    <footer>
-      <a href="https://github.com/chicogong/html-tools/blob/main/tools/dev/base64.html" target="_blank" rel="noreferrer">
-        View source
-      </a>
-      · 纯前端工具 · 无服务器 ·
-      <a href="../../index.html">WebUtils</a>
-    </footer>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>Base64 编解码工具安全吗？数据会上传服务器吗？</summary>
-      <p>
-        完全安全。所有 Base64
-        编码和解码都在你的浏览器本地完成，文本和文件内容不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>Base64 编码后数据会变大多少？</summary>
-      <p>
-        Base64 编码会将原始数据体积增加约 33%，因为每 3 字节原始数据会被转换为 4 个 ASCII 字符。例如
-        100 字节的文件编码后约为 136 字符。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>为什么解码失败，提示「无效的 Base64 字符串」？</summary>
-      <p>
-        常见原因包括：字符串中混入了空格或换行、使用了 URL-safe Base64（含 - 和 _ 字符）而非标准
-        Base64（含 + 和 /）、末尾缺少填充字符 = 。请检查并修正输入后重试。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何对文件进行 Base64 编码？</summary>
-      <p>
-        在「文件编码」卡片中点击「选择文件」，选取任意文件后工具会自动将其编码为
-        Base64，结果显示在右侧输出框中，可直接复制使用。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>Base64 编码支持中文和 Unicode 字符吗？</summary>
-      <p>
-        支持。本工具在编码前会先进行 UTF-8 转换，确保中文、日文、emoji 等 Unicode
-        字符都能正确编码和还原，不会出现乱码。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "Base64 编解码",
-              "item": "https://tools.realtime-ai.chat/tools/dev/base64.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Base64 编解码",
+            "item": "https://tools.realtime-ai.chat/tools/dev/base64.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Base64 编解码工具安全吗？数据会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 Base64 编码和解码都在你的浏览器本地完成，文本和文件内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Base64 编码后数据会变大多少？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Base64 编码会将原始数据体积增加约 33%，因为每 3 字节原始数据会被转换为 4 个 ASCII 字符。例如 100 字节的文件编码后约为 136 字符。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "为什么解码失败，提示「无效的 Base64 字符串」？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "常见原因包括：字符串中混入了空格或换行、使用了 URL-safe Base64（含 - 和 _ 字符）而非标准 Base64（含 + 和 /）、末尾缺少填充字符 = 。请检查并修正输入后重试。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何对文件进行 Base64 编码？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "在「文件编码」卡片中点击「选择文件」，选取任意文件后工具会自动将其编码为 Base64，结果显示在右侧输出框中，可直接复制使用。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Base64 编码支持中文和 Unicode 字符吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "支持。本工具在编码前会先进行 UTF-8 转换，确保中文、日文、emoji 等 Unicode 字符都能正确编码和还原，不会出现乱码。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Base64 编解码工具安全吗？数据会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 Base64 编码和解码都在你的浏览器本地完成，文本和文件内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "Base64 编码后数据会变大多少？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Base64 编码会将原始数据体积增加约 33%，因为每 3 字节原始数据会被转换为 4 个 ASCII 字符。例如 100 字节的文件编码后约为 136 字符。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "为什么解码失败，提示「无效的 Base64 字符串」？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "常见原因包括：字符串中混入了空格或换行、使用了 URL-safe Base64（含 - 和 _ 字符）而非标准 Base64（含 + 和 /）、末尾缺少填充字符 = 。请检查并修正输入后重试。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何对文件进行 Base64 编码？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "在「文件编码」卡片中点击「选择文件」，选取任意文件后工具会自动将其编码为 Base64，结果显示在右侧输出框中，可直接复制使用。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Base64 编码支持中文和 Unicode 字符吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "支持。本工具在编码前会先进行 UTF-8 转换，确保中文、日文、emoji 等 Unicode 字符都能正确编码和还原，不会出现乱码。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  const inputEl = document.getElementById("input");
-  const outputEl = document.getElementById("output");
-  const statusEl = document.getElementById("status");
-  const fileInput = document.getElementById("fileInput");
-  const fileNameEl = document.getElementById("fileName");
+    <script>
+      const inputEl = document.getElementById("input");
+      const outputEl = document.getElementById("output");
+      const statusEl = document.getElementById("status");
+      const fileInput = document.getElementById("fileInput");
+      const fileNameEl = document.getElementById("fileName");
 
-  const LS_KEY = "base64_input_v1";
+      const LS_KEY = "base64_input_v1";
 
-  // URL state
-  window.loadFromUrl = function () {
-    const hash = location.hash.slice(1);
-    if (!hash) return false;
-    try {
-      inputEl.value = decodeURIComponent(atob(hash));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  };
+      // URL state
+      window.loadFromUrl = function () {
+        const hash = location.hash.slice(1);
+        if (!hash) return false;
+        try {
+          inputEl.value = decodeURIComponent(atob(hash));
+          return true;
+        } catch (e) {
+          return false;
+        }
+      };
 
-  function saveToUrl() {
-    try {
-      const encoded = btoa(encodeURIComponent(inputEl.value));
-      history.replaceState(null, "", "#" + encoded);
-    } catch (e) {}
-  }
+      function saveToUrl() {
+        try {
+          const encoded = btoa(encodeURIComponent(inputEl.value));
+          history.replaceState(null, "", "#" + encoded);
+        } catch (e) {}
+      }
 
-  // localStorage
-  function loadFromStorage() {
-    const saved = localStorage.getItem(LS_KEY);
-    if (saved) {
-      inputEl.value = saved;
-    }
-  }
+      // localStorage
+      function loadFromStorage() {
+        const saved = localStorage.getItem(LS_KEY);
+        if (saved) {
+          inputEl.value = saved;
+        }
+      }
 
-  function saveToStorage() {
-    localStorage.setItem(LS_KEY, inputEl.value);
-  }
+      function saveToStorage() {
+        localStorage.setItem(LS_KEY, inputEl.value);
+      }
 
-  // 编码
-  function encode() {
-    const text = inputEl.value;
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      // 编码
+      function encode() {
+        const text = inputEl.value;
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
 
-    try {
-      // 支持 Unicode
-      const encoded = btoa(unescape(encodeURIComponent(text)));
-      outputEl.value = encoded;
-      showStatus("编码成功，长度: " + encoded.length, "success");
-    } catch (e) {
-      showStatus("编码失败: " + e.message, "error");
-    }
-  }
+        try {
+          // 支持 Unicode
+          const encoded = btoa(unescape(encodeURIComponent(text)));
+          outputEl.value = encoded;
+          showStatus("编码成功，长度: " + encoded.length, "success");
+        } catch (e) {
+          showStatus("编码失败: " + e.message, "error");
+        }
+      }
 
-  // 解码
-  window.decode = function () {
-    const text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      // 解码
+      window.decode = function () {
+        const text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
 
-    try {
-      // 支持 Unicode
-      const decoded = decodeURIComponent(escape(atob(text)));
-      outputEl.value = decoded;
-      showStatus("解码成功", "success");
-    } catch (e) {
-      showStatus("解码失败: 无效的 Base64 字符串", "error");
-    }
-  };
+        try {
+          // 支持 Unicode
+          const decoded = decodeURIComponent(escape(atob(text)));
+          outputEl.value = decoded;
+          showStatus("解码成功", "success");
+        } catch (e) {
+          showStatus("解码失败: 无效的 Base64 字符串", "error");
+        }
+      };
 
-  // 文件编码
-  function encodeFile(file) {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const base64 = reader.result.split(",")[1];
-      outputEl.value = base64;
-      showStatus("文件编码成功，大小: " + formatSize(base64.length), "success");
-    };
-    reader.onerror = () => {
-      showStatus("文件读取失败", "error");
-    };
-    reader.readAsDataURL(file);
-  }
+      // 文件编码
+      function encodeFile(file) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const base64 = reader.result.split(",")[1];
+          outputEl.value = base64;
+          showStatus("文件编码成功，大小: " + formatSize(base64.length), "success");
+        };
+        reader.onerror = () => {
+          showStatus("文件读取失败", "error");
+        };
+        reader.readAsDataURL(file);
+      }
 
-  function formatSize(bytes) {
-    if (bytes < 1024) return bytes + " B";
-    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
-    return (bytes / (1024 * 1024)).toFixed(1) + " MB";
-  }
+      function formatSize(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+      }
 
-  function showStatus(msg, type) {
-    statusEl.textContent = msg;
-    statusEl.className = "status " + (type || "");
-  }
+      function showStatus(msg, type) {
+        statusEl.textContent = msg;
+        statusEl.className = "status " + (type || "");
+      }
 
-  // 事件绑定
-  document.getElementById("btnPaste").onclick = async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      inputEl.value = text;
-      saveToStorage();
-      saveToUrl();
-      showStatus("已粘贴", "success");
-    } catch (e) {
-      showStatus("无法访问剪贴板", "error");
-    }
-  };
+      // 事件绑定
+      document.getElementById("btnPaste").onclick = async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+          inputEl.value = text;
+          saveToStorage();
+          saveToUrl();
+          showStatus("已粘贴", "success");
+        } catch (e) {
+          showStatus("无法访问剪贴板", "error");
+        }
+      };
 
-  document.getElementById("btnEncode").onclick = encode;
-  document.getElementById("btnDecode").onclick = window.decode;
+      document.getElementById("btnEncode").onclick = encode;
+      document.getElementById("btnDecode").onclick = window.decode;
 
-  document.getElementById("btnCopy").onclick = async () => {
-    if (!outputEl.value) {
-      showStatus("没有可复制的内容", "error");
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(outputEl.value);
-      showStatus("已复制到剪贴板", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+      document.getElementById("btnCopy").onclick = async () => {
+        if (!outputEl.value) {
+          showStatus("没有可复制的内容", "error");
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(outputEl.value);
+          showStatus("已复制到剪贴板", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
 
-  document.getElementById("btnShare").onclick = async () => {
-    saveToUrl();
-    try {
-      await navigator.clipboard.writeText(location.href);
-      showStatus("分享链接已复制", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+      document.getElementById("btnShare").onclick = async () => {
+        saveToUrl();
+        try {
+          await navigator.clipboard.writeText(location.href);
+          showStatus("分享链接已复制", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
 
-  document.getElementById("btnClear").onclick = () => {
-    inputEl.value = "";
-    outputEl.value = "";
-    fileNameEl.textContent = "";
-    fileInput.value = "";
-    localStorage.removeItem(LS_KEY);
-    history.replaceState(null, "", location.pathname);
-    showStatus("已清空", "success");
-  };
+      document.getElementById("btnClear").onclick = () => {
+        inputEl.value = "";
+        outputEl.value = "";
+        fileNameEl.textContent = "";
+        fileInput.value = "";
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+        showStatus("已清空", "success");
+      };
 
-  fileInput.onchange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      fileNameEl.textContent = file.name + " (" + formatSize(file.size) + ")";
-      encodeFile(file);
-    }
-  };
+      fileInput.onchange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+          fileNameEl.textContent = file.name + " (" + formatSize(file.size) + ")";
+          encodeFile(file);
+        }
+      };
 
-  inputEl.addEventListener("input", () => {
-    saveToStorage();
-    saveToUrl();
-  });
+      inputEl.addEventListener("input", () => {
+        saveToStorage();
+        saveToUrl();
+      });
 
-  // 初始化
-  if (!loadFromUrl()) {
-    loadFromStorage();
-  }
+      // 初始化
+      if (!loadFromUrl()) {
+        loadFromStorage();
+      }
 
-  window.toggleTheme = function () {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
+      window.toggleTheme = function () {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      };
 
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
 
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-</script>
-    
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/diff-checker.html
+++ b/tools/dev/diff-checker.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "文本差异比较",
-      "item": "https://tools.realtime-ai.chat/tools/dev/diff-checker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "文本差异比较",
+            "item": "https://tools.realtime-ai.chat/tools/dev/diff-checker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "文本差异比较 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "文本差异比较 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,686 +88,689 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: #1e1e1e;
-    min-height: 100vh;
-    padding: 20px;
-    color: #d4d4d4;
-  }
-  .container {
-    max-width: 1400px;
-    margin: 0 auto;
-  }
-  .back-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    color: #569cd6;
-    text-decoration: none;
-    margin-bottom: 20px;
-  }
-  .back-link:hover {
-    opacity: 0.8;
-  }
-  h1 {
-    color: #d4d4d4;
-    text-align: center;
-    margin-bottom: 30px;
-    font-size: 2rem;
-  }
-  .input-section {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-    margin-bottom: 20px;
-  }
-  @media (max-width: 768px) {
-    .input-section {
-      grid-template-columns: 1fr;
-    }
-  }
-  .input-panel {
-    background: #252526;
-    border-radius: 8px;
-    overflow: hidden;
-  }
-  .panel-header {
-    background: #333;
-    padding: 10px 15px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .panel-title {
-    font-weight: 600;
-    color: #ccc;
-  }
-  .clear-btn {
-    background: transparent;
-    border: none;
-    color: #888;
-    cursor: pointer;
-    font-size: 12px;
-  }
-  .clear-btn:hover {
-    color: #d4d4d4;
-  }
-  textarea {
-    width: 100%;
-    height: 250px;
-    background: #1e1e1e;
-    border: none;
-    padding: 15px;
-    color: #d4d4d4;
-    font-family: Consolas, Monaco, monospace;
-    font-size: 14px;
-    resize: vertical;
-  }
-  textarea:focus {
-    outline: none;
-  }
-  textarea::placeholder {
-    color: #6a6a6a;
-  }
-  .btn-group {
-    display: flex;
-    justify-content: center;
-    gap: 15px;
-    margin-bottom: 25px;
-  }
-  .btn {
-    padding: 12px 30px;
-    border: none;
-    border-radius: 6px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s;
-  }
-  .btn-primary {
-    background: #0e639c;
-    color: white;
-  }
-  .btn-primary:hover {
-    background: #17b;
-  }
-  .btn-secondary {
-    background: #3c3c3c;
-    color: #d4d4d4;
-  }
-  .btn-secondary:hover {
-    background: #4c4c4c;
-  }
-  .stats {
-    display: flex;
-    justify-content: center;
-    gap: 30px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-  }
-  .stat-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .stat-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
-  }
-  .stat-dot.added {
-    background: #2ea043;
-  }
-  .stat-dot.removed {
-    background: #f85149;
-  }
-  .stat-dot.modified {
-    background: #d29922;
-  }
-  .result-section {
-    background: #252526;
-    border-radius: 8px;
-    overflow: hidden;
-  }
-  .result-header {
-    background: #333;
-    padding: 10px 15px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .view-toggle {
-    display: flex;
-    gap: 5px;
-  }
-  .view-btn {
-    padding: 5px 12px;
-    border: 1px solid #555;
-    background: transparent;
-    color: #888;
-    cursor: pointer;
-    font-size: 12px;
-    border-radius: 3px;
-  }
-  .view-btn.active {
-    background: #0e639c;
-    border-color: #0e639c;
-    color: white;
-  }
-  .diff-container {
-    overflow-x: auto;
-  }
-  .diff-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: Consolas, Monaco, monospace;
-    font-size: 13px;
-  }
-  .diff-table td {
-    padding: 2px 10px;
-    white-space: pre;
-    vertical-align: top;
-  }
-  .line-number {
-    width: 50px;
-    text-align: right;
-    color: #6e7681;
-    background: #161b22;
-    user-select: none;
-    border-right: 1px solid #30363d;
-  }
-  .diff-added {
-    background: rgba(46, 160, 67, 0.15);
-  }
-  .diff-added .line-number {
-    background: rgba(46, 160, 67, 0.3);
-  }
-  .diff-removed {
-    background: rgba(248, 81, 73, 0.15);
-  }
-  .diff-removed .line-number {
-    background: rgba(248, 81, 73, 0.3);
-  }
-  .no-diff {
-    padding: 40px;
-    text-align: center;
-    color: #6a6a6a;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: #1e1e1e;
+        min-height: 100vh;
+        padding: 20px;
+        color: #d4d4d4;
+      }
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        color: #569cd6;
+        text-decoration: none;
+        margin-bottom: 20px;
+      }
+      .back-link:hover {
+        opacity: 0.8;
+      }
+      h1 {
+        color: #d4d4d4;
+        text-align: center;
+        margin-bottom: 30px;
+        font-size: 2rem;
+      }
+      .input-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+        margin-bottom: 20px;
+      }
+      @media (max-width: 768px) {
+        .input-section {
+          grid-template-columns: 1fr;
+        }
+      }
+      .input-panel {
+        background: #252526;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .panel-header {
+        background: #333;
+        padding: 10px 15px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .panel-title {
+        font-weight: 600;
+        color: #ccc;
+      }
+      .clear-btn {
+        background: transparent;
+        border: none;
+        color: #888;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      .clear-btn:hover {
+        color: #d4d4d4;
+      }
+      textarea {
+        width: 100%;
+        height: 250px;
+        background: #1e1e1e;
+        border: none;
+        padding: 15px;
+        color: #d4d4d4;
+        font-family: Consolas, Monaco, monospace;
+        font-size: 14px;
+        resize: vertical;
+      }
+      textarea:focus {
+        outline: none;
+      }
+      textarea::placeholder {
+        color: #6a6a6a;
+      }
+      .btn-group {
+        display: flex;
+        justify-content: center;
+        gap: 15px;
+        margin-bottom: 25px;
+      }
+      .btn {
+        padding: 12px 30px;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.3s;
+      }
+      .btn-primary {
+        background: #0e639c;
+        color: white;
+      }
+      .btn-primary:hover {
+        background: #17b;
+      }
+      .btn-secondary {
+        background: #3c3c3c;
+        color: #d4d4d4;
+      }
+      .btn-secondary:hover {
+        background: #4c4c4c;
+      }
+      .stats {
+        display: flex;
+        justify-content: center;
+        gap: 30px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+      }
+      .stat-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .stat-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+      }
+      .stat-dot.added {
+        background: #2ea043;
+      }
+      .stat-dot.removed {
+        background: #f85149;
+      }
+      .stat-dot.modified {
+        background: #d29922;
+      }
+      .result-section {
+        background: #252526;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .result-header {
+        background: #333;
+        padding: 10px 15px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .view-toggle {
+        display: flex;
+        gap: 5px;
+      }
+      .view-btn {
+        padding: 5px 12px;
+        border: 1px solid #555;
+        background: transparent;
+        color: #888;
+        cursor: pointer;
+        font-size: 12px;
+        border-radius: 3px;
+      }
+      .view-btn.active {
+        background: #0e639c;
+        border-color: #0e639c;
+        color: white;
+      }
+      .diff-container {
+        overflow-x: auto;
+      }
+      .diff-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: Consolas, Monaco, monospace;
+        font-size: 13px;
+      }
+      .diff-table td {
+        padding: 2px 10px;
+        white-space: pre;
+        vertical-align: top;
+      }
+      .line-number {
+        width: 50px;
+        text-align: right;
+        color: #6e7681;
+        background: #161b22;
+        user-select: none;
+        border-right: 1px solid #30363d;
+      }
+      .diff-added {
+        background: rgba(46, 160, 67, 0.15);
+      }
+      .diff-added .line-number {
+        background: rgba(46, 160, 67, 0.3);
+      }
+      .diff-removed {
+        background: rgba(248, 81, 73, 0.15);
+      }
+      .diff-removed .line-number {
+        background: rgba(248, 81, 73, 0.3);
+      }
+      .no-diff {
+        padding: 40px;
+        text-align: center;
+        color: #6a6a6a;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <h1>文本对比工具</h1>
-  <div class="input-section">
-    <div class="input-panel">
-      <div class="panel-header">
-        <span class="panel-title">原始文本</span>
-        <button class="clear-btn" onclick="clearText('text1')">清空</button>
+        <h1>文本对比工具</h1>
+        <div class="input-section">
+          <div class="input-panel">
+            <div class="panel-header">
+              <span class="panel-title">原始文本</span>
+              <button class="clear-btn" onclick="clearText('text1')">清空</button>
+            </div>
+            <textarea id="text1" placeholder="输入或粘贴原始文本..."></textarea>
+          </div>
+          <div class="input-panel">
+            <div class="panel-header">
+              <span class="panel-title">修改后文本</span>
+              <button class="clear-btn" onclick="clearText('text2')">清空</button>
+            </div>
+            <textarea id="text2" placeholder="输入或粘贴修改后的文本..."></textarea>
+          </div>
+        </div>
+        <div class="btn-group">
+          <button class="btn btn-primary" onclick="compareDiff()">对比差异</button>
+          <button class="btn btn-secondary" onclick="swapTexts()">交换文本</button>
+          <button class="btn btn-secondary" onclick="loadSample()">加载示例</button>
+        </div>
+        <div class="stats" id="stats" style="display: none">
+          <div class="stat-item">
+            <span class="stat-dot added"></span>
+            <span>
+              新增:
+              <strong id="addedCount">0</strong>
+              行
+            </span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-dot removed"></span>
+            <span>
+              删除:
+              <strong id="removedCount">0</strong>
+              行
+            </span>
+          </div>
+        </div>
+        <div class="result-section">
+          <div class="result-header">
+            <span class="panel-title">对比结果</span>
+            <div class="view-toggle">
+              <button class="view-btn active" onclick="setView('unified')">统一视图</button>
+            </div>
+          </div>
+          <div class="diff-container" id="diffContainer">
+            <div class="no-diff">输入两段文本并点击"对比差异"按钮</div>
+          </div>
+        </div>
       </div>
-      <textarea id="text1" placeholder="输入或粘贴原始文本..."></textarea>
+      <section class="faq-section container">
+        <h2>常见问题</h2>
+        <details class="faq-item">
+          <summary>文本差异比较工具安全吗？粘贴的代码或文本会上传服务器吗？</summary>
+          <p>
+            完全安全。所有对比运算均在浏览器本地执行，粘贴的代码或文本不会上传到任何服务器，也不会被记录。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>对比结果如何区分新增、删除和未变化的行？</summary>
+          <p>
+            新增行有绿色背景并标注行号，删除行有红色背景并标注行号，未变化的行以普通样式展示。顶部统计区域还会汇总新增行数和删除行数。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>如何加载示例数据体验工具功能？</summary>
+          <p>
+            点击「加载示例」按钮，工具会自动填入一对示例函数代码（原始版本与修改版本），立即执行对比，方便快速了解工具的高亮和行号标注效果。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>能用来比较 JSON、XML 或配置文件吗？</summary>
+          <p>
+            可以。只要是纯文本格式（JSON、XML、YAML、INI、日志等）都可以直接粘贴对比。对比结果以等宽字体展示行号，适合阅读结构化文本的差异。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>交换文本按钮有什么用？</summary>
+          <p>
+            点击「交换文本」会把左侧原始文本和右侧修改后文本互换，让你可以反向查看差异（原来的删除变为新增，新增变为删除），无需重新粘贴内容。
+          </p>
+        </details>
+      </section>
     </div>
-    <div class="input-panel">
-      <div class="panel-header">
-        <span class="panel-title">修改后文本</span>
-        <button class="clear-btn" onclick="clearText('text2')">清空</button>
-      </div>
-      <textarea id="text2" placeholder="输入或粘贴修改后的文本..."></textarea>
-    </div>
-  </div>
-  <div class="btn-group">
-    <button class="btn btn-primary" onclick="compareDiff()">对比差异</button>
-    <button class="btn btn-secondary" onclick="swapTexts()">交换文本</button>
-    <button class="btn btn-secondary" onclick="loadSample()">加载示例</button>
-  </div>
-  <div class="stats" id="stats" style="display: none">
-    <div class="stat-item">
-      <span class="stat-dot added"></span>
-      <span>
-        新增:
-        <strong id="addedCount">0</strong>
-        行
-      </span>
-    </div>
-    <div class="stat-item">
-      <span class="stat-dot removed"></span>
-      <span>
-        删除:
-        <strong id="removedCount">0</strong>
-        行
-      </span>
-    </div>
-  </div>
-  <div class="result-section">
-    <div class="result-header">
-      <span class="panel-title">对比结果</span>
-      <div class="view-toggle">
-        <button class="view-btn active" onclick="setView('unified')">统一视图</button>
-      </div>
-    </div>
-    <div class="diff-container" id="diffContainer">
-      <div class="no-diff">输入两段文本并点击"对比差异"按钮</div>
-    </div>
-  </div>
-</div>
-<section class="faq-section container">
-  <h2>常见问题</h2>
-  <details class="faq-item">
-    <summary>文本差异比较工具安全吗？粘贴的代码或文本会上传服务器吗？</summary>
-    <p>
-      完全安全。所有对比运算均在浏览器本地执行，粘贴的代码或文本不会上传到任何服务器，也不会被记录。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>对比结果如何区分新增、删除和未变化的行？</summary>
-    <p>
-      新增行有绿色背景并标注行号，删除行有红色背景并标注行号，未变化的行以普通样式展示。顶部统计区域还会汇总新增行数和删除行数。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>如何加载示例数据体验工具功能？</summary>
-    <p>
-      点击「加载示例」按钮，工具会自动填入一对示例函数代码（原始版本与修改版本），立即执行对比，方便快速了解工具的高亮和行号标注效果。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>能用来比较 JSON、XML 或配置文件吗？</summary>
-    <p>
-      可以。只要是纯文本格式（JSON、XML、YAML、INI、日志等）都可以直接粘贴对比。对比结果以等宽字体展示行号，适合阅读结构化文本的差异。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>交换文本按钮有什么用？</summary>
-    <p>
-      点击「交换文本」会把左侧原始文本和右侧修改后文本互换，让你可以反向查看差异（原来的删除变为新增，新增变为删除），无需重新粘贴内容。
-    </p>
-  </details>
-</section>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "文本差异比较工具安全吗？粘贴的代码或文本会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有对比运算均在浏览器本地执行，粘贴的代码或文本不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "对比结果如何区分新增、删除和未变化的行？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "新增行有绿色背景并标注行号，删除行有红色背景并标注行号，未变化的行以普通样式展示。顶部统计区域还会汇总新增行数和删除行数。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何加载示例数据体验工具功能？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "点击「加载示例」按钮，工具会自动填入一对示例函数代码（原始版本与修改版本），立即执行对比，方便快速了解工具的高亮和行号标注效果。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "能用来比较 JSON、XML 或配置文件吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。只要是纯文本格式（JSON、XML、YAML、INI、日志等）都可以直接粘贴对比。对比结果以等宽字体展示行号，适合阅读结构化文本的差异。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "交换文本按钮有什么用？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "点击「交换文本」会把左侧原始文本和右侧修改后文本互换，让你可以反向查看差异（原来的删除变为新增，新增变为删除），无需重新粘贴内容。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "文本差异比较工具安全吗？粘贴的代码或文本会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有对比运算均在浏览器本地执行，粘贴的代码或文本不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "对比结果如何区分新增、删除和未变化的行？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "新增行有绿色背景并标注行号，删除行有红色背景并标注行号，未变化的行以普通样式展示。顶部统计区域还会汇总新增行数和删除行数。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何加载示例数据体验工具功能？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "点击「加载示例」按钮，工具会自动填入一对示例函数代码（原始版本与修改版本），立即执行对比，方便快速了解工具的高亮和行号标注效果。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "能用来比较 JSON、XML 或配置文件吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。只要是纯文本格式（JSON、XML、YAML、INI、日志等）都可以直接粘贴对比。对比结果以等宽字体展示行号，适合阅读结构化文本的差异。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "交换文本按钮有什么用？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "点击「交换文本」会把左侧原始文本和右侧修改后文本互换，让你可以反向查看差异（原来的删除变为新增，新增变为删除），无需重新粘贴内容。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
+      let diffResult = null;
 
-  let diffResult = null;
+      function clearText(id) {
+        document.getElementById(id).value = "";
+      }
+      function swapTexts() {
+        const text1 = document.getElementById("text1");
+        const text2 = document.getElementById("text2");
+        const temp = text1.value;
+        text1.value = text2.value;
+        text2.value = temp;
+      }
 
-        function clearText(id) {
-          document.getElementById(id).value = "";
-        }
-        function swapTexts() {
-          const text1 = document.getElementById("text1");
-          const text2 = document.getElementById("text2");
-          const temp = text1.value;
-          text1.value = text2.value;
-          text2.value = temp;
-        }
-
-        function loadSample() {
-          document.getElementById("text1").value = `function greet(name) {
+      function loadSample() {
+        document.getElementById("text1").value = `function greet(name) {
     console.log("Hello, " + name);
     return true;
   }
 
   const user = "World";
   greet(user);`;
-          document.getElementById("text2").value = `function greet(name, greeting = "Hello") {
+        document.getElementById("text2").value = `function greet(name, greeting = "Hello") {
     console.log(greeting + ", " + name + "!");
     return true;
   }
@@ -775,119 +778,119 @@
   const user = "World";
   const message = "Hi";
   greet(user, message);`;
-        }
+      }
 
-        function escapeHtml(text) {
-          const div = document.createElement("div");
-          div.textContent = text;
-          return div.innerHTML;
-        }
+      function escapeHtml(text) {
+        const div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
 
-        function getDiff(lines1, lines2) {
-          const m = lines1.length,
-            n = lines2.length;
-          const dp = Array(m + 1)
-            .fill(null)
-            .map(() => Array(n + 1).fill(0));
-          for (let i = 1; i <= m; i++) {
-            for (let j = 1; j <= n; j++) {
-              if (lines1[i - 1] === lines2[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1;
-              else dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-            }
+      function getDiff(lines1, lines2) {
+        const m = lines1.length,
+          n = lines2.length;
+        const dp = Array(m + 1)
+          .fill(null)
+          .map(() => Array(n + 1).fill(0));
+        for (let i = 1; i <= m; i++) {
+          for (let j = 1; j <= n; j++) {
+            if (lines1[i - 1] === lines2[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1;
+            else dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
           }
-          const result = [];
-          let i = m,
-            j = n;
-          while (i > 0 || j > 0) {
-            if (i > 0 && j > 0 && lines1[i - 1] === lines2[j - 1]) {
-              result.unshift({ type: "same", line1: i, line2: j, content: lines1[i - 1] });
-              i--;
-              j--;
-            } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-              result.unshift({ type: "added", line1: null, line2: j, content: lines2[j - 1] });
-              j--;
-            } else if (i > 0) {
-              result.unshift({ type: "removed", line1: i, line2: null, content: lines1[i - 1] });
-              i--;
-            }
-          }
-          return result;
         }
-
-        function compareDiff() {
-          const text1 = document.getElementById("text1").value;
-          const text2 = document.getElementById("text2").value;
-          const lines1 = text1.split("\n");
-          const lines2 = text2.split("\n");
-          diffResult = getDiff(lines1, lines2);
-          let added = 0,
-            removed = 0;
-          diffResult.forEach((item) => {
-            if (item.type === "added") added++;
-            else if (item.type === "removed") removed++;
-          });
-          document.getElementById("addedCount").textContent = added;
-          document.getElementById("removedCount").textContent = removed;
-          document.getElementById("stats").style.display = "flex";
-          renderDiff();
-        }
-
-        function renderDiff() {
-          if (!diffResult) return;
-          const container = document.getElementById("diffContainer");
-          if (diffResult.every((d) => d.type === "same")) {
-            container.innerHTML = '<div class="no-diff">两段文本完全相同</div>';
-            return;
+        const result = [];
+        let i = m,
+          j = n;
+        while (i > 0 || j > 0) {
+          if (i > 0 && j > 0 && lines1[i - 1] === lines2[j - 1]) {
+            result.unshift({ type: "same", line1: i, line2: j, content: lines1[i - 1] });
+            i--;
+            j--;
+          } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+            result.unshift({ type: "added", line1: null, line2: j, content: lines2[j - 1] });
+            j--;
+          } else if (i > 0) {
+            result.unshift({ type: "removed", line1: i, line2: null, content: lines1[i - 1] });
+            i--;
           }
-          let html = '<table class="diff-table">';
-          for (const item of diffResult) {
-            const lineNum1 = item.line1 || "";
-            const lineNum2 = item.line2 || "";
-            const content = escapeHtml(item.content || "");
-            let rowClass = "",
-              prefix = "  ";
-            if (item.type === "added") {
-              rowClass = "diff-added";
-              prefix = "+ ";
-            } else if (item.type === "removed") {
-              rowClass = "diff-removed";
-              prefix = "- ";
-            }
-            html += `<tr class="${rowClass}">
+        }
+        return result;
+      }
+
+      function compareDiff() {
+        const text1 = document.getElementById("text1").value;
+        const text2 = document.getElementById("text2").value;
+        const lines1 = text1.split("\n");
+        const lines2 = text2.split("\n");
+        diffResult = getDiff(lines1, lines2);
+        let added = 0,
+          removed = 0;
+        diffResult.forEach((item) => {
+          if (item.type === "added") added++;
+          else if (item.type === "removed") removed++;
+        });
+        document.getElementById("addedCount").textContent = added;
+        document.getElementById("removedCount").textContent = removed;
+        document.getElementById("stats").style.display = "flex";
+        renderDiff();
+      }
+
+      function renderDiff() {
+        if (!diffResult) return;
+        const container = document.getElementById("diffContainer");
+        if (diffResult.every((d) => d.type === "same")) {
+          container.innerHTML = '<div class="no-diff">两段文本完全相同</div>';
+          return;
+        }
+        let html = '<table class="diff-table">';
+        for (const item of diffResult) {
+          const lineNum1 = item.line1 || "";
+          const lineNum2 = item.line2 || "";
+          const content = escapeHtml(item.content || "");
+          let rowClass = "",
+            prefix = "  ";
+          if (item.type === "added") {
+            rowClass = "diff-added";
+            prefix = "+ ";
+          } else if (item.type === "removed") {
+            rowClass = "diff-removed";
+            prefix = "- ";
+          }
+          html += `<tr class="${rowClass}">
             <td class="line-number">${lineNum1}</td>
             <td class="line-number">${lineNum2}</td>
             <td class="line-content">${prefix}${content}</td>
           </tr>`;
-          }
-          html += "</table>";
-          container.innerHTML = html;
         }
+        html += "</table>";
+        container.innerHTML = html;
+      }
 
-        function setView(view) {
-          document
-            .querySelectorAll(".view-btn")
-            .forEach((btn) => btn.classList.toggle("active", btn.textContent.includes("统一")));
-          renderDiff();
-        }
+      function setView(view) {
+        document
+          .querySelectorAll(".view-btn")
+          .forEach((btn) => btn.classList.toggle("active", btn.textContent.includes("统一")));
+        renderDiff();
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          const html = document.documentElement;
-          const currentTheme = html.getAttribute("data-theme");
-          const newTheme = currentTheme === "light" ? "dark" : "light";
-          html.setAttribute("data-theme", newTheme);
-          document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-          localStorage.setItem("theme", newTheme);
-        }
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
 
-        // Load saved theme
-        const savedTheme = localStorage.getItem("theme") || "dark";
-        if (savedTheme === "light") {
-          document.documentElement.setAttribute("data-theme", "light");
-          document.getElementById("theme-icon").textContent = "☀️";
-        }
-</script>
-    
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/hash-generator.html
+++ b/tools/dev/hash-generator.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Hash 生成器 - WebUtils" />
-    <meta property="og:description" content="计算文本或文件的 MD5、SHA-1、SHA-256、SHA-512 哈希值" />
+    <meta
+      property="og:description"
+      content="计算文本或文件的 MD5、SHA-1、SHA-256、SHA-512 哈希值"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/dev/hash-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Hash 生成器 - WebUtils" />
-    <meta name="twitter:description" content="计算文本或文件的 MD5、SHA-1、SHA-256、SHA-512 哈希值" />
+    <meta
+      name="twitter:description"
+      content="计算文本或文件的 MD5、SHA-1、SHA-256、SHA-512 哈希值"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Hash 生成器",
-      "item": "https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Hash 生成器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Hash 生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Hash 生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1393 +97,1411 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
 
-  textarea {
-    width: 100%;
-    min-height: 140px;
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-    resize: vertical;
-  }
+      textarea {
+        width: 100%;
+        min-height: 140px;
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+        resize: vertical;
+      }
 
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  /* Options Row */
-  .options-row {
-    display: flex;
-    gap: var(--space-6);
-    flex-wrap: wrap;
-    margin-bottom: var(--space-4);
-    align-items: center;
-  }
+      /* Options Row */
+      .options-row {
+        display: flex;
+        gap: var(--space-6);
+        flex-wrap: wrap;
+        margin-bottom: var(--space-4);
+        align-items: center;
+      }
 
-  .option-group {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
+      .option-group {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
 
-  .option-group label {
-    margin: 0;
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-    font-weight: 500;
-  }
+      .option-group label {
+        margin: 0;
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+        font-weight: 500;
+      }
 
-  select {
-    padding: var(--space-2) var(--space-3);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-sans);
-    transition: all var(--transition-fast);
-  }
+      select {
+        padding: var(--space-2) var(--space-3);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-sans);
+        transition: all var(--transition-fast);
+      }
 
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          Hash Results
          ============================================ */
-  .hash-results {
-    margin-top: var(--space-4);
-  }
+      .hash-results {
+        margin-top: var(--space-4);
+      }
 
-  .hash-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: var(--space-2);
-    font-family: var(--font-mono);
-  }
+      .hash-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: var(--space-2);
+        font-family: var(--font-mono);
+      }
 
-  .hash-item:last-child {
-    margin-bottom: 0;
-  }
+      .hash-item:last-child {
+        margin-bottom: 0;
+      }
 
-  .hash-label {
-    font-weight: 600;
-    min-width: 80px;
-    color: var(--color-accent-primary);
-    font-size: 0.875rem;
-  }
+      .hash-label {
+        font-weight: 600;
+        min-width: 80px;
+        color: var(--color-accent-primary);
+        font-size: 0.875rem;
+      }
 
-  .hash-value {
-    flex: 1;
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    word-break: break-all;
-    color: var(--color-text-primary);
-  }
+      .hash-value {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        word-break: break-all;
+        color: var(--color-text-primary);
+      }
 
-  .hash-copy {
-    padding: var(--space-2) var(--space-3);
-    font-size: 0.8125rem;
-    background: var(--color-bg-input);
-    border-color: var(--color-border-default);
-    white-space: nowrap;
-  }
+      .hash-copy {
+        padding: var(--space-2) var(--space-3);
+        font-size: 0.8125rem;
+        background: var(--color-bg-input);
+        border-color: var(--color-border-default);
+        white-space: nowrap;
+      }
 
-  .hash-copy:hover {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-  }
+      .hash-copy:hover {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+      }
 
-  /* ============================================
+      /* ============================================
          Status Messages
          ============================================ */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          File Section
          ============================================ */
-  .divider {
-    height: 1px;
-    background: var(--color-border-subtle);
-    margin: var(--space-5) 0;
-  }
+      .divider {
+        height: 1px;
+        background: var(--color-border-subtle);
+        margin: var(--space-5) 0;
+      }
 
-  .file-section {
-    margin-top: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-  }
+      .file-section {
+        margin-top: var(--space-5);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+      }
 
-  .file-section h3 {
-    font-size: 1rem;
-    margin-bottom: var(--space-4);
-    color: var(--color-text-primary);
-    font-weight: 600;
-  }
+      .file-section h3 {
+        font-size: 1rem;
+        margin-bottom: var(--space-4);
+        color: var(--color-text-primary);
+        font-weight: 600;
+      }
 
-  .file-input-wrapper {
-    position: relative;
-    display: inline-block;
-  }
+      .file-input-wrapper {
+        position: relative;
+        display: inline-block;
+      }
 
-  .file-input-wrapper input[type="file"] {
-    position: absolute;
-    left: 0;
-    top: 0;
-    opacity: 0;
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-  }
+      .file-input-wrapper input[type="file"] {
+        position: absolute;
+        left: 0;
+        top: 0;
+        opacity: 0;
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+      }
 
-  .file-name {
-    margin-left: var(--space-3);
-    color: var(--color-text-secondary);
-    font-size: 0.9375rem;
-  }
+      .file-name {
+        margin-left: var(--space-3);
+        color: var(--color-text-secondary);
+        font-size: 0.9375rem;
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .input-row {
-      flex-direction: column;
-    }
+        .input-row {
+          flex-direction: column;
+        }
 
-    .options-row {
-      gap: var(--space-4);
-      flex-direction: column;
-      align-items: flex-start;
-    }
+        .options-row {
+          gap: var(--space-4);
+          flex-direction: column;
+          align-items: flex-start;
+        }
 
-    .option-group {
-      flex-direction: column;
-      align-items: flex-start;
-    }
+        .option-group {
+          flex-direction: column;
+          align-items: flex-start;
+        }
 
-    .hash-item {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-2);
-    }
+        .hash-item {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-2);
+        }
 
-    .hash-copy {
-      width: 100%;
-      text-align: center;
-    }
-  }
+        .hash-copy {
+          width: 100%;
+          text-align: center;
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible),
-  select:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible),
+      select:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Breadcrumb Navigation -->
-    <nav class="card" style="margin-bottom: var(--space-4); padding: var(--space-3) var(--space-4)">
-      <div style="
-          display: flex;
-          align-items: center;
-          gap: var(--space-2);
-          font-family: var(--font-mono);
-          font-size: 0.875rem;
-        ">
-        <a href="../../index.html" style="color: var(--color-accent-primary); text-decoration: none">
-          首页
-        </a>
-        <span style="color: var(--text-muted)">/</span>
-        <a href="../../index.html#dev" style="color: var(--color-accent-primary); text-decoration: none">
-          开发工具
-        </a>
-        <span style="color: var(--text-muted)">/</span>
-        <span style="color: var(--color-text-primary); font-weight: 500">Hash 生成器</span>
-      </div>
-    </nav>
+        <div class="container">
+          <!-- Breadcrumb Navigation -->
+          <nav
+            class="card"
+            style="margin-bottom: var(--space-4); padding: var(--space-3) var(--space-4)"
+          >
+            <div
+              style="
+                display: flex;
+                align-items: center;
+                gap: var(--space-2);
+                font-family: var(--font-mono);
+                font-size: 0.875rem;
+              "
+            >
+              <a
+                href="../../index.html"
+                style="color: var(--color-accent-primary); text-decoration: none"
+              >
+                首页
+              </a>
+              <span style="color: var(--text-muted)">/</span>
+              <a
+                href="../../index.html#dev"
+                style="color: var(--color-accent-primary); text-decoration: none"
+              >
+                开发工具
+              </a>
+              <span style="color: var(--text-muted)">/</span>
+              <span style="color: var(--color-text-primary); font-weight: 500">Hash 生成器</span>
+            </div>
+          </nav>
 
-    <!-- Text Hash Card -->
-    <div class="card">
-      <h2 class="card-title">文本哈希</h2>
+          <!-- Text Hash Card -->
+          <div class="card">
+            <h2 class="card-title">文本哈希</h2>
 
-      <div class="input-group">
-        <label for="input">输入文本</label>
-        <textarea id="input" placeholder="输入要计算哈希的文本..."></textarea>
-      </div>
+            <div class="input-group">
+              <label for="input">输入文本</label>
+              <textarea id="input" placeholder="输入要计算哈希的文本..."></textarea>
+            </div>
 
-      <div class="options-row">
-        <div class="option-group">
-          <label for="encoding">编码:</label>
-          <select id="encoding">
-            <option value="utf8" selected="">UTF-8</option>
-            <option value="ascii">ASCII</option>
-          </select>
-        </div>
-        <div class="option-group">
-          <label for="outputCase">输出格式:</label>
-          <select id="outputCase">
-            <option value="lower" selected="">小写</option>
-            <option value="upper">大写</option>
-          </select>
-        </div>
-      </div>
+            <div class="options-row">
+              <div class="option-group">
+                <label for="encoding">编码:</label>
+                <select id="encoding">
+                  <option value="utf8" selected="">UTF-8</option>
+                  <option value="ascii">ASCII</option>
+                </select>
+              </div>
+              <div class="option-group">
+                <label for="outputCase">输出格式:</label>
+                <select id="outputCase">
+                  <option value="lower" selected="">小写</option>
+                  <option value="upper">大写</option>
+                </select>
+              </div>
+            </div>
 
-      <div class="input-row">
-        <button id="btnPaste">粘贴</button>
-        <button id="btnHash" class="primary">计算 Hash</button>
-        <button id="btnClear">清空</button>
-      </div>
+            <div class="input-row">
+              <button id="btnPaste">粘贴</button>
+              <button id="btnHash" class="primary">计算 Hash</button>
+              <button id="btnClear">清空</button>
+            </div>
 
-      <div class="hash-results" id="results">
-        <div class="hash-item">
-          <span class="hash-label">MD5</span>
-          <span class="hash-value" id="md5">-</span>
-          <button class="hash-copy" data-target="md5">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-1</span>
-          <span class="hash-value" id="sha1">-</span>
-          <button class="hash-copy" data-target="sha1">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-256</span>
-          <span class="hash-value" id="sha256">-</span>
-          <button class="hash-copy" data-target="sha256">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-512</span>
-          <span class="hash-value" id="sha512">-</span>
-          <button class="hash-copy" data-target="sha512">复制</button>
-        </div>
-      </div>
+            <div class="hash-results" id="results">
+              <div class="hash-item">
+                <span class="hash-label">MD5</span>
+                <span class="hash-value" id="md5">-</span>
+                <button class="hash-copy" data-target="md5">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-1</span>
+                <span class="hash-value" id="sha1">-</span>
+                <button class="hash-copy" data-target="sha1">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-256</span>
+                <span class="hash-value" id="sha256">-</span>
+                <button class="hash-copy" data-target="sha256">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-512</span>
+                <span class="hash-value" id="sha512">-</span>
+                <button class="hash-copy" data-target="sha512">复制</button>
+              </div>
+            </div>
 
-      <div id="status" class="status"></div>
-    </div>
-
-    <!-- File Hash Card -->
-    <div class="card">
-      <h2 class="card-title">文件哈希</h2>
-
-      <div class="file-section">
-        <div class="input-row">
-          <div class="file-input-wrapper">
-            <button>选择文件</button>
-            <input type="file" id="fileInput">
+            <div id="status" class="status"></div>
           </div>
-          <span id="fileName" class="file-name"></span>
-        </div>
-      </div>
 
-      <div class="hash-results" id="fileResults" style="margin-top: var(--space-4); display: none">
-        <div class="hash-item">
-          <span class="hash-label">MD5</span>
-          <span class="hash-value" id="fileMd5">-</span>
-          <button class="hash-copy" data-target="fileMd5">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-1</span>
-          <span class="hash-value" id="fileSha1">-</span>
-          <button class="hash-copy" data-target="fileSha1">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-256</span>
-          <span class="hash-value" id="fileSha256">-</span>
-          <button class="hash-copy" data-target="fileSha256">复制</button>
-        </div>
-        <div class="hash-item">
-          <span class="hash-label">SHA-512</span>
-          <span class="hash-value" id="fileSha512">-</span>
-          <button class="hash-copy" data-target="fileSha512">复制</button>
-        </div>
-      </div>
+          <!-- File Hash Card -->
+          <div class="card">
+            <h2 class="card-title">文件哈希</h2>
 
-      <div id="fileStatus" class="status"></div>
+            <div class="file-section">
+              <div class="input-row">
+                <div class="file-input-wrapper">
+                  <button>选择文件</button>
+                  <input type="file" id="fileInput" />
+                </div>
+                <span id="fileName" class="file-name"></span>
+              </div>
+            </div>
+
+            <div
+              class="hash-results"
+              id="fileResults"
+              style="margin-top: var(--space-4); display: none"
+            >
+              <div class="hash-item">
+                <span class="hash-label">MD5</span>
+                <span class="hash-value" id="fileMd5">-</span>
+                <button class="hash-copy" data-target="fileMd5">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-1</span>
+                <span class="hash-value" id="fileSha1">-</span>
+                <button class="hash-copy" data-target="fileSha1">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-256</span>
+                <span class="hash-value" id="fileSha256">-</span>
+                <button class="hash-copy" data-target="fileSha256">复制</button>
+              </div>
+              <div class="hash-item">
+                <span class="hash-label">SHA-512</span>
+                <span class="hash-value" id="fileSha512">-</span>
+                <button class="hash-copy" data-target="fileSha512">复制</button>
+              </div>
+            </div>
+
+            <div id="fileStatus" class="status"></div>
+          </div>
+        </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>Hash 生成器安全吗？文本或文件内容会上传到服务器吗？</summary>
+            <p>
+              完全安全。所有哈希计算均在你的浏览器本地完成，文本使用 Web Crypto API，文件通过
+              FileReader 读取后在本地处理，内容不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>MD5、SHA-1、SHA-256、SHA-512 有什么区别？该选哪种？</summary>
+            <p>
+              MD5 输出 128
+              位，速度快但已被证明存在碰撞漏洞，仅适合校验文件完整性，不推荐用于安全场景；SHA-1 输出
+              160 位，同样不再推荐用于安全用途；SHA-256 是目前主流安全标准；SHA-512
+              安全性更高，适合高安全性要求的场景。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何用哈希值校验文件完整性？</summary>
+            <p>
+              下载文件后，使用「文件哈希」功能选择该文件，工具会计算其 SHA-256
+              等哈希值。将结果与官网或发布者提供的哈希值逐字符对比，完全一致则说明文件未被篡改。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>输入同样的文本，每次得到的哈希值一样吗？</summary>
+            <p>
+              是的，哈希函数具有确定性：相同的输入始终产生相同的输出。只要文本内容（含空格、换行、大小写）完全相同，哈希值就完全相同；哪怕改动一个字符，结果也会完全不同。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>Hash 生成器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件
+              HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>Hash 生成器安全吗？文本或文件内容会上传到服务器吗？</summary>
-      <p>
-        完全安全。所有哈希计算均在你的浏览器本地完成，文本使用 Web Crypto API，文件通过 FileReader
-        读取后在本地处理，内容不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>MD5、SHA-1、SHA-256、SHA-512 有什么区别？该选哪种？</summary>
-      <p>
-        MD5 输出 128
-        位，速度快但已被证明存在碰撞漏洞，仅适合校验文件完整性，不推荐用于安全场景；SHA-1 输出 160
-        位，同样不再推荐用于安全用途；SHA-256 是目前主流安全标准；SHA-512
-        安全性更高，适合高安全性要求的场景。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何用哈希值校验文件完整性？</summary>
-      <p>
-        下载文件后，使用「文件哈希」功能选择该文件，工具会计算其 SHA-256
-        等哈希值。将结果与官网或发布者提供的哈希值逐字符对比，完全一致则说明文件未被篡改。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>输入同样的文本，每次得到的哈希值一样吗？</summary>
-      <p>
-        是的，哈希函数具有确定性：相同的输入始终产生相同的输出。只要文本内容（含空格、换行、大小写）完全相同，哈希值就完全相同；哪怕改动一个字符，结果也会完全不同。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>Hash 生成器可以离线使用吗？</summary>
-      <p>
-        可以。本工具是单文件
-        HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "Hash 生成器",
-              "item": "https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Hash 生成器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/hash-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Hash 生成器安全吗？文本或文件内容会上传到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有哈希计算均在你的浏览器本地完成，文本使用 Web Crypto API，文件通过 FileReader 读取后在本地处理，内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "MD5、SHA-1、SHA-256、SHA-512 有什么区别？该选哪种？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "MD5 输出 128 位，速度快但已被证明存在碰撞漏洞，仅适合校验文件完整性，不推荐用于安全场景；SHA-1 输出 160 位，同样不再推荐用于安全用途；SHA-256 是目前主流安全标准；SHA-512 安全性更高，适合高安全性要求的场景。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何用哈希值校验文件完整性？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "下载文件后，使用「文件哈希」功能选择该文件，工具会计算其 SHA-256 等哈希值。将结果与官网或发布者提供的哈希值逐字符对比，完全一致则说明文件未被篡改。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "输入同样的文本，每次得到的哈希值一样吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "是的，哈希函数具有确定性：相同的输入始终产生相同的输出。只要文本内容（含空格、换行、大小写）完全相同，哈希值就完全相同；哪怕改动一个字符，结果也会完全不同。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Hash 生成器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Hash 生成器安全吗？文本或文件内容会上传到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有哈希计算均在你的浏览器本地完成，文本使用 Web Crypto API，文件通过 FileReader 读取后在本地处理，内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "MD5、SHA-1、SHA-256、SHA-512 有什么区别？该选哪种？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "MD5 输出 128 位，速度快但已被证明存在碰撞漏洞，仅适合校验文件完整性，不推荐用于安全场景；SHA-1 输出 160 位，同样不再推荐用于安全用途；SHA-256 是目前主流安全标准；SHA-512 安全性更高，适合高安全性要求的场景。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何用哈希值校验文件完整性？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "下载文件后，使用「文件哈希」功能选择该文件，工具会计算其 SHA-256 等哈希值。将结果与官网或发布者提供的哈希值逐字符对比，完全一致则说明文件未被篡改。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "输入同样的文本，每次得到的哈希值一样吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "是的，哈希函数具有确定性：相同的输入始终产生相同的输出。只要文本内容（含空格、换行、大小写）完全相同，哈希值就完全相同；哪怕改动一个字符，结果也会完全不同。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Hash 生成器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // Elements
-  // ============================================
-  const inputEl = document.getElementById("input");
-  const statusEl = document.getElementById("status");
-  const fileInput = document.getElementById("fileInput");
-  const fileNameEl = document.getElementById("fileName");
-  const fileStatusEl = document.getElementById("fileStatus");
-  const fileResultsEl = document.getElementById("fileResults");
-  const encodingEl = document.getElementById("encoding");
-  const outputCaseEl = document.getElementById("outputCase");
+    <script>
+      // ============================================
+      // Elements
+      // ============================================
+      const inputEl = document.getElementById("input");
+      const statusEl = document.getElementById("status");
+      const fileInput = document.getElementById("fileInput");
+      const fileNameEl = document.getElementById("fileName");
+      const fileStatusEl = document.getElementById("fileStatus");
+      const fileResultsEl = document.getElementById("fileResults");
+      const encodingEl = document.getElementById("encoding");
+      const outputCaseEl = document.getElementById("outputCase");
 
-  // ============================================
-  // MD5 Implementation
-  // ============================================
-  const MD5 = (function () {
-    function safeAdd(x, y) {
-      const lsw = (x & 0xffff) + (y & 0xffff);
-      const msw = (x >> 16) + (y >> 16) + (lsw >> 16);
-      return (msw << 16) | (lsw & 0xffff);
-    }
-    function bitRotateLeft(num, cnt) {
-      return (num << cnt) | (num >>> (32 - cnt));
-    }
-    function md5cmn(q, a, b, x, s, t) {
-      return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
-    }
-    function md5ff(a, b, c, d, x, s, t) {
-      return md5cmn((b & c) | (~b & d), a, b, x, s, t);
-    }
-    function md5gg(a, b, c, d, x, s, t) {
-      return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
-    }
-    function md5hh(a, b, c, d, x, s, t) {
-      return md5cmn(b ^ c ^ d, a, b, x, s, t);
-    }
-    function md5ii(a, b, c, d, x, s, t) {
-      return md5cmn(c ^ (b | ~d), a, b, x, s, t);
-    }
-    function binlMD5(x, len) {
-      x[len >> 5] |= 0x80 << (len % 32);
-      x[(((len + 64) >>> 9) << 4) + 14] = len;
-      let a = 1732584193,
-        b = -271733879,
-        c = -1732584194,
-        d = 271733878;
-      for (let i = 0; i < x.length; i += 16) {
-        const olda = a,
-          oldb = b,
-          oldc = c,
-          oldd = d;
-        a = md5ff(a, b, c, d, x[i], 7, -680876936);
-        d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
-        c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
-        b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
-        a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
-        d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
-        c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
-        b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
-        a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
-        d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
-        c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
-        b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
-        a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
-        d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
-        c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
-        b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
-        a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
-        d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
-        c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
-        b = md5gg(b, c, d, a, x[i], 20, -373897302);
-        a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
-        d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
-        c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
-        b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
-        a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
-        d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
-        c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
-        b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
-        a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
-        d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
-        c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
-        b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
-        a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
-        d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
-        c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
-        b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
-        a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
-        d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
-        c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
-        b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
-        a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
-        d = md5hh(d, a, b, c, x[i + 0], 11, -358537222);
-        c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
-        b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
-        a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
-        d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
-        c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
-        b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
-        a = md5ii(a, b, c, d, x[i], 6, -198630844);
-        d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
-        c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
-        b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
-        a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
-        d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
-        c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
-        b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
-        a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
-        d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
-        c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
-        b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
-        a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
-        d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
-        c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
-        b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
-        a = safeAdd(a, olda);
-        b = safeAdd(b, oldb);
-        c = safeAdd(c, oldc);
-        d = safeAdd(d, oldd);
+      // ============================================
+      // MD5 Implementation
+      // ============================================
+      const MD5 = (function () {
+        function safeAdd(x, y) {
+          const lsw = (x & 0xffff) + (y & 0xffff);
+          const msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+          return (msw << 16) | (lsw & 0xffff);
+        }
+        function bitRotateLeft(num, cnt) {
+          return (num << cnt) | (num >>> (32 - cnt));
+        }
+        function md5cmn(q, a, b, x, s, t) {
+          return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
+        }
+        function md5ff(a, b, c, d, x, s, t) {
+          return md5cmn((b & c) | (~b & d), a, b, x, s, t);
+        }
+        function md5gg(a, b, c, d, x, s, t) {
+          return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
+        }
+        function md5hh(a, b, c, d, x, s, t) {
+          return md5cmn(b ^ c ^ d, a, b, x, s, t);
+        }
+        function md5ii(a, b, c, d, x, s, t) {
+          return md5cmn(c ^ (b | ~d), a, b, x, s, t);
+        }
+        function binlMD5(x, len) {
+          x[len >> 5] |= 0x80 << (len % 32);
+          x[(((len + 64) >>> 9) << 4) + 14] = len;
+          let a = 1732584193,
+            b = -271733879,
+            c = -1732584194,
+            d = 271733878;
+          for (let i = 0; i < x.length; i += 16) {
+            const olda = a,
+              oldb = b,
+              oldc = c,
+              oldd = d;
+            a = md5ff(a, b, c, d, x[i], 7, -680876936);
+            d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
+            c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
+            b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
+            a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
+            d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
+            c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
+            b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
+            a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
+            d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
+            c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
+            b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
+            a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
+            d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
+            c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
+            b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
+            a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
+            d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
+            c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
+            b = md5gg(b, c, d, a, x[i], 20, -373897302);
+            a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
+            d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
+            c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
+            b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
+            a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
+            d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
+            c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
+            b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
+            a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
+            d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
+            c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
+            b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
+            a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
+            d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
+            c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
+            b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
+            a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
+            d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
+            c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
+            b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
+            a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
+            d = md5hh(d, a, b, c, x[i + 0], 11, -358537222);
+            c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
+            b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
+            a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
+            d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
+            c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
+            b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
+            a = md5ii(a, b, c, d, x[i], 6, -198630844);
+            d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
+            c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
+            b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
+            a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
+            d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
+            c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
+            b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
+            a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
+            d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
+            c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
+            b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
+            a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
+            d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
+            c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
+            b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
+            a = safeAdd(a, olda);
+            b = safeAdd(b, oldb);
+            c = safeAdd(c, oldc);
+            d = safeAdd(d, oldd);
+          }
+          return [a, b, c, d];
+        }
+        function binl2hex(binarray) {
+          const hexTab = "0123456789abcdef";
+          let str = "";
+          for (let i = 0; i < binarray.length * 4; i++) {
+            str +=
+              hexTab.charAt((binarray[i >> 2] >> ((i % 4) * 8 + 4)) & 0xf) +
+              hexTab.charAt((binarray[i >> 2] >> ((i % 4) * 8)) & 0xf);
+          }
+          return str;
+        }
+        function str2binl(str) {
+          const bin = [];
+          const mask = (1 << 8) - 1;
+          for (let i = 0; i < str.length * 8; i += 8) {
+            bin[i >> 5] |= (str.charCodeAt(i / 8) & mask) << (i % 32);
+          }
+          return bin;
+        }
+        function utf8Encode(str) {
+          return unescape(encodeURIComponent(str));
+        }
+        return function (str) {
+          return binl2hex(binlMD5(str2binl(utf8Encode(str)), utf8Encode(str).length * 8));
+        };
+      })();
+
+      // ============================================
+      // SHA Implementation
+      // ============================================
+      async function sha(algorithm, text) {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(text);
+        const hashBuffer = await crypto.subtle.digest(algorithm, data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
       }
-      return [a, b, c, d];
-    }
-    function binl2hex(binarray) {
-      const hexTab = "0123456789abcdef";
-      let str = "";
-      for (let i = 0; i < binarray.length * 4; i++) {
-        str +=
-          hexTab.charAt((binarray[i >> 2] >> ((i % 4) * 8 + 4)) & 0xf) +
-          hexTab.charAt((binarray[i >> 2] >> ((i % 4) * 8)) & 0xf);
+
+      async function shaFile(algorithm, file) {
+        const arrayBuffer = await file.arrayBuffer();
+        const hashBuffer = await crypto.subtle.digest(algorithm, arrayBuffer);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
       }
-      return str;
-    }
-    function str2binl(str) {
-      const bin = [];
-      const mask = (1 << 8) - 1;
-      for (let i = 0; i < str.length * 8; i += 8) {
-        bin[i >> 5] |= (str.charCodeAt(i / 8) & mask) << (i % 32);
+
+      // ============================================
+      // MD5 for File
+      // ============================================
+      function md5File(file) {
+        return new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const binary = e.target.result;
+            resolve(MD5(binary));
+          };
+          reader.readAsBinaryString(file);
+        });
       }
-      return bin;
-    }
-    function utf8Encode(str) {
-      return unescape(encodeURIComponent(str));
-    }
-    return function (str) {
-      return binl2hex(binlMD5(str2binl(utf8Encode(str)), utf8Encode(str).length * 8));
-    };
-  })();
 
-  // ============================================
-  // SHA Implementation
-  // ============================================
-  async function sha(algorithm, text) {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(text);
-    const hashBuffer = await crypto.subtle.digest(algorithm, data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-  }
+      // ============================================
+      // Utilities
+      // ============================================
+      function formatHash(hash) {
+        return outputCaseEl.value === "upper" ? hash.toUpperCase() : hash.toLowerCase();
+      }
 
-  async function shaFile(algorithm, file) {
-    const arrayBuffer = await file.arrayBuffer();
-    const hashBuffer = await crypto.subtle.digest(algorithm, arrayBuffer);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-  }
+      function showStatus(el, msg, type) {
+        el.textContent = msg;
+        el.className = "status " + (type || "");
+      }
 
-  // ============================================
-  // MD5 for File
-  // ============================================
-  function md5File(file) {
-    return new Promise((resolve) => {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const binary = e.target.result;
-        resolve(MD5(binary));
+      function formatSize(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+      }
+
+      // ============================================
+      // Hash Calculation
+      // ============================================
+      async function calculateHash() {
+        const text = inputEl.value;
+        if (!text) {
+          showStatus(statusEl, "请输入内容", "error");
+          return;
+        }
+
+        try {
+          const md5 = formatHash(MD5(text));
+          const sha1 = formatHash(await sha("SHA-1", text));
+          const sha256 = formatHash(await sha("SHA-256", text));
+          const sha512 = formatHash(await sha("SHA-512", text));
+
+          document.getElementById("md5").textContent = md5;
+          document.getElementById("sha1").textContent = sha1;
+          document.getElementById("sha256").textContent = sha256;
+          document.getElementById("sha512").textContent = sha512;
+
+          showStatus(statusEl, "计算完成", "success");
+        } catch (e) {
+          showStatus(statusEl, "计算失败: " + e.message, "error");
+        }
+      }
+
+      async function calculateFileHash(file) {
+        try {
+          showStatus(fileStatusEl, "正在计算...", "");
+          fileResultsEl.style.display = "none";
+
+          const md5 = formatHash(await md5File(file));
+          const sha1 = formatHash(await shaFile("SHA-1", file));
+          const sha256 = formatHash(await shaFile("SHA-256", file));
+          const sha512 = formatHash(await shaFile("SHA-512", file));
+
+          document.getElementById("fileMd5").textContent = md5;
+          document.getElementById("fileSha1").textContent = sha1;
+          document.getElementById("fileSha256").textContent = sha256;
+          document.getElementById("fileSha512").textContent = sha512;
+
+          fileResultsEl.style.display = "block";
+          showStatus(fileStatusEl, "文件哈希计算完成", "success");
+        } catch (e) {
+          showStatus(fileStatusEl, "计算失败: " + e.message, "error");
+        }
+      }
+
+      // ============================================
+      // Event Handlers
+      // ============================================
+      document.getElementById("btnPaste").onclick = async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+          inputEl.value = text;
+          showStatus(statusEl, "已粘贴", "success");
+          calculateHash();
+        } catch (e) {
+          showStatus(statusEl, "无法访问剪贴板", "error");
+        }
       };
-      reader.readAsBinaryString(file);
-    });
-  }
 
-  // ============================================
-  // Utilities
-  // ============================================
-  function formatHash(hash) {
-    return outputCaseEl.value === "upper" ? hash.toUpperCase() : hash.toLowerCase();
-  }
+      document.getElementById("btnHash").onclick = calculateHash;
 
-  function showStatus(el, msg, type) {
-    el.textContent = msg;
-    el.className = "status " + (type || "");
-  }
+      document.getElementById("btnClear").onclick = () => {
+        inputEl.value = "";
+        fileNameEl.textContent = "";
+        fileInput.value = "";
+        document.getElementById("md5").textContent = "-";
+        document.getElementById("sha1").textContent = "-";
+        document.getElementById("sha256").textContent = "-";
+        document.getElementById("sha512").textContent = "-";
+        document.getElementById("fileMd5").textContent = "-";
+        document.getElementById("fileSha1").textContent = "-";
+        document.getElementById("fileSha256").textContent = "-";
+        document.getElementById("fileSha512").textContent = "-";
+        fileResultsEl.style.display = "none";
+        showStatus(statusEl, "已清空", "success");
+      };
 
-  function formatSize(bytes) {
-    if (bytes < 1024) return bytes + " B";
-    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
-    return (bytes / (1024 * 1024)).toFixed(1) + " MB";
-  }
+      // Copy buttons
+      document.querySelectorAll(".hash-copy").forEach((btn) => {
+        btn.onclick = async () => {
+          const targetId = btn.dataset.target;
+          const value = document.getElementById(targetId).textContent;
+          if (value === "-") {
+            showStatus(statusEl, "没有可复制的内容", "error");
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(value);
+            showStatus(statusEl, targetId.toUpperCase() + " 已复制", "success");
+          } catch (e) {
+            showStatus(statusEl, "复制失败", "error");
+          }
+        };
+      });
 
-  // ============================================
-  // Hash Calculation
-  // ============================================
-  async function calculateHash() {
-    const text = inputEl.value;
-    if (!text) {
-      showStatus(statusEl, "请输入内容", "error");
-      return;
-    }
+      fileInput.onchange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+          fileNameEl.textContent = file.name + " (" + formatSize(file.size) + ")";
+          calculateFileHash(file);
+        }
+      };
 
-    try {
-      const md5 = formatHash(MD5(text));
-      const sha1 = formatHash(await sha("SHA-1", text));
-      const sha256 = formatHash(await sha("SHA-256", text));
-      const sha512 = formatHash(await sha("SHA-512", text));
+      // Real-time calculation
+      inputEl.addEventListener("input", () => {
+        if (inputEl.value) {
+          calculateHash();
+        }
+      });
 
-      document.getElementById("md5").textContent = md5;
-      document.getElementById("sha1").textContent = sha1;
-      document.getElementById("sha256").textContent = sha256;
-      document.getElementById("sha512").textContent = sha512;
+      outputCaseEl.addEventListener("change", () => {
+        if (inputEl.value) {
+          calculateHash();
+        }
+      });
 
-      showStatus(statusEl, "计算完成", "success");
-    } catch (e) {
-      showStatus(statusEl, "计算失败: " + e.message, "error");
-    }
-  }
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-  async function calculateFileHash(file) {
-    try {
-      showStatus(fileStatusEl, "正在计算...", "");
-      fileResultsEl.style.display = "none";
-
-      const md5 = formatHash(await md5File(file));
-      const sha1 = formatHash(await shaFile("SHA-1", file));
-      const sha256 = formatHash(await shaFile("SHA-256", file));
-      const sha512 = formatHash(await shaFile("SHA-512", file));
-
-      document.getElementById("fileMd5").textContent = md5;
-      document.getElementById("fileSha1").textContent = sha1;
-      document.getElementById("fileSha256").textContent = sha256;
-      document.getElementById("fileSha512").textContent = sha512;
-
-      fileResultsEl.style.display = "block";
-      showStatus(fileStatusEl, "文件哈希计算完成", "success");
-    } catch (e) {
-      showStatus(fileStatusEl, "计算失败: " + e.message, "error");
-    }
-  }
-
-  // ============================================
-  // Event Handlers
-  // ============================================
-  document.getElementById("btnPaste").onclick = async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      inputEl.value = text;
-      showStatus(statusEl, "已粘贴", "success");
-      calculateHash();
-    } catch (e) {
-      showStatus(statusEl, "无法访问剪贴板", "error");
-    }
-  };
-
-  document.getElementById("btnHash").onclick = calculateHash;
-
-  document.getElementById("btnClear").onclick = () => {
-    inputEl.value = "";
-    fileNameEl.textContent = "";
-    fileInput.value = "";
-    document.getElementById("md5").textContent = "-";
-    document.getElementById("sha1").textContent = "-";
-    document.getElementById("sha256").textContent = "-";
-    document.getElementById("sha512").textContent = "-";
-    document.getElementById("fileMd5").textContent = "-";
-    document.getElementById("fileSha1").textContent = "-";
-    document.getElementById("fileSha256").textContent = "-";
-    document.getElementById("fileSha512").textContent = "-";
-    fileResultsEl.style.display = "none";
-    showStatus(statusEl, "已清空", "success");
-  };
-
-  // Copy buttons
-  document.querySelectorAll(".hash-copy").forEach((btn) => {
-    btn.onclick = async () => {
-      const targetId = btn.dataset.target;
-      const value = document.getElementById(targetId).textContent;
-      if (value === "-") {
-        showStatus(statusEl, "没有可复制的内容", "error");
-        return;
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
       }
-      try {
-        await navigator.clipboard.writeText(value);
-        showStatus(statusEl, targetId.toUpperCase() + " 已复制", "success");
-      } catch (e) {
-        showStatus(statusEl, "复制失败", "error");
+
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
+
+        document.documentElement.setAttribute("data-theme", theme);
       }
-    };
-  });
 
-  fileInput.onchange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      fileNameEl.textContent = file.name + " (" + formatSize(file.size) + ")";
-      calculateFileHash(file);
-    }
-  };
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+    </script>
 
-  // Real-time calculation
-  inputEl.addEventListener("input", () => {
-    if (inputEl.value) {
-      calculateHash();
-    }
-  });
-
-  outputCaseEl.addEventListener("change", () => {
-    if (inputEl.value) {
-      calculateHash();
-    }
-  });
-
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
-
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
-
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/json-formatter.html
+++ b/tools/dev/json-formatter.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="JSON 格式化 - WebUtils" />
     <meta property="og:description" content="JSON 格式化、压缩、校验，支持错误定位和语法高亮" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/dev/json-formatter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "JSON 格式化",
-      "item": "https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JSON 格式化",
+            "item": "https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "JSON 格式化 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "JSON 格式化 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1333 +91,1356 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
-  .nav-back-text {
-    display: inline;
-  }
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
-    padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  .tool-card {
-    width: 100%;
-    max-width: var(--container-max);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    border: 1px solid var(--glass-border);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    box-shadow: var(--shadow-lg);
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    transition: all var(--transition-normal);
-    animation: fade-in-up 0.4s ease-out;
-  }
-  @keyframes fade-in-up {
-    from {
-      opacity: 0;
-      transform: translateY(16px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-  .tool-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    margin-bottom: var(--space-5);
-    padding-bottom: var(--space-5);
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-  .tool-icon {
-    width: 48px;
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-tertiary));
-    border-radius: var(--radius-md);
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-bg-deep);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
-    font-family: var(--font-mono);
-  }
-  .tool-info h1 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text-primary);
-  }
-  .tool-info .desc {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-top: var(--space-1);
-  }
-  .toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-3);
-    margin-bottom: var(--space-5);
-  }
-  .btn-group {
-    display: flex;
-    gap: 2px;
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-sm);
-    padding: 2px;
-  }
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    height: 36px;
-    padding: 0 var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    white-space: nowrap;
-  }
-  .btn:hover {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-  }
-  .btn-primary {
-    background: var(--color-accent-primary);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    background: #00b894;
-    box-shadow: var(--shadow-glow);
-  }
-  .options-bar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-5);
-    align-items: center;
-    margin-bottom: var(--space-5);
-    font-size: 0.875rem;
-  }
-  .option-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    color: var(--color-text-secondary);
-  }
-  .option-item select {
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    padding: var(--space-2) var(--space-3);
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
-  .option-item select:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-  }
-  .option-item input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    accent-color: var(--color-accent-primary);
-    cursor: pointer;
-  }
-  .option-item label {
-    cursor: pointer;
-  }
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-5);
-    flex: 1;
-    min-height: 400px;
-  }
-  .panel {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-  .panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-3);
-  }
-  .panel-label {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-  .panel-textarea {
-    flex: 1;
-    width: 100%;
-    min-height: 350px;
-    padding: var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--color-text-primary);
-    background: var(--color-bg-input);
-    border: 2px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    resize: vertical;
-    tab-size: 2;
-    transition: all var(--transition-fast);
-  }
-  .panel-textarea::placeholder {
-    color: var(--text-muted);
-  }
-  .panel-textarea:hover {
-    border-color: var(--color-border-strong);
-  }
-  .panel-textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
-  }
-  .panel-textarea.error {
-    border-color: var(--color-error);
-    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
-  }
-  .panel-textarea[readonly] {
-    background: var(--color-bg-subtle);
-  }
-  .error-detail {
-    display: none;
-    margin-top: var(--space-4);
-    padding: var(--space-4);
-    background: rgba(239, 68, 68, 0.1);
-    border: 1px solid var(--color-error);
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    color: var(--color-error);
-  }
-  .error-detail.show {
-    display: block;
-  }
-  .error-detail p {
-    margin-bottom: var(--space-2);
-  }
-  .error-detail p:last-child {
-    margin-bottom: 0;
-  }
-  .error-detail code {
-    background: rgba(239, 68, 68, 0.15);
-    padding: 2px var(--space-2);
-    border-radius: var(--radius-sm);
-  }
-  .status-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-    margin-top: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-  }
-  .status {
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-  .status.success {
-    color: var(--color-success);
-  }
-  .status.success::before {
-    content: "✓";
-  }
-  .status.error {
-    color: var(--color-error);
-  }
-  .status.error::before {
-    content: "✗";
-  }
-  .stats {
-    display: none;
-    gap: var(--space-6);
-    flex-wrap: wrap;
-  }
-  .stats.show {
-    display: flex;
-  }
-  .stat-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-accent-primary);
-  }
-  .stat-label {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-  .footer {
-    text-align: center;
-    margin-top: var(--space-5);
-    padding-top: var(--space-4);
-  }
-  .footer p {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    flex-wrap: wrap;
-  }
-  .footer a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
-  .footer a:hover {
-    color: var(--color-text-primary);
-  }
-  @media (max-width: 900px) {
-    .panels {
-      grid-template-columns: 1fr;
-      gap: var(--space-4);
-    }
-    .panel-textarea {
-      min-height: 250px;
-    }
-  }
-  @media (max-width: 640px) {
-    :root {
-      --nav-height: 52px;
-    }
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
-    .nav-back-text {
-      display: none;
-    }
-    .main-content {
-      padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
-        calc(var(--space-5) + var(--safe-area-bottom));
-    }
-    .tool-card {
-      padding: var(--space-4);
-      border-radius: var(--radius-md);
-    }
-    .tool-header {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-      margin-bottom: var(--space-4);
-      padding-bottom: var(--space-4);
-    }
-    .tool-icon {
-      width: 40px;
-      height: 40px;
-      font-size: 1rem;
-    }
-    .tool-info h1 {
-      font-size: 1.125rem;
-    }
-    .toolbar {
-      gap: var(--space-2);
-      margin-bottom: var(--space-4);
-    }
-    .btn-group {
-      flex-wrap: wrap;
-    }
-    .btn {
-      height: 34px;
-      padding: 0 var(--space-3);
-      font-size: 0.75rem;
-    }
-    .options-bar {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-      margin-bottom: var(--space-4);
-    }
-    .panels {
-      min-height: auto;
-    }
-    .panel-textarea {
-      min-height: 180px;
-    }
-    .status-bar {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-    }
-    .stats.show {
-      gap: var(--space-4);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible),
-  select:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible) {
-    outline: none;
-  }
-</style>
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
+      .nav-back-text {
+        display: inline;
+      }
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
+        padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      .tool-card {
+        width: 100%;
+        max-width: var(--container-max);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        box-shadow: var(--shadow-lg);
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        transition: all var(--transition-normal);
+        animation: fade-in-up 0.4s ease-out;
+      }
+      @keyframes fade-in-up {
+        from {
+          opacity: 0;
+          transform: translateY(16px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .tool-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        margin-bottom: var(--space-5);
+        padding-bottom: var(--space-5);
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+      .tool-icon {
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(
+          135deg,
+          var(--color-accent-primary),
+          var(--color-accent-tertiary)
+        );
+        border-radius: var(--radius-md);
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--color-bg-deep);
+        box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
+        font-family: var(--font-mono);
+      }
+      .tool-info h1 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--color-text-primary);
+      }
+      .tool-info .desc {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        margin-top: var(--space-1);
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-bottom: var(--space-5);
+      }
+      .btn-group {
+        display: flex;
+        gap: 2px;
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-sm);
+        padding: 2px;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        height: 36px;
+        padding: 0 var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        white-space: nowrap;
+      }
+      .btn:hover {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+      }
+      .btn-primary {
+        background: var(--color-accent-primary);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        background: #00b894;
+        box-shadow: var(--shadow-glow);
+      }
+      .options-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-5);
+        align-items: center;
+        margin-bottom: var(--space-5);
+        font-size: 0.875rem;
+      }
+      .option-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--color-text-secondary);
+      }
+      .option-item select {
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        padding: var(--space-2) var(--space-3);
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+      .option-item select:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+      }
+      .option-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-accent-primary);
+        cursor: pointer;
+      }
+      .option-item label {
+        cursor: pointer;
+      }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+        flex: 1;
+        min-height: 400px;
+      }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      .panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--space-3);
+      }
+      .panel-label {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .panel-textarea {
+        flex: 1;
+        width: 100%;
+        min-height: 350px;
+        padding: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: var(--color-text-primary);
+        background: var(--color-bg-input);
+        border: 2px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        resize: vertical;
+        tab-size: 2;
+        transition: all var(--transition-fast);
+      }
+      .panel-textarea::placeholder {
+        color: var(--text-muted);
+      }
+      .panel-textarea:hover {
+        border-color: var(--color-border-strong);
+      }
+      .panel-textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
+      }
+      .panel-textarea.error {
+        border-color: var(--color-error);
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+      }
+      .panel-textarea[readonly] {
+        background: var(--color-bg-subtle);
+      }
+      .error-detail {
+        display: none;
+        margin-top: var(--space-4);
+        padding: var(--space-4);
+        background: rgba(239, 68, 68, 0.1);
+        border: 1px solid var(--color-error);
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        color: var(--color-error);
+      }
+      .error-detail.show {
+        display: block;
+      }
+      .error-detail p {
+        margin-bottom: var(--space-2);
+      }
+      .error-detail p:last-child {
+        margin-bottom: 0;
+      }
+      .error-detail code {
+        background: rgba(239, 68, 68, 0.15);
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-sm);
+      }
+      .status-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--space-4);
+        margin-top: var(--space-5);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+      }
+      .status {
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .status.success {
+        color: var(--color-success);
+      }
+      .status.success::before {
+        content: "✓";
+      }
+      .status.error {
+        color: var(--color-error);
+      }
+      .status.error::before {
+        content: "✗";
+      }
+      .stats {
+        display: none;
+        gap: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .stats.show {
+        display: flex;
+      }
+      .stat-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-accent-primary);
+      }
+      .stat-label {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+      .footer {
+        text-align: center;
+        margin-top: var(--space-5);
+        padding-top: var(--space-4);
+      }
+      .footer p {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .footer a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
+      .footer a:hover {
+        color: var(--color-text-primary);
+      }
+      @media (max-width: 900px) {
+        .panels {
+          grid-template-columns: 1fr;
+          gap: var(--space-4);
+        }
+        .panel-textarea {
+          min-height: 250px;
+        }
+      }
+      @media (max-width: 640px) {
+        :root {
+          --nav-height: 52px;
+        }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
+        .nav-back-text {
+          display: none;
+        }
+        .main-content {
+          padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
+            calc(var(--space-5) + var(--safe-area-bottom));
+        }
+        .tool-card {
+          padding: var(--space-4);
+          border-radius: var(--radius-md);
+        }
+        .tool-header {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+          margin-bottom: var(--space-4);
+          padding-bottom: var(--space-4);
+        }
+        .tool-icon {
+          width: 40px;
+          height: 40px;
+          font-size: 1rem;
+        }
+        .tool-info h1 {
+          font-size: 1.125rem;
+        }
+        .toolbar {
+          gap: var(--space-2);
+          margin-bottom: var(--space-4);
+        }
+        .btn-group {
+          flex-wrap: wrap;
+        }
+        .btn {
+          height: 34px;
+          padding: 0 var(--space-3);
+          font-size: 0.75rem;
+        }
+        .options-bar {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+          margin-bottom: var(--space-4);
+        }
+        .panels {
+          min-height: auto;
+        }
+        .panel-textarea {
+          min-height: 180px;
+        }
+        .status-bar {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+        }
+        .stats.show {
+          gap: var(--space-4);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible),
+      select:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible) {
+        outline: none;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="tool-card">
-    <div class="tool-header">
-      <div class="tool-icon">{}</div>
-      <div class="tool-info">
-        <h1>JSON 格式化</h1>
-        <p class="desc">格式化、压缩、校验，支持错误定位，纯本地处理</p>
-      </div>
-    </div>
-    <div class="toolbar">
-      <div class="btn-group">
-        <button id="btnPaste" class="btn">粘贴</button>
-        <button id="btnFormat" class="btn btn-primary">格式化</button>
-        <button id="btnMinify" class="btn btn-primary">压缩</button>
-        <button id="btnValidate" class="btn">校验</button>
-        <button id="btnSortKeys" class="btn">排序</button>
-      </div>
-      <div class="btn-group">
-        <button id="btnCopy" class="btn">复制</button>
-        <button id="btnShare" class="btn">分享</button>
-        <button id="btnClear" class="btn">清空</button>
-      </div>
-    </div>
-    <div class="options-bar">
-      <div class="option-item">
-        <span>缩进:</span>
-        <select id="indent">
-          <option value="2">2 空格</option>
-          <option value="4">4 空格</option>
-          <option value="tab">Tab</option>
-        </select>
-      </div>
-      <div class="option-item">
-        <input type="checkbox" id="removeEmpty">
-        <label for="removeEmpty">移除空值</label>
-      </div>
-    </div>
-    <div class="panels">
-      <div class="panel">
-        <div class="panel-header"><span class="panel-label">输入</span></div>
-        <textarea id="input" class="panel-textarea" placeholder="在此粘贴 JSON 数据..." spellcheck="false"></textarea>
-      </div>
-      <div class="panel">
-        <div class="panel-header"><span class="panel-label">输出</span></div>
-        <textarea id="output" class="panel-textarea" readonly="" placeholder="处理结果..." spellcheck="false"></textarea>
-      </div>
-    </div>
-    <div id="errorDetail" class="error-detail"></div>
-    <div class="status-bar">
-      <div id="status" class="status"></div>
-      <div id="stats" class="stats">
-        <div class="stat-item">
-          <span class="stat-value" id="statKeys">0</span>
-          <span class="stat-label">键</span>
+        <div class="tool-card">
+          <div class="tool-header">
+            <div class="tool-icon">{}</div>
+            <div class="tool-info">
+              <h1>JSON 格式化</h1>
+              <p class="desc">格式化、压缩、校验，支持错误定位，纯本地处理</p>
+            </div>
+          </div>
+          <div class="toolbar">
+            <div class="btn-group">
+              <button id="btnPaste" class="btn">粘贴</button>
+              <button id="btnFormat" class="btn btn-primary">格式化</button>
+              <button id="btnMinify" class="btn btn-primary">压缩</button>
+              <button id="btnValidate" class="btn">校验</button>
+              <button id="btnSortKeys" class="btn">排序</button>
+            </div>
+            <div class="btn-group">
+              <button id="btnCopy" class="btn">复制</button>
+              <button id="btnShare" class="btn">分享</button>
+              <button id="btnClear" class="btn">清空</button>
+            </div>
+          </div>
+          <div class="options-bar">
+            <div class="option-item">
+              <span>缩进:</span>
+              <select id="indent">
+                <option value="2">2 空格</option>
+                <option value="4">4 空格</option>
+                <option value="tab">Tab</option>
+              </select>
+            </div>
+            <div class="option-item">
+              <input type="checkbox" id="removeEmpty" />
+              <label for="removeEmpty">移除空值</label>
+            </div>
+          </div>
+          <div class="panels">
+            <div class="panel">
+              <div class="panel-header"><span class="panel-label">输入</span></div>
+              <textarea
+                id="input"
+                class="panel-textarea"
+                placeholder="在此粘贴 JSON 数据..."
+                spellcheck="false"
+              ></textarea>
+            </div>
+            <div class="panel">
+              <div class="panel-header"><span class="panel-label">输出</span></div>
+              <textarea
+                id="output"
+                class="panel-textarea"
+                readonly=""
+                placeholder="处理结果..."
+                spellcheck="false"
+              ></textarea>
+            </div>
+          </div>
+          <div id="errorDetail" class="error-detail"></div>
+          <div class="status-bar">
+            <div id="status" class="status"></div>
+            <div id="stats" class="stats">
+              <div class="stat-item">
+                <span class="stat-value" id="statKeys">0</span>
+                <span class="stat-label">键</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value" id="statArrays">0</span>
+                <span class="stat-label">数组</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value" id="statDepth">0</span>
+                <span class="stat-label">深度</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value" id="statSize">0</span>
+                <span class="stat-label">大小</span>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="stat-item">
-          <span class="stat-value" id="statArrays">0</span>
-          <span class="stat-label">数组</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value" id="statDepth">0</span>
-          <span class="stat-label">深度</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value" id="statSize">0</span>
-          <span class="stat-label">大小</span>
-        </div>
-      </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>这个 JSON 格式化工具安全吗？数据会上传服务器吗？</summary>
+            <p>
+              完全安全。所有格式化、压缩、校验都在你的浏览器本地完成，JSON
+              数据不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何定位并修复 JSON 格式错误？</summary>
+            <p>
+              点击「校验」或「格式化」后，工具会在错误详情区显示出错的行号、列号和原因（如缺少逗号、引号不匹配、多余的尾逗号），按提示修改对应位置即可。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>JSON 格式化和压缩有什么区别？</summary>
+            <p>
+              格式化（美化）会按缩进展开
+              JSON，便于阅读和调试；压缩（Minify）会去掉所有空格和换行，得到体积最小的单行
+              JSON，适合网络传输和存储。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>JSON 格式化工具可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>支持多大的 JSON 文件？</summary>
+            <p>
+              没有固定上限，受限于浏览器可用内存。常见的几 MB 级 JSON
+              都能流畅处理；超大文件可能因浏览器性能而变慢。
+            </p>
+          </details>
+        </section>
+        <footer class="footer">
+          <p>
+            <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+            <span>·</span>
+            <span>纯前端 · 无服务器</span>
+            <span>·</span>
+            <a href="../../index.html">WebUtils</a>
+          </p>
+        </footer>
+      </main>
     </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>这个 JSON 格式化工具安全吗？数据会上传服务器吗？</summary>
-      <p>
-        完全安全。所有格式化、压缩、校验都在你的浏览器本地完成，JSON
-        数据不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何定位并修复 JSON 格式错误？</summary>
-      <p>
-        点击「校验」或「格式化」后，工具会在错误详情区显示出错的行号、列号和原因（如缺少逗号、引号不匹配、多余的尾逗号），按提示修改对应位置即可。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>JSON 格式化和压缩有什么区别？</summary>
-      <p>
-        格式化（美化）会按缩进展开
-        JSON，便于阅读和调试；压缩（Minify）会去掉所有空格和换行，得到体积最小的单行
-        JSON，适合网络传输和存储。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>JSON 格式化工具可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。</p>
-    </details>
-    <details class="faq-item">
-      <summary>支持多大的 JSON 文件？</summary>
-      <p>
-        没有固定上限，受限于浏览器可用内存。常见的几 MB 级 JSON
-        都能流畅处理；超大文件可能因浏览器性能而变慢。
-      </p>
-    </details>
-  </section>
-  <footer class="footer">
-    <p>
-      <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">GitHub</a>
-      <span>·</span>
-      <span>纯前端 · 无服务器</span>
-      <span>·</span>
-      <a href="../../index.html">WebUtils</a>
-    </p>
-  </footer>
-</main>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "JSON 格式化",
-              "item": "https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
-            }
-          ]
-        }
-    </script>
-    <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "这个 JSON 格式化工具安全吗？数据会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有格式化、压缩、校验都在你的浏览器本地完成，JSON 数据不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何定位并修复 JSON 格式错误？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "点击「校验」或「格式化」后，工具会在错误详情区显示出错的行号、列号和原因（如缺少逗号、引号不匹配、多余的尾逗号），按提示修改对应位置即可。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "JSON 格式化和压缩有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "格式化（美化）会按缩进展开 JSON，便于阅读和调试；压缩（Minify）会去掉所有空格和换行，得到体积最小的单行 JSON，适合网络传输和存储。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "JSON 格式化工具可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "支持多大的 JSON 文件？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "没有固定上限，受限于浏览器可用内存。常见的几 MB 级 JSON 都能流畅处理；超大文件可能因浏览器性能而变慢。"
-              }
-            }
-          ]
-        }
-    </script>
-<script>
-  const inputEl = document.getElementById("input");
-  const outputEl = document.getElementById("output");
-  const statusEl = document.getElementById("status");
-  const errorDetailEl = document.getElementById("errorDetail");
-  const statsEl = document.getElementById("stats");
-  const indentEl = document.getElementById("indent");
-  const removeEmptyEl = document.getElementById("removeEmpty");
-  const LS_KEY = "json_formatter_input_v1";
-
-  window.loadFromUrl = function () {
-    const hash = location.hash.slice(1);
-    if (!hash) return false;
-    try {
-      inputEl.value = decodeURIComponent(atob(hash));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  };
-  function saveToUrl() {
-    try {
-      if (inputEl.value.length > 2000) return;
-      history.replaceState(null, "", "#" + btoa(encodeURIComponent(inputEl.value)));
-    } catch (e) {}
-  }
-  function loadFromStorage() {
-    const saved = localStorage.getItem(LS_KEY);
-    if (saved) inputEl.value = saved;
-  }
-  function saveToStorage() {
-    localStorage.setItem(LS_KEY, inputEl.value);
-  }
-  function getIndent() {
-    const val = indentEl.value;
-    return val === "tab" ? "\t" : parseInt(val, 10);
-  }
-
-  function parseError(e, text) {
-    const msg = e.message;
-    const posMatch = msg.match(/position\s+(\d+)/i);
-    const lineMatch = msg.match(/line\s+(\d+)/i);
-    const colMatch = msg.match(/column\s+(\d+)/i);
-    errorDetailEl.textContent = "";
-    if (posMatch) {
-      const pos = parseInt(posMatch[1], 10);
-      const lines = text.slice(0, pos).split("\n");
-      const line = lines.length;
-      const col = lines[lines.length - 1].length + 1;
-      const context = text.slice(Math.max(0, pos - 20), pos + 20);
-      const p1 = document.createElement("p");
-      p1.textContent = "位置: 第 " + line + " 行, 第 " + col + " 列";
-      const p2 = document.createElement("p");
-      p2.textContent = "上下文: ";
-      const code = document.createElement("code");
-      code.textContent = "..." + context + "...";
-      p2.appendChild(code);
-      const p3 = document.createElement("p");
-      p3.textContent = "原因: " + msg;
-      errorDetailEl.appendChild(p1);
-      errorDetailEl.appendChild(p2);
-      errorDetailEl.appendChild(p3);
-    } else if (lineMatch) {
-      const line = parseInt(lineMatch[1], 10);
-      const col = colMatch ? parseInt(colMatch[1], 10) : 1;
-      const lines = text.split("\n");
-      const context = lines[line - 1] || "";
-      const p1 = document.createElement("p");
-      p1.textContent = "位置: 第 " + line + " 行, 第 " + col + " 列";
-      const p2 = document.createElement("p");
-      p2.textContent = "该行: ";
-      const code = document.createElement("code");
-      code.textContent = context.slice(0, 50) + (context.length > 50 ? "..." : "");
-      p2.appendChild(code);
-      const p3 = document.createElement("p");
-      p3.textContent = "原因: " + msg;
-      errorDetailEl.appendChild(p1);
-      errorDetailEl.appendChild(p2);
-      errorDetailEl.appendChild(p3);
-    } else {
-      errorDetailEl.textContent = msg;
-    }
-  }
-
-  function removeEmptyValues(obj) {
-    if (Array.isArray(obj)) return obj.map(removeEmptyValues).filter((v) => v !== null && v !== "");
-    if (obj && typeof obj === "object") {
-      const result = {};
-      for (const [key, value] of Object.entries(obj)) {
-        if (value !== null && value !== "") result[key] = removeEmptyValues(value);
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JSON 格式化",
+            "item": "https://tools.realtime-ai.chat/tools/dev/json-formatter.html"
+          }
+        ]
       }
-      return result;
-    }
-    return obj;
-  }
-  function sortKeys(obj) {
-    if (Array.isArray(obj)) return obj.map(sortKeys);
-    if (obj && typeof obj === "object") {
-      const sorted = {};
-      Object.keys(obj)
-        .sort()
-        .forEach((key) => {
-          sorted[key] = sortKeys(obj[key]);
-        });
-      return sorted;
-    }
-    return obj;
-  }
-  function analyzeJson(obj, depth) {
-    depth = depth || 0;
-    const stats = { keys: 0, arrays: 0, maxDepth: depth };
-    if (Array.isArray(obj)) {
-      stats.arrays = 1;
-      obj.forEach(function (item) {
-        const sub = analyzeJson(item, depth + 1);
-        stats.keys += sub.keys;
-        stats.arrays += sub.arrays;
-        stats.maxDepth = Math.max(stats.maxDepth, sub.maxDepth);
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "这个 JSON 格式化工具安全吗？数据会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有格式化、压缩、校验都在你的浏览器本地完成，JSON 数据不会上传到任何服务器，也不会被记录。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何定位并修复 JSON 格式错误？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "点击「校验」或「格式化」后，工具会在错误详情区显示出错的行号、列号和原因（如缺少逗号、引号不匹配、多余的尾逗号），按提示修改对应位置即可。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "JSON 格式化和压缩有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "格式化（美化）会按缩进展开 JSON，便于阅读和调试；压缩（Minify）会去掉所有空格和换行，得到体积最小的单行 JSON，适合网络传输和存储。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "JSON 格式化工具可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "支持多大的 JSON 文件？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "没有固定上限，受限于浏览器可用内存。常见的几 MB 级 JSON 都能流畅处理；超大文件可能因浏览器性能而变慢。"
+            }
+          }
+        ]
+      }
+    </script>
+    <script>
+      const inputEl = document.getElementById("input");
+      const outputEl = document.getElementById("output");
+      const statusEl = document.getElementById("status");
+      const errorDetailEl = document.getElementById("errorDetail");
+      const statsEl = document.getElementById("stats");
+      const indentEl = document.getElementById("indent");
+      const removeEmptyEl = document.getElementById("removeEmpty");
+      const LS_KEY = "json_formatter_input_v1";
+
+      window.loadFromUrl = function () {
+        const hash = location.hash.slice(1);
+        if (!hash) return false;
+        try {
+          inputEl.value = decodeURIComponent(atob(hash));
+          return true;
+        } catch (e) {
+          return false;
+        }
+      };
+      function saveToUrl() {
+        try {
+          if (inputEl.value.length > 2000) return;
+          history.replaceState(null, "", "#" + btoa(encodeURIComponent(inputEl.value)));
+        } catch (e) {}
+      }
+      function loadFromStorage() {
+        const saved = localStorage.getItem(LS_KEY);
+        if (saved) inputEl.value = saved;
+      }
+      function saveToStorage() {
+        localStorage.setItem(LS_KEY, inputEl.value);
+      }
+      function getIndent() {
+        const val = indentEl.value;
+        return val === "tab" ? "\t" : parseInt(val, 10);
+      }
+
+      function parseError(e, text) {
+        const msg = e.message;
+        const posMatch = msg.match(/position\s+(\d+)/i);
+        const lineMatch = msg.match(/line\s+(\d+)/i);
+        const colMatch = msg.match(/column\s+(\d+)/i);
+        errorDetailEl.textContent = "";
+        if (posMatch) {
+          const pos = parseInt(posMatch[1], 10);
+          const lines = text.slice(0, pos).split("\n");
+          const line = lines.length;
+          const col = lines[lines.length - 1].length + 1;
+          const context = text.slice(Math.max(0, pos - 20), pos + 20);
+          const p1 = document.createElement("p");
+          p1.textContent = "位置: 第 " + line + " 行, 第 " + col + " 列";
+          const p2 = document.createElement("p");
+          p2.textContent = "上下文: ";
+          const code = document.createElement("code");
+          code.textContent = "..." + context + "...";
+          p2.appendChild(code);
+          const p3 = document.createElement("p");
+          p3.textContent = "原因: " + msg;
+          errorDetailEl.appendChild(p1);
+          errorDetailEl.appendChild(p2);
+          errorDetailEl.appendChild(p3);
+        } else if (lineMatch) {
+          const line = parseInt(lineMatch[1], 10);
+          const col = colMatch ? parseInt(colMatch[1], 10) : 1;
+          const lines = text.split("\n");
+          const context = lines[line - 1] || "";
+          const p1 = document.createElement("p");
+          p1.textContent = "位置: 第 " + line + " 行, 第 " + col + " 列";
+          const p2 = document.createElement("p");
+          p2.textContent = "该行: ";
+          const code = document.createElement("code");
+          code.textContent = context.slice(0, 50) + (context.length > 50 ? "..." : "");
+          p2.appendChild(code);
+          const p3 = document.createElement("p");
+          p3.textContent = "原因: " + msg;
+          errorDetailEl.appendChild(p1);
+          errorDetailEl.appendChild(p2);
+          errorDetailEl.appendChild(p3);
+        } else {
+          errorDetailEl.textContent = msg;
+        }
+      }
+
+      function removeEmptyValues(obj) {
+        if (Array.isArray(obj))
+          return obj.map(removeEmptyValues).filter((v) => v !== null && v !== "");
+        if (obj && typeof obj === "object") {
+          const result = {};
+          for (const [key, value] of Object.entries(obj)) {
+            if (value !== null && value !== "") result[key] = removeEmptyValues(value);
+          }
+          return result;
+        }
+        return obj;
+      }
+      function sortKeys(obj) {
+        if (Array.isArray(obj)) return obj.map(sortKeys);
+        if (obj && typeof obj === "object") {
+          const sorted = {};
+          Object.keys(obj)
+            .sort()
+            .forEach((key) => {
+              sorted[key] = sortKeys(obj[key]);
+            });
+          return sorted;
+        }
+        return obj;
+      }
+      function analyzeJson(obj, depth) {
+        depth = depth || 0;
+        const stats = { keys: 0, arrays: 0, maxDepth: depth };
+        if (Array.isArray(obj)) {
+          stats.arrays = 1;
+          obj.forEach(function (item) {
+            const sub = analyzeJson(item, depth + 1);
+            stats.keys += sub.keys;
+            stats.arrays += sub.arrays;
+            stats.maxDepth = Math.max(stats.maxDepth, sub.maxDepth);
+          });
+        } else if (obj && typeof obj === "object") {
+          stats.keys = Object.keys(obj).length;
+          Object.values(obj).forEach(function (value) {
+            const sub = analyzeJson(value, depth + 1);
+            stats.keys += sub.keys;
+            stats.arrays += sub.arrays;
+            stats.maxDepth = Math.max(stats.maxDepth, sub.maxDepth);
+          });
+        }
+        return stats;
+      }
+      function updateStats(obj, outputText) {
+        const analysis = analyzeJson(obj);
+        document.getElementById("statKeys").textContent = analysis.keys;
+        document.getElementById("statArrays").textContent = analysis.arrays;
+        document.getElementById("statDepth").textContent = analysis.maxDepth;
+        document.getElementById("statSize").textContent = formatSize(new Blob([outputText]).size);
+        statsEl.classList.add("show");
+      }
+      function formatSize(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+      }
+      function showStatus(msg, type) {
+        statusEl.textContent = msg;
+        statusEl.className = "status " + (type || "");
+      }
+
+      function format() {
+        const text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入 JSON", "error");
+          return;
+        }
+        try {
+          var obj = JSON.parse(text);
+          if (removeEmptyEl.checked) obj = removeEmptyValues(obj);
+          const output = JSON.stringify(obj, null, getIndent());
+          outputEl.value = output;
+          inputEl.classList.remove("error");
+          errorDetailEl.classList.remove("show");
+          updateStats(obj, output);
+          showStatus("格式化成功", "success");
+        } catch (e) {
+          inputEl.classList.add("error");
+          parseError(e, text);
+          errorDetailEl.classList.add("show");
+          statsEl.classList.remove("show");
+          showStatus("解析失败", "error");
+        }
+      }
+      function minify() {
+        const text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入 JSON", "error");
+          return;
+        }
+        try {
+          var obj = JSON.parse(text);
+          if (removeEmptyEl.checked) obj = removeEmptyValues(obj);
+          const output = JSON.stringify(obj);
+          outputEl.value = output;
+          inputEl.classList.remove("error");
+          errorDetailEl.classList.remove("show");
+          updateStats(obj, output);
+          showStatus("压缩成功 -" + (text.length - output.length) + " 字符", "success");
+        } catch (e) {
+          inputEl.classList.add("error");
+          parseError(e, text);
+          errorDetailEl.classList.add("show");
+          statsEl.classList.remove("show");
+          showStatus("解析失败", "error");
+        }
+      }
+      window.validate = function () {
+        const text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入 JSON", "error");
+          return;
+        }
+        try {
+          const obj = JSON.parse(text);
+          inputEl.classList.remove("error");
+          errorDetailEl.classList.remove("show");
+          updateStats(obj, text);
+          showStatus("JSON 有效", "success");
+        } catch (e) {
+          inputEl.classList.add("error");
+          parseError(e, text);
+          errorDetailEl.classList.add("show");
+          statsEl.classList.remove("show");
+          showStatus("JSON 无效", "error");
+        }
+      };
+      function sortKeysAction() {
+        const text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入 JSON", "error");
+          return;
+        }
+        try {
+          var obj = JSON.parse(text);
+          obj = sortKeys(obj);
+          const output = JSON.stringify(obj, null, getIndent());
+          outputEl.value = output;
+          inputEl.classList.remove("error");
+          errorDetailEl.classList.remove("show");
+          updateStats(obj, output);
+          showStatus("排序完成", "success");
+        } catch (e) {
+          inputEl.classList.add("error");
+          parseError(e, text);
+          errorDetailEl.classList.add("show");
+          statsEl.classList.remove("show");
+          showStatus("解析失败", "error");
+        }
+      }
+
+      document.getElementById("btnPaste").onclick = async function () {
+        try {
+          const text = await navigator.clipboard.readText();
+          inputEl.value = text;
+          saveToStorage();
+          saveToUrl();
+          showStatus("已粘贴", "success");
+        } catch (e) {
+          showStatus("无法访问剪贴板", "error");
+        }
+      };
+      document.getElementById("btnFormat").onclick = format;
+      document.getElementById("btnMinify").onclick = minify;
+      document.getElementById("btnValidate").onclick = validate;
+      document.getElementById("btnSortKeys").onclick = sortKeysAction;
+      document.getElementById("btnCopy").onclick = async function () {
+        if (!outputEl.value) {
+          showStatus("没有内容", "error");
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(outputEl.value);
+          showStatus("已复制", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
+      document.getElementById("btnShare").onclick = async function () {
+        saveToUrl();
+        try {
+          await navigator.clipboard.writeText(location.href);
+          showStatus("链接已复制", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
+      document.getElementById("btnClear").onclick = function () {
+        inputEl.value = "";
+        outputEl.value = "";
+        inputEl.classList.remove("error");
+        errorDetailEl.classList.remove("show");
+        statsEl.classList.remove("show");
+        statusEl.textContent = "";
+        statusEl.className = "status";
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+      };
+      inputEl.addEventListener("input", function () {
+        saveToStorage();
+        saveToUrl();
+        inputEl.classList.remove("error");
+        errorDetailEl.classList.remove("show");
       });
-    } else if (obj && typeof obj === "object") {
-      stats.keys = Object.keys(obj).length;
-      Object.values(obj).forEach(function (value) {
-        const sub = analyzeJson(value, depth + 1);
-        stats.keys += sub.keys;
-        stats.arrays += sub.arrays;
-        stats.maxDepth = Math.max(stats.maxDepth, sub.maxDepth);
+      document.addEventListener("keydown", function (e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+          e.preventDefault();
+          format();
+        }
       });
-    }
-    return stats;
-  }
-  function updateStats(obj, outputText) {
-    const analysis = analyzeJson(obj);
-    document.getElementById("statKeys").textContent = analysis.keys;
-    document.getElementById("statArrays").textContent = analysis.arrays;
-    document.getElementById("statDepth").textContent = analysis.maxDepth;
-    document.getElementById("statSize").textContent = formatSize(new Blob([outputText]).size);
-    statsEl.classList.add("show");
-  }
-  function formatSize(bytes) {
-    if (bytes < 1024) return bytes + " B";
-    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
-    return (bytes / (1024 * 1024)).toFixed(1) + " MB";
-  }
-  function showStatus(msg, type) {
-    statusEl.textContent = msg;
-    statusEl.className = "status " + (type || "");
-  }
 
-  function format() {
-    const text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入 JSON", "error");
-      return;
-    }
-    try {
-      var obj = JSON.parse(text);
-      if (removeEmptyEl.checked) obj = removeEmptyValues(obj);
-      const output = JSON.stringify(obj, null, getIndent());
-      outputEl.value = output;
-      inputEl.classList.remove("error");
-      errorDetailEl.classList.remove("show");
-      updateStats(obj, output);
-      showStatus("格式化成功", "success");
-    } catch (e) {
-      inputEl.classList.add("error");
-      parseError(e, text);
-      errorDetailEl.classList.add("show");
-      statsEl.classList.remove("show");
-      showStatus("解析失败", "error");
-    }
-  }
-  function minify() {
-    const text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入 JSON", "error");
-      return;
-    }
-    try {
-      var obj = JSON.parse(text);
-      if (removeEmptyEl.checked) obj = removeEmptyValues(obj);
-      const output = JSON.stringify(obj);
-      outputEl.value = output;
-      inputEl.classList.remove("error");
-      errorDetailEl.classList.remove("show");
-      updateStats(obj, output);
-      showStatus("压缩成功 -" + (text.length - output.length) + " 字符", "success");
-    } catch (e) {
-      inputEl.classList.add("error");
-      parseError(e, text);
-      errorDetailEl.classList.add("show");
-      statsEl.classList.remove("show");
-      showStatus("解析失败", "error");
-    }
-  }
-  window.validate = function () {
-    const text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入 JSON", "error");
-      return;
-    }
-    try {
-      const obj = JSON.parse(text);
-      inputEl.classList.remove("error");
-      errorDetailEl.classList.remove("show");
-      updateStats(obj, text);
-      showStatus("JSON 有效", "success");
-    } catch (e) {
-      inputEl.classList.add("error");
-      parseError(e, text);
-      errorDetailEl.classList.add("show");
-      statsEl.classList.remove("show");
-      showStatus("JSON 无效", "error");
-    }
-  };
-  function sortKeysAction() {
-    const text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入 JSON", "error");
-      return;
-    }
-    try {
-      var obj = JSON.parse(text);
-      obj = sortKeys(obj);
-      const output = JSON.stringify(obj, null, getIndent());
-      outputEl.value = output;
-      inputEl.classList.remove("error");
-      errorDetailEl.classList.remove("show");
-      updateStats(obj, output);
-      showStatus("排序完成", "success");
-    } catch (e) {
-      inputEl.classList.add("error");
-      parseError(e, text);
-      errorDetailEl.classList.add("show");
-      statsEl.classList.remove("show");
-      showStatus("解析失败", "error");
-    }
-  }
+      window.toggleTheme = function () {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      };
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+        if (!localStorage.getItem("theme"))
+          document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
+      });
 
-  document.getElementById("btnPaste").onclick = async function () {
-    try {
-      const text = await navigator.clipboard.readText();
-      inputEl.value = text;
-      saveToStorage();
-      saveToUrl();
-      showStatus("已粘贴", "success");
-    } catch (e) {
-      showStatus("无法访问剪贴板", "error");
-    }
-  };
-  document.getElementById("btnFormat").onclick = format;
-  document.getElementById("btnMinify").onclick = minify;
-  document.getElementById("btnValidate").onclick = validate;
-  document.getElementById("btnSortKeys").onclick = sortKeysAction;
-  document.getElementById("btnCopy").onclick = async function () {
-    if (!outputEl.value) {
-      showStatus("没有内容", "error");
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(outputEl.value);
-      showStatus("已复制", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
-  document.getElementById("btnShare").onclick = async function () {
-    saveToUrl();
-    try {
-      await navigator.clipboard.writeText(location.href);
-      showStatus("链接已复制", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
-  document.getElementById("btnClear").onclick = function () {
-    inputEl.value = "";
-    outputEl.value = "";
-    inputEl.classList.remove("error");
-    errorDetailEl.classList.remove("show");
-    statsEl.classList.remove("show");
-    statusEl.textContent = "";
-    statusEl.className = "status";
-    localStorage.removeItem(LS_KEY);
-    history.replaceState(null, "", location.pathname);
-  };
-  inputEl.addEventListener("input", function () {
-    saveToStorage();
-    saveToUrl();
-    inputEl.classList.remove("error");
-    errorDetailEl.classList.remove("show");
-  });
-  document.addEventListener("keydown", function (e) {
-    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-      e.preventDefault();
-      format();
-    }
-  });
+      initTheme();
+      if (!loadFromUrl()) loadFromStorage();
+    </script>
 
-  window.toggleTheme = function () {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
-    if (!localStorage.getItem("theme"))
-      document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
-  });
-
-  initTheme();
-  if (!loadFromUrl()) loadFromStorage();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/json-yaml.html
+++ b/tools/dev/json-yaml.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "JSON-YAML 转换",
-      "item": "https://tools.realtime-ai.chat/tools/dev/json-yaml.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JSON-YAML 转换",
+            "item": "https://tools.realtime-ai.chat/tools/dev/json-yaml.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "JSON-YAML 转换 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "JSON-YAML 转换 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1093 +88,1097 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="datetime-local"],
-  select,
-  textarea {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="datetime-local"],
+      select,
+      textarea {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  textarea {
-    width: 100%;
-    min-height: 300px;
-    font-family: var(--font-mono);
-    resize: vertical;
-    line-height: 1.5;
-  }
+      textarea {
+        width: 100%;
+        min-height: 300px;
+        font-family: var(--font-mono);
+        resize: vertical;
+        line-height: 1.5;
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          Panels (Two-column layout)
          ============================================ */
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-6);
-    margin-top: var(--space-6);
-  }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-6);
+        margin-top: var(--space-6);
+      }
 
-  .panel label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .panel label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  /* ============================================
+      /* ============================================
          Options Section
          ============================================ */
-  .options {
-    display: flex;
-    gap: var(--space-4);
-    flex-wrap: wrap;
-    align-items: center;
-    margin-bottom: var(--space-4);
-    font-size: 0.9375rem;
-  }
+      .options {
+        display: flex;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+        align-items: center;
+        margin-bottom: var(--space-4);
+        font-size: 0.9375rem;
+      }
 
-  .options label {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    cursor: pointer;
-  }
+      .options label {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        cursor: pointer;
+      }
 
-  .options input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
-  }
+      .options input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+      }
 
-  .options select {
-    padding: var(--space-2) var(--space-3);
-    font-size: 0.9375rem;
-  }
+      .options select {
+        padding: var(--space-2) var(--space-3);
+        font-size: 0.9375rem;
+      }
 
-  /* ============================================
+      /* ============================================
          Status Messages
          ============================================ */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .panels {
-      grid-template-columns: 1fr;
-      gap: var(--space-4);
-    }
+        .panels {
+          grid-template-columns: 1fr;
+          gap: var(--space-4);
+        }
 
-    .input-row {
-      flex-direction: column;
-    }
+        .input-row {
+          flex-direction: column;
+        }
 
-    textarea {
-      min-height: 250px;
-    }
+        textarea {
+          min-height: 250px;
+        }
 
-    .options {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-  }
+        .options {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Format Conversion Card -->
-    <div class="card">
-      <h2 class="card-title">格式转换</h2>
+        <div class="container">
+          <!-- Format Conversion Card -->
+          <div class="card">
+            <h2 class="card-title">格式转换</h2>
 
-      <div class="input-group">
-        <label>操作</label>
-        <div class="input-row">
-          <button id="btnPaste">粘贴</button>
-          <button id="btnJsonToYaml" class="primary">JSON → YAML</button>
-          <button id="btnYamlToJson" class="primary">YAML → JSON</button>
-          <button id="btnCopy">复制输出</button>
-          <button id="btnShare">分享链接</button>
-          <button id="btnClear">清空</button>
+            <div class="input-group">
+              <label>操作</label>
+              <div class="input-row">
+                <button id="btnPaste">粘贴</button>
+                <button id="btnJsonToYaml" class="primary">JSON → YAML</button>
+                <button id="btnYamlToJson" class="primary">YAML → JSON</button>
+                <button id="btnCopy">复制输出</button>
+                <button id="btnShare">分享链接</button>
+                <button id="btnClear">清空</button>
+              </div>
+            </div>
+
+            <div class="options">
+              <label>
+                <input type="checkbox" id="prettyPrint" checked="" />
+                格式化输出
+              </label>
+              <label>
+                JSON 缩进:
+                <select id="indent">
+                  <option value="2">2 空格</option>
+                  <option value="4">4 空格</option>
+                  <option value="tab">Tab</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="panels">
+              <div class="panel">
+                <label for="input">输入 (JSON 或 YAML)</label>
+                <textarea id="input" placeholder="在此粘贴 JSON 或 YAML..."></textarea>
+              </div>
+              <div class="panel">
+                <label for="output">输出</label>
+                <textarea id="output" readonly="" placeholder="转换结果将显示在这里..."></textarea>
+              </div>
+            </div>
+
+            <div id="status" class="status"></div>
+          </div>
         </div>
-      </div>
-
-      <div class="options">
-        <label>
-          <input type="checkbox" id="prettyPrint" checked="">
-          格式化输出
-        </label>
-        <label>
-          JSON 缩进:
-          <select id="indent">
-            <option value="2">2 空格</option>
-            <option value="4">4 空格</option>
-            <option value="tab">Tab</option>
-          </select>
-        </label>
-      </div>
-
-      <div class="panels">
-        <div class="panel">
-          <label for="input">输入 (JSON 或 YAML)</label>
-          <textarea id="input" placeholder="在此粘贴 JSON 或 YAML..."></textarea>
-        </div>
-        <div class="panel">
-          <label for="output">输出</label>
-          <textarea id="output" readonly="" placeholder="转换结果将显示在这里..."></textarea>
-        </div>
-      </div>
-
-      <div id="status" class="status"></div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>JSON-YAML 转换工具安全吗？数据会上传服务器吗？</summary>
+            <p>
+              完全安全。JSON 与 YAML
+              的互转完全在浏览器本地运行，你的数据不会上传到任何服务器，也不会被记录或缓存。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>工具如何自动检测输入是 JSON 还是 YAML？</summary>
+            <p>
+              工具会检查输入是否以 { 或 [ 开头并且能被 JSON.parse 解析，符合则判定为 JSON；否则按
+              YAML 处理。如需确保方向正确，可手动点击「JSON → YAML」或「YAML → JSON」按钮。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>YAML 转 JSON 时为什么数字或布尔值的类型发生了变化？</summary>
+            <p>
+              YAML 中 true/false/null/数字会被自动推断类型，转换为 JSON 后会反映其真实类型（如字符串
+              "true" 变为布尔 true）。若要保持原始字符串，需在 YAML 中用引号括起来。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>可以通过链接分享转换内容吗？</summary>
+            <p>
+              可以。点击「分享链接」按钮，工具会将输入内容编码到 URL Hash
+              中，复制链接后发给他人，对方打开即可看到相同的输入内容。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>这个转换工具可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件
+              HTML，将页面保存到本地后即使断网也能正常使用，无需安装或注册。js-yaml 库通过 CDN
+              加载，离线时需提前缓存。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>JSON-YAML 转换工具安全吗？数据会上传服务器吗？</summary>
-      <p>
-        完全安全。JSON 与 YAML
-        的互转完全在浏览器本地运行，你的数据不会上传到任何服务器，也不会被记录或缓存。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>工具如何自动检测输入是 JSON 还是 YAML？</summary>
-      <p>
-        工具会检查输入是否以 { 或 [ 开头并且能被 JSON.parse 解析，符合则判定为 JSON；否则按 YAML
-        处理。如需确保方向正确，可手动点击「JSON → YAML」或「YAML → JSON」按钮。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>YAML 转 JSON 时为什么数字或布尔值的类型发生了变化？</summary>
-      <p>
-        YAML 中 true/false/null/数字会被自动推断类型，转换为 JSON 后会反映其真实类型（如字符串
-        "true" 变为布尔 true）。若要保持原始字符串，需在 YAML 中用引号括起来。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>可以通过链接分享转换内容吗？</summary>
-      <p>
-        可以。点击「分享链接」按钮，工具会将输入内容编码到 URL Hash
-        中，复制链接后发给他人，对方打开即可看到相同的输入内容。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>这个转换工具可以离线使用吗？</summary>
-      <p>
-        可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常使用，无需安装或注册。js-yaml
-        库通过 CDN 加载，离线时需提前缓存。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "JSON-YAML 转换",
-              "item": "https://tools.realtime-ai.chat/tools/dev/json-yaml.html"
-            }
-          ]
-        }
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JSON-YAML 转换",
+            "item": "https://tools.realtime-ai.chat/tools/dev/json-yaml.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "JSON-YAML 转换工具安全吗？数据会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。JSON 与 YAML 的互转完全在浏览器本地运行，你的数据不会上传到任何服务器，也不会被记录或缓存。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "工具如何自动检测输入是 JSON 还是 YAML？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "工具会检查输入是否以 { 或 [ 开头并且能被 JSON.parse 解析，符合则判定为 JSON；否则按 YAML 处理。如需确保方向正确，可手动点击「JSON → YAML」或「YAML → JSON」按钮。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "YAML 转 JSON 时为什么数字或布尔值的类型发生了变化？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "YAML 中 true/false/null/数字会被自动推断类型，转换为 JSON 后会反映其真实类型（如字符串 \"true\" 变为布尔 true）。若要保持原始字符串，需在 YAML 中用引号括起来。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "可以通过链接分享转换内容吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。点击「分享链接」按钮，工具会将输入内容编码到 URL Hash 中，复制链接后发给他人，对方打开即可看到相同的输入内容。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "这个转换工具可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常使用，无需安装或注册。js-yaml 库通过 CDN 加载，离线时需提前缓存。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "JSON-YAML 转换工具安全吗？数据会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。JSON 与 YAML 的互转完全在浏览器本地运行，你的数据不会上传到任何服务器，也不会被记录或缓存。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "工具如何自动检测输入是 JSON 还是 YAML？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "工具会检查输入是否以 { 或 [ 开头并且能被 JSON.parse 解析，符合则判定为 JSON；否则按 YAML 处理。如需确保方向正确，可手动点击「JSON → YAML」或「YAML → JSON」按钮。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "YAML 转 JSON 时为什么数字或布尔值的类型发生了变化？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "YAML 中 true/false/null/数字会被自动推断类型，转换为 JSON 后会反映其真实类型（如字符串 \"true\" 变为布尔 true）。若要保持原始字符串，需在 YAML 中用引号括起来。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "可以通过链接分享转换内容吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。点击「分享链接」按钮，工具会将输入内容编码到 URL Hash 中，复制链接后发给他人，对方打开即可看到相同的输入内容。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "这个转换工具可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常使用，无需安装或注册。js-yaml 库通过 CDN 加载，离线时需提前缓存。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // Elements
-  // ============================================
-  var inputEl = document.getElementById("input");
-  var outputEl = document.getElementById("output");
-  var statusEl = document.getElementById("status");
-  var prettyPrintEl = document.getElementById("prettyPrint");
-  var indentEl = document.getElementById("indent");
+    <script>
+      // ============================================
+      // Elements
+      // ============================================
+      var inputEl = document.getElementById("input");
+      var outputEl = document.getElementById("output");
+      var statusEl = document.getElementById("status");
+      var prettyPrintEl = document.getElementById("prettyPrint");
+      var indentEl = document.getElementById("indent");
 
-  var LS_KEY = "json_yaml_input_v1";
+      var LS_KEY = "json_yaml_input_v1";
 
-  // ============================================
-  // URL State Management
-  // ============================================
-  window.loadFromUrl = function () {
-    var hash = location.hash.slice(1);
-    if (!hash) return false;
-    try {
-      inputEl.value = decodeURIComponent(atob(hash));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  };
+      // ============================================
+      // URL State Management
+      // ============================================
+      window.loadFromUrl = function () {
+        var hash = location.hash.slice(1);
+        if (!hash) return false;
+        try {
+          inputEl.value = decodeURIComponent(atob(hash));
+          return true;
+        } catch (e) {
+          return false;
+        }
+      };
 
-  function saveToUrl() {
-    try {
-      var encoded = btoa(encodeURIComponent(inputEl.value));
-      history.replaceState(null, "", "#" + encoded);
-    } catch (e) {}
-  }
+      function saveToUrl() {
+        try {
+          var encoded = btoa(encodeURIComponent(inputEl.value));
+          history.replaceState(null, "", "#" + encoded);
+        } catch (e) {}
+      }
 
-  // ============================================
-  // Local Storage
-  // ============================================
-  function loadFromStorage() {
-    var saved = localStorage.getItem(LS_KEY);
-    if (saved) {
-      inputEl.value = saved;
-    }
-  }
+      // ============================================
+      // Local Storage
+      // ============================================
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (saved) {
+          inputEl.value = saved;
+        }
+      }
 
-  function saveToStorage() {
-    localStorage.setItem(LS_KEY, inputEl.value);
-  }
+      function saveToStorage() {
+        localStorage.setItem(LS_KEY, inputEl.value);
+      }
 
-  // ============================================
-  // Utility Functions
-  // ============================================
-  function getIndent() {
-    var val = indentEl.value;
-    if (val === "tab") return "\t";
-    return parseInt(val, 10);
-  }
+      // ============================================
+      // Utility Functions
+      // ============================================
+      function getIndent() {
+        var val = indentEl.value;
+        if (val === "tab") return "\t";
+        return parseInt(val, 10);
+      }
 
-  window.detectFormat = function (text) {
-    var trimmed = text.trim();
-    if (!trimmed) return null;
+      window.detectFormat = function (text) {
+        var trimmed = text.trim();
+        if (!trimmed) return null;
 
-    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-      try {
-        JSON.parse(trimmed);
-        return "json";
-      } catch (e) {}
-    }
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+          try {
+            JSON.parse(trimmed);
+            return "json";
+          } catch (e) {}
+        }
 
-    return "yaml";
-  };
+        return "yaml";
+      };
 
-  function showStatus(msg, type) {
-    statusEl.textContent = msg;
-    statusEl.className = "status " + (type || "");
-  }
+      function showStatus(msg, type) {
+        statusEl.textContent = msg;
+        statusEl.className = "status " + (type || "");
+      }
 
-  // ============================================
-  // Conversion Functions
-  // ============================================
-  function jsonToYaml() {
-    var text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      // ============================================
+      // Conversion Functions
+      // ============================================
+      function jsonToYaml() {
+        var text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
 
-    try {
-      var obj = JSON.parse(text);
-      var yamlStr = jsyaml.dump(obj, {
-        indent: 2,
-        lineWidth: -1,
-        noRefs: true
+        try {
+          var obj = JSON.parse(text);
+          var yamlStr = jsyaml.dump(obj, {
+            indent: 2,
+            lineWidth: -1,
+            noRefs: true
+          });
+          outputEl.value = yamlStr;
+          showStatus("JSON → YAML 转换成功", "success");
+        } catch (e) {
+          showStatus("JSON 解析错误: " + e.message, "error");
+        }
+      }
+
+      window.yamlToJson = function () {
+        var text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
+
+        try {
+          var obj = jsyaml.load(text);
+          var indent = prettyPrintEl.checked ? getIndent() : 0;
+          var jsonStr = JSON.stringify(obj, null, indent);
+          outputEl.value = jsonStr;
+          showStatus("YAML → JSON 转换成功", "success");
+        } catch (e) {
+          showStatus("YAML 解析错误: " + e.message, "error");
+        }
+      };
+
+      // ============================================
+      // Event Handlers
+      // ============================================
+      document.getElementById("btnPaste").onclick = async function () {
+        try {
+          var text = await navigator.clipboard.readText();
+          inputEl.value = text;
+          saveToStorage();
+          saveToUrl();
+          showStatus("已粘贴", "success");
+        } catch (e) {
+          showStatus("无法访问剪贴板", "error");
+        }
+      };
+
+      document.getElementById("btnJsonToYaml").onclick = jsonToYaml;
+      document.getElementById("btnYamlToJson").onclick = window.yamlToJson;
+
+      document.getElementById("btnCopy").onclick = async function () {
+        if (!outputEl.value) {
+          showStatus("没有可复制的内容", "error");
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(outputEl.value);
+          showStatus("已复制到剪贴板", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
+
+      document.getElementById("btnShare").onclick = async function () {
+        saveToUrl();
+        try {
+          await navigator.clipboard.writeText(location.href);
+          showStatus("分享链接已复制", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
+
+      document.getElementById("btnClear").onclick = function () {
+        inputEl.value = "";
+        outputEl.value = "";
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+        showStatus("已清空", "success");
+      };
+
+      inputEl.addEventListener("input", function () {
+        saveToStorage();
+        saveToUrl();
       });
-      outputEl.value = yamlStr;
-      showStatus("JSON → YAML 转换成功", "success");
-    } catch (e) {
-      showStatus("JSON 解析错误: " + e.message, "error");
-    }
-  }
 
-  window.yamlToJson = function () {
-    var text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        var html = document.documentElement;
+        var currentTheme = html.getAttribute("data-theme") || "dark";
+        var newTheme = currentTheme === "light" ? "dark" : "light";
 
-    try {
-      var obj = jsyaml.load(text);
-      var indent = prettyPrintEl.checked ? getIndent() : 0;
-      var jsonStr = JSON.stringify(obj, null, indent);
-      outputEl.value = jsonStr;
-      showStatus("YAML → JSON 转换成功", "success");
-    } catch (e) {
-      showStatus("YAML 解析错误: " + e.message, "error");
-    }
-  };
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      }
 
-  // ============================================
-  // Event Handlers
-  // ============================================
-  document.getElementById("btnPaste").onclick = async function () {
-    try {
-      var text = await navigator.clipboard.readText();
-      inputEl.value = text;
-      saveToStorage();
-      saveToUrl();
-      showStatus("已粘贴", "success");
-    } catch (e) {
-      showStatus("无法访问剪贴板", "error");
-    }
-  };
+      window.toggleTheme = toggleTheme;
 
-  document.getElementById("btnJsonToYaml").onclick = jsonToYaml;
-  document.getElementById("btnYamlToJson").onclick = window.yamlToJson;
+      function initTheme() {
+        var savedTheme = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = savedTheme || (prefersDark ? "dark" : "light");
 
-  document.getElementById("btnCopy").onclick = async function () {
-    if (!outputEl.value) {
-      showStatus("没有可复制的内容", "error");
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(outputEl.value);
-      showStatus("已复制到剪贴板", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  document.getElementById("btnShare").onclick = async function () {
-    saveToUrl();
-    try {
-      await navigator.clipboard.writeText(location.href);
-      showStatus("分享链接已复制", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      if (!loadFromUrl()) {
+        loadFromStorage();
+      }
+    </script>
 
-  document.getElementById("btnClear").onclick = function () {
-    inputEl.value = "";
-    outputEl.value = "";
-    localStorage.removeItem(LS_KEY);
-    history.replaceState(null, "", location.pathname);
-    showStatus("已清空", "success");
-  };
-
-  inputEl.addEventListener("input", function () {
-    saveToStorage();
-    saveToUrl();
-  });
-
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    var html = document.documentElement;
-    var currentTheme = html.getAttribute("data-theme") || "dark";
-    var newTheme = currentTheme === "light" ? "dark" : "light";
-
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
-
-  window.toggleTheme = toggleTheme;
-
-  function initTheme() {
-    var savedTheme = localStorage.getItem("theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    var theme = savedTheme || (prefersDark ? "dark" : "light");
-
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  if (!loadFromUrl()) {
-    loadFromStorage();
-  }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/jwt-decoder.html
+++ b/tools/dev/jwt-decoder.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "JWT 解码器",
-      "item": "https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JWT 解码器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "JWT 解码器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "JWT 解码器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,946 +88,955 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  textarea,
-  input[type="text"],
-  input[type="number"],
-  input[type="datetime-local"],
-  select {
-    width: 100%;
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-  }
+      textarea,
+      input[type="text"],
+      input[type="number"],
+      input[type="datetime-local"],
+      select {
+        width: 100%;
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+      }
 
-  textarea {
-    resize: vertical;
-    min-height: 120px;
-    font-size: 0.875rem;
-  }
+      textarea {
+        resize: vertical;
+        min-height: 120px;
+        font-size: 0.875rem;
+      }
 
-  textarea:focus,
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      textarea:focus,
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          JWT Parts Display
          ============================================ */
-  .parts {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-5);
-    margin-top: var(--space-5);
-  }
+      .parts {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-top: var(--space-5);
+      }
 
-  .part {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-4);
-    box-shadow: var(--shadow-md);
-    transition: all var(--transition-normal);
-  }
+      .part {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-4);
+        box-shadow: var(--shadow-md);
+        transition: all var(--transition-normal);
+      }
 
-  .part:hover {
-    border-color: var(--color-accent-primary);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
-  }
+      .part:hover {
+        border-color: var(--color-accent-primary);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-lg);
+      }
 
-  .part-title {
-    font-size: 0.9375rem;
-    font-weight: 600;
-    margin-bottom: var(--space-3);
-    padding-bottom: var(--space-3);
-    border-bottom: 2px solid var(--color-accent-primary);
-    color: var(--color-text-primary);
-  }
+      .part-title {
+        font-size: 0.9375rem;
+        font-weight: 600;
+        margin-bottom: var(--space-3);
+        padding-bottom: var(--space-3);
+        border-bottom: 2px solid var(--color-accent-primary);
+        color: var(--color-text-primary);
+      }
 
-  .part.header .part-title {
-    border-bottom-color: #ef4444;
-    color: #ef4444;
-  }
+      .part.header .part-title {
+        border-bottom-color: #ef4444;
+        color: #ef4444;
+      }
 
-  .part.payload .part-title {
-    border-bottom-color: #8b5cf6;
-    color: #8b5cf6;
-  }
+      .part.payload .part-title {
+        border-bottom-color: #8b5cf6;
+        color: #8b5cf6;
+      }
 
-  .part.signature .part-title {
-    border-bottom-color: #3b82f6;
-    color: #3b82f6;
-  }
+      .part.signature .part-title {
+        border-bottom-color: #3b82f6;
+        color: #3b82f6;
+      }
 
-  pre {
-    font-size: 0.8125rem;
-    overflow-x: auto;
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-    color: var(--color-text-secondary);
-    max-height: 200px;
-    overflow-y: auto;
-    line-height: 1.5;
-  }
+      pre {
+        font-size: 0.8125rem;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
+        color: var(--color-text-secondary);
+        max-height: 200px;
+        overflow-y: auto;
+        line-height: 1.5;
+      }
 
-  /* Status Messages */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      /* Status Messages */
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .parts {
-      grid-template-columns: 1fr;
-      gap: var(--space-4);
-    }
-  }
+        .parts {
+          grid-template-columns: 1fr;
+          gap: var(--space-4);
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- JWT Input Card -->
-    <div class="card">
-      <h2 class="card-title">粘贴 JWT 令牌</h2>
-      <div class="input-group">
-        <label>输入 JWT</label>
-        <textarea id="jwt" placeholder="粘贴你的 JWT 令牌...
-例如: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U" oninput="decode()"></textarea>
-        <div id="status" class="status"></div>
-      </div>
+        <div class="container">
+          <!-- JWT Input Card -->
+          <div class="card">
+            <h2 class="card-title">粘贴 JWT 令牌</h2>
+            <div class="input-group">
+              <label>输入 JWT</label>
+              <textarea
+                id="jwt"
+                placeholder="粘贴你的 JWT 令牌...
+例如: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+                oninput="decode()"
+              ></textarea>
+              <div id="status" class="status"></div>
+            </div>
+          </div>
+
+          <!-- JWT Parts Display -->
+          <div class="parts">
+            <div class="part header">
+              <div class="part-title">Header (头部)</div>
+              <pre id="header">-</pre>
+            </div>
+            <div class="part payload">
+              <div class="part-title">Payload (负载)</div>
+              <pre id="payload">-</pre>
+            </div>
+            <div class="part signature">
+              <div class="part-title">Signature (签名)</div>
+              <pre id="signature">-</pre>
+            </div>
+          </div>
+        </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>JWT 解码器安全吗？令牌内容会上传服务器吗？</summary>
+            <p>
+              完全安全。所有 JWT
+              解码都在你的浏览器本地完成，粘贴的令牌内容不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>JWT 由哪三部分组成？</summary>
+            <p>
+              JWT
+              由三部分组成，用点（.）分隔：Header（头部）包含算法类型和令牌类型；Payload（负载）包含声明数据，如用户
+              ID、权限、过期时间等；Signature（签名）由前两部分和密钥生成，用于验证令牌未被篡改。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>这个工具可以验证 JWT 签名吗？</summary>
+            <p>
+              本工具仅支持解码 JWT 的 Header 和 Payload 部分（Base64URL
+              解码），不验证签名真实性。签名验证需要服务端私钥，建议在服务端进行。工具会显示 Payload
+              中的 exp 字段并提示令牌是否已过期。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何查看 JWT 的过期时间？</summary>
+            <p>
+              粘贴 JWT 后，若 Payload 中包含 exp 字段（Unix
+              时间戳格式），工具会自动将其转换为可读的本地时间，并显示当前令牌是「有效」还是「已过期」。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>JWT 解码器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
 
-    <!-- JWT Parts Display -->
-    <div class="parts">
-      <div class="part header">
-        <div class="part-title">Header (头部)</div>
-        <pre id="header">-</pre>
-      </div>
-      <div class="part payload">
-        <div class="part-title">Payload (负载)</div>
-        <pre id="payload">-</pre>
-      </div>
-      <div class="part signature">
-        <div class="part-title">Signature (签名)</div>
-        <pre id="signature">-</pre>
-      </div>
-    </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>JWT 解码器安全吗？令牌内容会上传服务器吗？</summary>
-      <p>
-        完全安全。所有 JWT
-        解码都在你的浏览器本地完成，粘贴的令牌内容不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>JWT 由哪三部分组成？</summary>
-      <p>
-        JWT
-        由三部分组成，用点（.）分隔：Header（头部）包含算法类型和令牌类型；Payload（负载）包含声明数据，如用户
-        ID、权限、过期时间等；Signature（签名）由前两部分和密钥生成，用于验证令牌未被篡改。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>这个工具可以验证 JWT 签名吗？</summary>
-      <p>
-        本工具仅支持解码 JWT 的 Header 和 Payload 部分（Base64URL
-        解码），不验证签名真实性。签名验证需要服务端私钥，建议在服务端进行。工具会显示 Payload 中的
-        exp 字段并提示令牌是否已过期。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何查看 JWT 的过期时间？</summary>
-      <p>
-        粘贴 JWT 后，若 Payload 中包含 exp 字段（Unix
-        时间戳格式），工具会自动将其转换为可读的本地时间，并显示当前令牌是「有效」还是「已过期」。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>JWT 解码器可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。</p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "JWT 解码器",
-              "item": "https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "JWT 解码器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/jwt-decoder.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "JWT 解码器安全吗？令牌内容会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 JWT 解码都在你的浏览器本地完成，粘贴的令牌内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "JWT 由哪三部分组成？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "JWT 由三部分组成，用点（.）分隔：Header（头部）包含算法类型和令牌类型；Payload（负载）包含声明数据，如用户 ID、权限、过期时间等；Signature（签名）由前两部分和密钥生成，用于验证令牌未被篡改。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "这个工具可以验证 JWT 签名吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "本工具仅支持解码 JWT 的 Header 和 Payload 部分（Base64URL 解码），不验证签名真实性。签名验证需要服务端私钥，建议在服务端进行。工具会显示 Payload 中的 exp 字段并提示令牌是否已过期。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何查看 JWT 的过期时间？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "粘贴 JWT 后，若 Payload 中包含 exp 字段（Unix 时间戳格式），工具会自动将其转换为可读的本地时间，并显示当前令牌是「有效」还是「已过期」。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "JWT 解码器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "JWT 解码器安全吗？令牌内容会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 JWT 解码都在你的浏览器本地完成，粘贴的令牌内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "JWT 由哪三部分组成？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "JWT 由三部分组成，用点（.）分隔：Header（头部）包含算法类型和令牌类型；Payload（负载）包含声明数据，如用户 ID、权限、过期时间等；Signature（签名）由前两部分和密钥生成，用于验证令牌未被篡改。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "这个工具可以验证 JWT 签名吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "本工具仅支持解码 JWT 的 Header 和 Payload 部分（Base64URL 解码），不验证签名真实性。签名验证需要服务端私钥，建议在服务端进行。工具会显示 Payload 中的 exp 字段并提示令牌是否已过期。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何查看 JWT 的过期时间？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "粘贴 JWT 后，若 Payload 中包含 exp 字段（Unix 时间戳格式），工具会自动将其转换为可读的本地时间，并显示当前令牌是「有效」还是「已过期」。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "JWT 解码器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // JWT Decoding
-  // ============================================
-  function decode() {
-    const jwt = document.getElementById("jwt").value.trim();
-    const statusEl = document.getElementById("status");
+    <script>
+      // ============================================
+      // JWT Decoding
+      // ============================================
+      function decode() {
+        const jwt = document.getElementById("jwt").value.trim();
+        const statusEl = document.getElementById("status");
 
-    if (!jwt) {
-      ["header", "payload", "signature"].forEach(
-        (id) => (document.getElementById(id).textContent = "-")
-      );
-      statusEl.textContent = "";
-      statusEl.className = "status";
-      return;
-    }
+        if (!jwt) {
+          ["header", "payload", "signature"].forEach(
+            (id) => (document.getElementById(id).textContent = "-")
+          );
+          statusEl.textContent = "";
+          statusEl.className = "status";
+          return;
+        }
 
-    try {
-      const parts = jwt.split(".");
-      if (parts.length !== 3) {
-        throw new Error("无效的 JWT: 必须包含 3 部分 (header.payload.signature)");
+        try {
+          const parts = jwt.split(".");
+          if (parts.length !== 3) {
+            throw new Error("无效的 JWT: 必须包含 3 部分 (header.payload.signature)");
+          }
+
+          // Decode header
+          const header = JSON.parse(atob(parts[0].replace(/-/g, "+").replace(/_/g, "/")));
+
+          // Decode payload
+          const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+
+          // Display parts
+          document.getElementById("header").textContent = JSON.stringify(header, null, 2);
+
+          let payloadText = JSON.stringify(payload, null, 2);
+          if (payload.exp) {
+            const expDate = new Date(payload.exp * 1000);
+            const now = new Date();
+            const isExpired = expDate < now;
+            payloadText += "\n\n过期时间: " + expDate.toLocaleString();
+            payloadText += "\n状态: " + (isExpired ? "已过期" : "有效");
+          }
+
+          document.getElementById("payload").textContent = payloadText;
+          document.getElementById("signature").textContent = parts[2].substring(0, 50) + "...";
+
+          statusEl.textContent = "解析成功";
+          statusEl.className = "status success";
+        } catch (e) {
+          document.getElementById("header").textContent = "解析错误";
+          document.getElementById("payload").textContent = e.message;
+          document.getElementById("signature").textContent = "-";
+
+          statusEl.textContent = "错误: " + e.message;
+          statusEl.className = "status error";
+        }
       }
 
-      // Decode header
-      const header = JSON.parse(atob(parts[0].replace(/-/g, "+").replace(/_/g, "/")));
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-      // Decode payload
-      const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-
-      // Display parts
-      document.getElementById("header").textContent = JSON.stringify(header, null, 2);
-
-      let payloadText = JSON.stringify(payload, null, 2);
-      if (payload.exp) {
-        const expDate = new Date(payload.exp * 1000);
-        const now = new Date();
-        const isExpired = expDate < now;
-        payloadText += "\n\n过期时间: " + expDate.toLocaleString();
-        payloadText += "\n状态: " + (isExpired ? "已过期" : "有效");
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
       }
 
-      document.getElementById("payload").textContent = payloadText;
-      document.getElementById("signature").textContent = parts[2].substring(0, 50) + "...";
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
 
-      statusEl.textContent = "解析成功";
-      statusEl.className = "status success";
-    } catch (e) {
-      document.getElementById("header").textContent = "解析错误";
-      document.getElementById("payload").textContent = e.message;
-      document.getElementById("signature").textContent = "-";
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-      statusEl.textContent = "错误: " + e.message;
-      statusEl.className = "status error";
-    }
-  }
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+    </script>
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
-
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
-
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/regex-tester.html
+++ b/tools/dev/regex-tester.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "正则测试器",
-      "item": "https://tools.realtime-ai.chat/tools/dev/regex-tester.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "正则测试器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/regex-tester.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "正则测试器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "正则测试器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,911 +88,933 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
-  .nav-back-text {
-    display: inline;
-  }
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
-    padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  .tool-card {
-    width: 100%;
-    max-width: var(--container-max);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    border: 1px solid var(--glass-border);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    box-shadow: var(--shadow-lg);
-    display: flex;
-    flex-direction: column;
-    transition: all var(--transition-normal);
-    animation: fade-in-up 0.4s ease-out;
-  }
-  @keyframes fade-in-up {
-    from {
-      opacity: 0;
-      transform: translateY(16px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-  .tool-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    margin-bottom: var(--space-5);
-    padding-bottom: var(--space-5);
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-  .tool-icon {
-    width: 48px;
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-tertiary));
-    border-radius: var(--radius-md);
-    font-size: 1.5rem;
-    color: var(--color-bg-deep);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
-  }
-  .tool-info h1 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text-primary);
-  }
-  .tool-info .desc {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-top: var(--space-1);
-  }
-  .form-group {
-    margin-bottom: var(--space-5);
-  }
-  .form-label {
-    display: block;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    margin-bottom: var(--space-2);
-  }
-  .form-input {
-    width: 100%;
-    height: 48px;
-    padding: 0 var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.9375rem;
-    color: var(--color-text-primary);
-    background: var(--color-bg-input);
-    border: 2px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    outline: none;
-    transition: all var(--transition-fast);
-  }
-  .form-input::placeholder {
-    color: var(--text-muted);
-  }
-  .form-input:hover {
-    border-color: var(--color-border-strong);
-  }
-  .form-input:focus {
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
-  }
-  .form-textarea {
-    width: 100%;
-    min-height: 150px;
-    padding: var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--color-text-primary);
-    background: var(--color-bg-input);
-    border: 2px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    resize: vertical;
-    outline: none;
-    transition: all var(--transition-fast);
-  }
-  .form-textarea::placeholder {
-    color: var(--text-muted);
-  }
-  .form-textarea:hover {
-    border-color: var(--color-border-strong);
-  }
-  .form-textarea:focus {
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
-  }
-  .flags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-    margin-bottom: var(--space-5);
-    font-size: 0.875rem;
-  }
-  .flag-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    color: var(--color-text-secondary);
-  }
-  .flag-item input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--color-accent-primary);
-    cursor: pointer;
-  }
-  .flag-item label {
-    cursor: pointer;
-  }
-  .result-section {
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-5);
-    margin-top: var(--space-2);
-  }
-  .result-title {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .result-content {
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.8;
-    color: var(--color-text-primary);
-    word-break: break-all;
-  }
-  .match {
-    background: rgba(0, 212, 170, 0.25);
-    padding: 2px 4px;
-    border-radius: var(--radius-sm);
-    color: var(--color-accent-primary);
-  }
-  .result-info {
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-    margin-top: var(--space-3);
-  }
-  .error-msg {
-    color: var(--color-error);
-  }
-  .footer {
-    text-align: center;
-    margin-top: var(--space-5);
-    padding-top: var(--space-4);
-  }
-  .footer p {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    flex-wrap: wrap;
-  }
-  .footer a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
-  .footer a:hover {
-    color: var(--color-text-primary);
-  }
-  @media (max-width: 640px) {
-    :root {
-      --nav-height: 52px;
-    }
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
-    .nav-back-text {
-      display: none;
-    }
-    .main-content {
-      padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
-        calc(var(--space-5) + var(--safe-area-bottom));
-    }
-    .tool-card {
-      padding: var(--space-4);
-      border-radius: var(--radius-md);
-    }
-    .tool-header {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-      margin-bottom: var(--space-4);
-      padding-bottom: var(--space-4);
-    }
-    .tool-icon {
-      width: 40px;
-      height: 40px;
-      font-size: 1.25rem;
-    }
-    .tool-info h1 {
-      font-size: 1.125rem;
-    }
-    .form-input {
-      height: 44px;
-    }
-    .flags {
-      gap: var(--space-3);
-    }
-    .result-section {
-      padding: var(--space-4);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
+      .nav-back-text {
+        display: inline;
+      }
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
+        padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      .tool-card {
+        width: 100%;
+        max-width: var(--container-max);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        box-shadow: var(--shadow-lg);
+        display: flex;
+        flex-direction: column;
+        transition: all var(--transition-normal);
+        animation: fade-in-up 0.4s ease-out;
+      }
+      @keyframes fade-in-up {
+        from {
+          opacity: 0;
+          transform: translateY(16px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .tool-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        margin-bottom: var(--space-5);
+        padding-bottom: var(--space-5);
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+      .tool-icon {
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(
+          135deg,
+          var(--color-accent-primary),
+          var(--color-accent-tertiary)
+        );
+        border-radius: var(--radius-md);
+        font-size: 1.5rem;
+        color: var(--color-bg-deep);
+        box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
+      }
+      .tool-info h1 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--color-text-primary);
+      }
+      .tool-info .desc {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        margin-top: var(--space-1);
+      }
+      .form-group {
+        margin-bottom: var(--space-5);
+      }
+      .form-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        margin-bottom: var(--space-2);
+      }
+      .form-input {
+        width: 100%;
+        height: 48px;
+        padding: 0 var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.9375rem;
+        color: var(--color-text-primary);
+        background: var(--color-bg-input);
+        border: 2px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        outline: none;
+        transition: all var(--transition-fast);
+      }
+      .form-input::placeholder {
+        color: var(--text-muted);
+      }
+      .form-input:hover {
+        border-color: var(--color-border-strong);
+      }
+      .form-input:focus {
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
+      }
+      .form-textarea {
+        width: 100%;
+        min-height: 150px;
+        padding: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: var(--color-text-primary);
+        background: var(--color-bg-input);
+        border: 2px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        resize: vertical;
+        outline: none;
+        transition: all var(--transition-fast);
+      }
+      .form-textarea::placeholder {
+        color: var(--text-muted);
+      }
+      .form-textarea:hover {
+        border-color: var(--color-border-strong);
+      }
+      .form-textarea:focus {
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
+      }
+      .flags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-4);
+        margin-bottom: var(--space-5);
+        font-size: 0.875rem;
+      }
+      .flag-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--color-text-secondary);
+      }
+      .flag-item input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--color-accent-primary);
+        cursor: pointer;
+      }
+      .flag-item label {
+        cursor: pointer;
+      }
+      .result-section {
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-5);
+        margin-top: var(--space-2);
+      }
+      .result-title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .result-content {
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        line-height: 1.8;
+        color: var(--color-text-primary);
+        word-break: break-all;
+      }
+      .match {
+        background: rgba(0, 212, 170, 0.25);
+        padding: 2px 4px;
+        border-radius: var(--radius-sm);
+        color: var(--color-accent-primary);
+      }
+      .result-info {
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+        margin-top: var(--space-3);
+      }
+      .error-msg {
+        color: var(--color-error);
+      }
+      .footer {
+        text-align: center;
+        margin-top: var(--space-5);
+        padding-top: var(--space-4);
+      }
+      .footer p {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .footer a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
+      .footer a:hover {
+        color: var(--color-text-primary);
+      }
+      @media (max-width: 640px) {
+        :root {
+          --nav-height: 52px;
+        }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
+        .nav-back-text {
+          display: none;
+        }
+        .main-content {
+          padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
+            calc(var(--space-5) + var(--safe-area-bottom));
+        }
+        .tool-card {
+          padding: var(--space-4);
+          border-radius: var(--radius-md);
+        }
+        .tool-header {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+          margin-bottom: var(--space-4);
+          padding-bottom: var(--space-4);
+        }
+        .tool-icon {
+          width: 40px;
+          height: 40px;
+          font-size: 1.25rem;
+        }
+        .tool-info h1 {
+          font-size: 1.125rem;
+        }
+        .form-input {
+          height: 44px;
+        }
+        .flags {
+          gap: var(--space-3);
+        }
+        .result-section {
+          padding: var(--space-4);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="tool-card">
-    <div class="tool-header">
-      <div class="tool-icon">🔍</div>
-      <div class="tool-info">
-        <h1>正则测试器</h1>
-        <p class="desc">实时测试正则表达式，高亮显示匹配结果</p>
-      </div>
+        <div class="tool-card">
+          <div class="tool-header">
+            <div class="tool-icon">🔍</div>
+            <div class="tool-info">
+              <h1>正则测试器</h1>
+              <p class="desc">实时测试正则表达式，高亮显示匹配结果</p>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="regex">正则表达式</label>
+            <input
+              type="text"
+              id="regex"
+              class="form-input"
+              placeholder="/pattern/"
+              oninput="testRegex()"
+            />
+          </div>
+          <div class="flags">
+            <div class="flag-item">
+              <input type="checkbox" id="flagG" checked="" onchange="testRegex()" />
+              <label for="flagG">g (全局)</label>
+            </div>
+            <div class="flag-item">
+              <input type="checkbox" id="flagI" onchange="testRegex()" />
+              <label for="flagI">i (忽略大小写)</label>
+            </div>
+            <div class="flag-item">
+              <input type="checkbox" id="flagM" onchange="testRegex()" />
+              <label for="flagM">m (多行)</label>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="text">测试文本</label>
+            <textarea
+              id="text"
+              class="form-textarea"
+              placeholder="输入要测试的文本..."
+              oninput="testRegex()"
+            ></textarea>
+          </div>
+          <div class="result-section">
+            <div class="result-title">结果</div>
+            <div class="result-content" id="result">-</div>
+            <div class="result-info" id="info"></div>
+          </div>
+        </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>正则测试器安全吗？输入的文本会上传服务器吗？</summary>
+            <p>
+              完全安全。正则表达式和测试文本的所有匹配运算都在浏览器本地完成，数据不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>g、i、m 三个标志分别是什么意思？</summary>
+            <p>
+              g（global）表示全局匹配，会找出所有匹配项而非仅第一个；i（ignoreCase）表示忽略大小写；m（multiline）表示多行模式，让
+              ^ 和 $ 匹配每行的开头和结尾，而不是整个字符串的首尾。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何匹配中文字符？</summary>
+            <p>
+              使用 Unicode 范围 [一-龥] 可以匹配常用汉字。如果需要匹配更广泛的 Unicode
+              字母，可以结合 \p{L} 并开启 u 标志（浏览器原生正则支持）。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>正则测试器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，将页面保存到本地后，即使断网也能正常运行，无需安装或注册。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>为什么我的正则表达式在这里能匹配，但在代码里不行？</summary>
+            <p>
+              常见原因是字符串转义问题：在 JavaScript 字符串里写正则时，反斜杠需要双重转义（如 \\d
+              表示 \d），而在正则字面量 /\d/ 中则无需额外转义。检查所用语言的转义规则即可。
+            </p>
+          </details>
+        </section>
+        <footer class="footer">
+          <p>
+            <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+            <span>·</span>
+            <span>纯前端 · 无服务器</span>
+            <span>·</span>
+            <a href="../../index.html">WebUtils</a>
+          </p>
+        </footer>
+      </main>
     </div>
-    <div class="form-group">
-      <label class="form-label" for="regex">正则表达式</label>
-      <input type="text" id="regex" class="form-input" placeholder="/pattern/" oninput="testRegex()">
-    </div>
-    <div class="flags">
-      <div class="flag-item">
-        <input type="checkbox" id="flagG" checked="" onchange="testRegex()">
-        <label for="flagG">g (全局)</label>
-      </div>
-      <div class="flag-item">
-        <input type="checkbox" id="flagI" onchange="testRegex()">
-        <label for="flagI">i (忽略大小写)</label>
-      </div>
-      <div class="flag-item">
-        <input type="checkbox" id="flagM" onchange="testRegex()">
-        <label for="flagM">m (多行)</label>
-      </div>
-    </div>
-    <div class="form-group">
-      <label class="form-label" for="text">测试文本</label>
-      <textarea id="text" class="form-textarea" placeholder="输入要测试的文本..." oninput="testRegex()"></textarea>
-    </div>
-    <div class="result-section">
-      <div class="result-title">结果</div>
-      <div class="result-content" id="result">-</div>
-      <div class="result-info" id="info"></div>
-    </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>正则测试器安全吗？输入的文本会上传服务器吗？</summary>
-      <p>
-        完全安全。正则表达式和测试文本的所有匹配运算都在浏览器本地完成，数据不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>g、i、m 三个标志分别是什么意思？</summary>
-      <p>
-        g（global）表示全局匹配，会找出所有匹配项而非仅第一个；i（ignoreCase）表示忽略大小写；m（multiline）表示多行模式，让
-        ^ 和 $ 匹配每行的开头和结尾，而不是整个字符串的首尾。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何匹配中文字符？</summary>
-      <p>
-        使用 Unicode 范围 [一-龥] 可以匹配常用汉字。如果需要匹配更广泛的 Unicode 字母，可以结合
-        \p{L} 并开启 u 标志（浏览器原生正则支持）。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>正则测试器可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，将页面保存到本地后，即使断网也能正常运行，无需安装或注册。</p>
-    </details>
-    <details class="faq-item">
-      <summary>为什么我的正则表达式在这里能匹配，但在代码里不行？</summary>
-      <p>
-        常见原因是字符串转义问题：在 JavaScript 字符串里写正则时，反斜杠需要双重转义（如 \\d 表示
-        \d），而在正则字面量 /\d/ 中则无需额外转义。检查所用语言的转义规则即可。
-      </p>
-    </details>
-  </section>
-  <footer class="footer">
-    <p>
-      <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">GitHub</a>
-      <span>·</span>
-      <span>纯前端 · 无服务器</span>
-      <span>·</span>
-      <a href="../../index.html">WebUtils</a>
-    </p>
-  </footer>
-</main>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "正则测试器",
-              "item": "https://tools.realtime-ai.chat/tools/dev/regex-tester.html"
-            }
-          ]
-        }
-    </script>
-    <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "正则测试器安全吗？输入的文本会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。正则表达式和测试文本的所有匹配运算都在浏览器本地完成，数据不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "g、i、m 三个标志分别是什么意思？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "g（global）表示全局匹配，会找出所有匹配项而非仅第一个；i（ignoreCase）表示忽略大小写；m（multiline）表示多行模式，让 ^ 和 $ 匹配每行的开头和结尾，而不是整个字符串的首尾。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何匹配中文字符？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "使用 Unicode 范围 [一-龥] 可以匹配常用汉字。如果需要匹配更广泛的 Unicode 字母，可以结合 \\p{L} 并开启 u 标志（浏览器原生正则支持）。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "正则测试器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断网也能正常运行，无需安装或注册。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "为什么我的正则表达式在这里能匹配，但在代码里不行？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "常见原因是字符串转义问题：在 JavaScript 字符串里写正则时，反斜杠需要双重转义（如 \\\\d 表示 \\d），而在正则字面量 /\\d/ 中则无需额外转义。检查所用语言的转义规则即可。"
-              }
-            }
-          ]
-        }
-    </script>
-<script>
-  function testRegex() {
-    var pattern = document.getElementById("regex").value;
-    var text = document.getElementById("text").value;
-    var flags =
-      (document.getElementById("flagG").checked ? "g" : "") +
-      (document.getElementById("flagI").checked ? "i" : "") +
-      (document.getElementById("flagM").checked ? "m" : "");
-
-    if (!pattern || !text) {
-      document.getElementById("result").textContent = "-";
-      document.getElementById("info").textContent = "";
-      return;
-    }
-
-    try {
-      var regex = new RegExp(pattern, flags);
-      var matches = text.match(regex);
-
-      if (matches) {
-        var highlighted = escapeHtml(text);
-        // Create regex for replacement with escaped pattern
-        var replaceRegex = new RegExp(escapeRegex(pattern), flags);
-        highlighted = text.replace(regex, function (m) {
-          return '<span class="match">' + escapeHtml(m) + "</span>";
-        });
-        document.getElementById("result").innerHTML = highlighted;
-        document.getElementById("info").textContent =
-          "找到 " + matches.length + " 个匹配: " + matches.join(", ");
-        document.getElementById("info").className = "result-info";
-      } else {
-        document.getElementById("result").textContent = text;
-        document.getElementById("info").textContent = "没有匹配";
-        document.getElementById("info").className = "result-info";
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "正则测试器",
+            "item": "https://tools.realtime-ai.chat/tools/dev/regex-tester.html"
+          }
+        ]
       }
-    } catch (e) {
-      document.getElementById("result").innerHTML =
-        '<span class="error-msg">无效的正则表达式: ' + escapeHtml(e.message) + "</span>";
-      document.getElementById("info").textContent = "";
-    }
-  }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "正则测试器安全吗？输入的文本会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。正则表达式和测试文本的所有匹配运算都在浏览器本地完成，数据不会上传到任何服务器，也不会被记录。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "g、i、m 三个标志分别是什么意思？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "g（global）表示全局匹配，会找出所有匹配项而非仅第一个；i（ignoreCase）表示忽略大小写；m（multiline）表示多行模式，让 ^ 和 $ 匹配每行的开头和结尾，而不是整个字符串的首尾。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何匹配中文字符？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "使用 Unicode 范围 [一-龥] 可以匹配常用汉字。如果需要匹配更广泛的 Unicode 字母，可以结合 \\p{L} 并开启 u 标志（浏览器原生正则支持）。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "正则测试器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断网也能正常运行，无需安装或注册。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "为什么我的正则表达式在这里能匹配，但在代码里不行？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "常见原因是字符串转义问题：在 JavaScript 字符串里写正则时，反斜杠需要双重转义（如 \\\\d 表示 \\d），而在正则字面量 /\\d/ 中则无需额外转义。检查所用语言的转义规则即可。"
+            }
+          }
+        ]
+      }
+    </script>
+    <script>
+      function testRegex() {
+        var pattern = document.getElementById("regex").value;
+        var text = document.getElementById("text").value;
+        var flags =
+          (document.getElementById("flagG").checked ? "g" : "") +
+          (document.getElementById("flagI").checked ? "i" : "") +
+          (document.getElementById("flagM").checked ? "m" : "");
 
-  function escapeHtml(text) {
-    var div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
-  }
+        if (!pattern || !text) {
+          document.getElementById("result").textContent = "-";
+          document.getElementById("info").textContent = "";
+          return;
+        }
 
-  function escapeRegex(string) {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  }
+        try {
+          var regex = new RegExp(pattern, flags);
+          var matches = text.match(regex);
 
-  // Theme
-  window.toggleTheme = function () {
-    var html = document.documentElement;
-    var currentTheme = html.getAttribute("data-theme") || "dark";
-    var newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
+          if (matches) {
+            var highlighted = escapeHtml(text);
+            // Create regex for replacement with escaped pattern
+            var replaceRegex = new RegExp(escapeRegex(pattern), flags);
+            highlighted = text.replace(regex, function (m) {
+              return '<span class="match">' + escapeHtml(m) + "</span>";
+            });
+            document.getElementById("result").innerHTML = highlighted;
+            document.getElementById("info").textContent =
+              "找到 " + matches.length + " 个匹配: " + matches.join(", ");
+            document.getElementById("info").className = "result-info";
+          } else {
+            document.getElementById("result").textContent = text;
+            document.getElementById("info").textContent = "没有匹配";
+            document.getElementById("info").className = "result-info";
+          }
+        } catch (e) {
+          document.getElementById("result").innerHTML =
+            '<span class="error-msg">无效的正则表达式: ' + escapeHtml(e.message) + "</span>";
+          document.getElementById("info").textContent = "";
+        }
+      }
 
-  function initTheme() {
-    var savedTheme = localStorage.getItem("theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    var theme = savedTheme || (prefersDark ? "dark" : "light");
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+      function escapeHtml(text) {
+        var div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
 
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
-    if (!localStorage.getItem("theme"))
-      document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
-  });
+      function escapeRegex(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      }
 
-  initTheme();
-</script>
-    
+      // Theme
+      window.toggleTheme = function () {
+        var html = document.documentElement;
+        var currentTheme = html.getAttribute("data-theme") || "dark";
+        var newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      };
+
+      function initTheme() {
+        var savedTheme = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = savedTheme || (prefersDark ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+        if (!localStorage.getItem("theme"))
+          document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
+      });
+
+      initTheme();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/dev/url-codec.html
+++ b/tools/dev/url-codec.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "开发工具",
-      "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "URL 编解码",
-      "item": "https://tools.realtime-ai.chat/tools/dev/url-codec.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/tools/dev/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "URL 编解码",
+            "item": "https://tools.realtime-ai.chat/tools/dev/url-codec.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "URL 编解码 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "URL 编解码 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1252 +88,1265 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-  }
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  textarea {
-    width: 100%;
-    min-height: 250px;
-    resize: vertical;
-    line-height: 1.5;
-    font-family: var(--font-mono);
-  }
+      textarea {
+        width: 100%;
+        min-height: 250px;
+        resize: vertical;
+        line-height: 1.5;
+        font-family: var(--font-mono);
+      }
 
-  .text-input {
-    flex: 1;
-    min-width: 200px;
-  }
+      .text-input {
+        flex: 1;
+        min-width: 200px;
+      }
 
-  .unit-select {
-    width: 120px;
-  }
+      .unit-select {
+        width: 120px;
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          Options
          ============================================ */
-  .options {
-    display: flex;
-    gap: var(--space-4);
-    flex-wrap: wrap;
-    margin-bottom: var(--space-5);
-    padding: var(--space-4);
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--color-border-subtle);
-  }
+      .options {
+        display: flex;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+        margin-bottom: var(--space-5);
+        padding: var(--space-4);
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-subtle);
+      }
 
-  .options label {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    cursor: pointer;
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .options label {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        cursor: pointer;
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .options input[type="radio"] {
-    cursor: pointer;
-    width: 16px;
-    height: 16px;
-    accent-color: var(--color-accent-primary);
-  }
+      .options input[type="radio"] {
+        cursor: pointer;
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-accent-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Panels
          ============================================ */
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-5);
-    margin-bottom: var(--space-5);
-  }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+        margin-bottom: var(--space-5);
+      }
 
-  @media (max-width: 768px) {
-    .panels {
-      grid-template-columns: 1fr;
-    }
-  }
+      @media (max-width: 768px) {
+        .panels {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .panel label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-3);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .panel label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-3);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  /* ============================================
+      /* ============================================
          Status Messages
          ============================================ */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          URL Parser Section
          ============================================ */
-  .url-parser {
-    margin-top: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-  }
+      .url-parser {
+        margin-top: var(--space-5);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+      }
 
-  .url-parser h3 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0 0 var(--space-4);
-    color: var(--color-text-primary);
-  }
+      .url-parser h3 {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 0 0 var(--space-4);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Result Table
          ============================================ */
-  .parsed-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9375rem;
-    margin-top: var(--space-4);
-  }
+      .parsed-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9375rem;
+        margin-top: var(--space-4);
+      }
 
-  .parsed-table th,
-  .parsed-table td {
-    padding: var(--space-3) var(--space-4);
-    text-align: left;
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
+      .parsed-table th,
+      .parsed-table td {
+        padding: var(--space-3) var(--space-4);
+        text-align: left;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
 
-  .parsed-table th {
-    background: var(--color-bg-subtle);
-    font-weight: 600;
-    width: 150px;
-    color: var(--color-text-secondary);
-    font-size: 0.875rem;
-  }
+      .parsed-table th {
+        background: var(--color-bg-subtle);
+        font-weight: 600;
+        width: 150px;
+        color: var(--color-text-secondary);
+        font-size: 0.875rem;
+      }
 
-  .parsed-table td {
-    font-family: var(--font-mono);
-    color: var(--color-text-primary);
-    word-break: break-all;
-  }
+      .parsed-table td {
+        font-family: var(--font-mono);
+        color: var(--color-text-primary);
+        word-break: break-all;
+      }
 
-  .parsed-table tr:last-child th,
-  .parsed-table tr:last-child td {
-    border-bottom: none;
-  }
+      .parsed-table tr:last-child th,
+      .parsed-table tr:last-child td {
+        border-bottom: none;
+      }
 
-  /* ============================================
+      /* ============================================
          Info Box
          ============================================ */
-  .info {
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    margin-top: var(--space-5);
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-  }
+      .info {
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        margin-top: var(--space-5);
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        line-height: 1.6;
+      }
 
-  .info strong {
-    color: var(--color-text-primary);
-    font-weight: 600;
-  }
+      .info strong {
+        color: var(--color-text-primary);
+        font-weight: 600;
+      }
 
-  /* ============================================
+      /* ============================================
          Footer
          ============================================ */
-  footer {
-    text-align: center;
-    margin-top: var(--space-8);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-    color: var(--text-muted);
-    font-size: 0.875rem;
-  }
+      footer {
+        text-align: center;
+        margin-top: var(--space-8);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+        color: var(--text-muted);
+        font-size: 0.875rem;
+      }
 
-  footer a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
+      footer a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
 
-  footer a:hover {
-    color: #00c299;
-  }
+      footer a:hover {
+        color: #00c299;
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .input-row {
-      flex-direction: column;
-    }
+        .input-row {
+          flex-direction: column;
+        }
 
-    .text-input,
-    .unit-select {
-      width: 100%;
-    }
+        .text-input,
+        .unit-select {
+          width: 100%;
+        }
 
-    .options {
-      flex-direction: column;
-      gap: var(--space-2);
-    }
+        .options {
+          flex-direction: column;
+          gap: var(--space-2);
+        }
 
-    .parsed-table th {
-      width: 100px;
-      font-size: 0.8125rem;
-    }
+        .parsed-table th {
+          width: 100px;
+          font-size: 0.8125rem;
+        }
 
-    .parsed-table th,
-    .parsed-table td {
-      padding: var(--space-2) var(--space-3);
-    }
-  }
+        .parsed-table th,
+        .parsed-table td {
+          padding: var(--space-2) var(--space-3);
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- URL Codec Card -->
-    <div class="card">
-      <h2 class="card-title">URL 编解码</h2>
+        <div class="container">
+          <!-- URL Codec Card -->
+          <div class="card">
+            <h2 class="card-title">URL 编解码</h2>
 
-      <div class="input-row" style="margin-bottom: var(--space-4)">
-        <button id="btnPaste">粘贴</button>
-        <button id="btnEncode" class="primary">编码</button>
-        <button id="btnDecode" class="primary">解码</button>
-        <button id="btnCopy">复制输出</button>
-        <button id="btnShare">分享链接</button>
-        <button id="btnClear">清空</button>
-      </div>
+            <div class="input-row" style="margin-bottom: var(--space-4)">
+              <button id="btnPaste">粘贴</button>
+              <button id="btnEncode" class="primary">编码</button>
+              <button id="btnDecode" class="primary">解码</button>
+              <button id="btnCopy">复制输出</button>
+              <button id="btnShare">分享链接</button>
+              <button id="btnClear">清空</button>
+            </div>
 
-      <div class="options">
-        <label>
-          <input type="radio" name="mode" value="component" checked="">
-          组件编码 (encodeURIComponent)
-        </label>
-        <label>
-          <input type="radio" name="mode" value="uri">
-          完整 URI (encodeURI)
-        </label>
-      </div>
+            <div class="options">
+              <label>
+                <input type="radio" name="mode" value="component" checked="" />
+                组件编码 (encodeURIComponent)
+              </label>
+              <label>
+                <input type="radio" name="mode" value="uri" />
+                完整 URI (encodeURI)
+              </label>
+            </div>
 
-      <div class="panels">
-        <div class="panel">
-          <label for="input">输入</label>
-          <textarea id="input" placeholder="输入 URL 或文本..."></textarea>
+            <div class="panels">
+              <div class="panel">
+                <label for="input">输入</label>
+                <textarea id="input" placeholder="输入 URL 或文本..."></textarea>
+              </div>
+              <div class="panel">
+                <label for="output">输出</label>
+                <textarea id="output" readonly="" placeholder="结果将显示在这里..."></textarea>
+              </div>
+            </div>
+
+            <div id="status" class="status"></div>
+
+            <div class="url-parser">
+              <h3>URL 解析</h3>
+              <button id="btnParse">解析 URL</button>
+              <table
+                id="parsedTable"
+                class="parsed-table"
+                style="display: none; margin-top: var(--space-4)"
+              >
+                <tbody>
+                  <tr>
+                    <th>协议</th>
+                    <td id="urlProtocol"></td>
+                  </tr>
+                  <tr>
+                    <th>主机</th>
+                    <td id="urlHost"></td>
+                  </tr>
+                  <tr>
+                    <th>端口</th>
+                    <td id="urlPort"></td>
+                  </tr>
+                  <tr>
+                    <th>路径</th>
+                    <td id="urlPath"></td>
+                  </tr>
+                  <tr>
+                    <th>查询参数</th>
+                    <td id="urlSearch"></td>
+                  </tr>
+                  <tr>
+                    <th>Hash</th>
+                    <td id="urlHash"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="info">
+              <strong>组件编码 vs 完整 URI：</strong>
+              <br />
+              · encodeURIComponent: 编码所有特殊字符，适合编码查询参数值
+              <br />
+              · encodeURI: 保留 URL 结构字符 (: / ? # 等)，适合编码完整 URL
+            </div>
+          </div>
+
+          <footer>
+            <a
+              href="https://github.com/chicogong/html-tools/blob/main/tools/dev/url-codec.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View source
+            </a>
+            · 纯前端工具 · 无服务器 ·
+            <a href="../../index.html">WebUtils</a>
+          </footer>
         </div>
-        <div class="panel">
-          <label for="output">输出</label>
-          <textarea id="output" readonly="" placeholder="结果将显示在这里..."></textarea>
-        </div>
-      </div>
-
-      <div id="status" class="status"></div>
-
-      <div class="url-parser">
-        <h3>URL 解析</h3>
-        <button id="btnParse">解析 URL</button>
-        <table id="parsedTable" class="parsed-table" style="display: none; margin-top: var(--space-4)">
-          <tbody>
-            <tr>
-              <th>协议</th>
-              <td id="urlProtocol"></td>
-            </tr>
-            <tr>
-              <th>主机</th>
-              <td id="urlHost"></td>
-            </tr>
-            <tr>
-              <th>端口</th>
-              <td id="urlPort"></td>
-            </tr>
-            <tr>
-              <th>路径</th>
-              <td id="urlPath"></td>
-            </tr>
-            <tr>
-              <th>查询参数</th>
-              <td id="urlSearch"></td>
-            </tr>
-            <tr>
-              <th>Hash</th>
-              <td id="urlHash"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="info">
-        <strong>组件编码 vs 完整 URI：</strong>
-        <br>
-        · encodeURIComponent: 编码所有特殊字符，适合编码查询参数值
-        <br>
-        · encodeURI: 保留 URL 结构字符 (: / ? # 等)，适合编码完整 URL
-      </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>URL 编解码工具安全吗？数据会上传服务器吗？</summary>
+            <p>
+              完全安全。所有 URL 编码和解码都在你的浏览器本地完成，输入的 URL
+              或文本不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>encodeURIComponent 和 encodeURI 有什么区别？</summary>
+            <p>
+              encodeURIComponent（组件编码）会编码几乎所有特殊字符（包括 : / ? # &amp;
+              等），适合编码查询参数的值；encodeURI（完整 URI 编码）会保留 URL 结构字符，适合对整个
+              URL 进行编码而不破坏其结构。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>中文 URL 应该用哪种方式编码？</summary>
+            <p>
+              中文字符应使用 encodeURIComponent 编码，会被转换为 %E4%B8%AD%E6%96%87
+              这样的百分号编码形式，可以安全地放在 URL 的任意位置。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何解析 URL 的各个组成部分？</summary>
+            <p>
+              在输入框中粘贴完整 URL，点击「解析
+              URL」按钮，工具会自动拆解出协议、主机名、端口、路径、查询参数和 Hash
+              等各个部分，方便逐项检查。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>URL 编解码工具可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
 
-    <footer>
-      <a href="https://github.com/chicogong/html-tools/blob/main/tools/dev/url-codec.html" target="_blank" rel="noreferrer">
-        View source
-      </a>
-      · 纯前端工具 · 无服务器 ·
-      <a href="../../index.html">WebUtils</a>
-    </footer>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>URL 编解码工具安全吗？数据会上传服务器吗？</summary>
-      <p>
-        完全安全。所有 URL 编码和解码都在你的浏览器本地完成，输入的 URL
-        或文本不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>encodeURIComponent 和 encodeURI 有什么区别？</summary>
-      <p>
-        encodeURIComponent（组件编码）会编码几乎所有特殊字符（包括 : / ? # &amp;
-        等），适合编码查询参数的值；encodeURI（完整 URI 编码）会保留 URL 结构字符，适合对整个 URL
-        进行编码而不破坏其结构。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>中文 URL 应该用哪种方式编码？</summary>
-      <p>
-        中文字符应使用 encodeURIComponent 编码，会被转换为 %E4%B8%AD%E6%96%87
-        这样的百分号编码形式，可以安全地放在 URL 的任意位置。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何解析 URL 的各个组成部分？</summary>
-      <p>
-        在输入框中粘贴完整 URL，点击「解析
-        URL」按钮，工具会自动拆解出协议、主机名、端口、路径、查询参数和 Hash
-        等各个部分，方便逐项检查。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>URL 编解码工具可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。</p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "开发工具",
-              "item": "https://tools.realtime-ai.chat/#dev"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "URL 编解码",
-              "item": "https://tools.realtime-ai.chat/tools/dev/url-codec.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "开发工具",
+            "item": "https://tools.realtime-ai.chat/#dev"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "URL 编解码",
+            "item": "https://tools.realtime-ai.chat/tools/dev/url-codec.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "URL 编解码工具安全吗？数据会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 URL 编码和解码都在你的浏览器本地完成，输入的 URL 或文本不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "encodeURIComponent 和 encodeURI 有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "encodeURIComponent（组件编码）会编码几乎所有特殊字符（包括 : / ? # & 等），适合编码查询参数的值；encodeURI（完整 URI 编码）会保留 URL 结构字符，适合对整个 URL 进行编码而不破坏其结构。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "中文 URL 应该用哪种方式编码？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "中文字符应使用 encodeURIComponent 编码，会被转换为 %E4%B8%AD%E6%96%87 这样的百分号编码形式，可以安全地放在 URL 的任意位置。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何解析 URL 的各个组成部分？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "在输入框中粘贴完整 URL，点击「解析 URL」按钮，工具会自动拆解出协议、主机名、端口、路径、查询参数和 Hash 等各个部分，方便逐项检查。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "URL 编解码工具可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "URL 编解码工具安全吗？数据会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 URL 编码和解码都在你的浏览器本地完成，输入的 URL 或文本不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "encodeURIComponent 和 encodeURI 有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "encodeURIComponent（组件编码）会编码几乎所有特殊字符（包括 : / ? # & 等），适合编码查询参数的值；encodeURI（完整 URI 编码）会保留 URL 结构字符，适合对整个 URL 进行编码而不破坏其结构。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "中文 URL 应该用哪种方式编码？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "中文字符应使用 encodeURIComponent 编码，会被转换为 %E4%B8%AD%E6%96%87 这样的百分号编码形式，可以安全地放在 URL 的任意位置。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何解析 URL 的各个组成部分？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "在输入框中粘贴完整 URL，点击「解析 URL」按钮，工具会自动拆解出协议、主机名、端口、路径、查询参数和 Hash 等各个部分，方便逐项检查。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "URL 编解码工具可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // Elements
-  // ============================================
-  var inputEl = document.getElementById("input");
-  var outputEl = document.getElementById("output");
-  var statusEl = document.getElementById("status");
-  var parsedTable = document.getElementById("parsedTable");
+    <script>
+      // ============================================
+      // Elements
+      // ============================================
+      var inputEl = document.getElementById("input");
+      var outputEl = document.getElementById("output");
+      var statusEl = document.getElementById("status");
+      var parsedTable = document.getElementById("parsedTable");
 
-  var LS_KEY = "url_codec_input_v1";
+      var LS_KEY = "url_codec_input_v1";
 
-  // ============================================
-  // Utility Functions
-  // ============================================
-  function getMode() {
-    return document.querySelector('input[name="mode"]:checked').value;
-  }
+      // ============================================
+      // Utility Functions
+      // ============================================
+      function getMode() {
+        return document.querySelector('input[name="mode"]:checked').value;
+      }
 
-  function showStatus(msg, type) {
-    statusEl.textContent = msg;
-    statusEl.className = "status " + (type || "");
-  }
+      function showStatus(msg, type) {
+        statusEl.textContent = msg;
+        statusEl.className = "status " + (type || "");
+      }
 
-  // ============================================
-  // URL State Management
-  // ============================================
-  window.loadFromUrl = function () {
-    var hash = location.hash.slice(1);
-    if (!hash) return false;
-    try {
-      inputEl.value = decodeURIComponent(atob(hash));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  };
+      // ============================================
+      // URL State Management
+      // ============================================
+      window.loadFromUrl = function () {
+        var hash = location.hash.slice(1);
+        if (!hash) return false;
+        try {
+          inputEl.value = decodeURIComponent(atob(hash));
+          return true;
+        } catch (e) {
+          return false;
+        }
+      };
 
-  function saveToUrl() {
-    try {
-      var encoded = btoa(encodeURIComponent(inputEl.value));
-      history.replaceState(null, "", "#" + encoded);
-    } catch (e) {
-      // Silent fail
-    }
-  }
+      function saveToUrl() {
+        try {
+          var encoded = btoa(encodeURIComponent(inputEl.value));
+          history.replaceState(null, "", "#" + encoded);
+        } catch (e) {
+          // Silent fail
+        }
+      }
 
-  // ============================================
-  // localStorage
-  // ============================================
-  function loadFromStorage() {
-    var saved = localStorage.getItem(LS_KEY);
-    if (saved) {
-      inputEl.value = saved;
-    }
-  }
+      // ============================================
+      // localStorage
+      // ============================================
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (saved) {
+          inputEl.value = saved;
+        }
+      }
 
-  function saveToStorage() {
-    localStorage.setItem(LS_KEY, inputEl.value);
-  }
+      function saveToStorage() {
+        localStorage.setItem(LS_KEY, inputEl.value);
+      }
 
-  // ============================================
-  // Encoding/Decoding Functions
-  // ============================================
-  function encode() {
-    var text = inputEl.value;
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      // ============================================
+      // Encoding/Decoding Functions
+      // ============================================
+      function encode() {
+        var text = inputEl.value;
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
 
-    try {
-      var mode = getMode();
-      var encoded = mode === "component" ? encodeURIComponent(text) : encodeURI(text);
-      outputEl.value = encoded;
-      showStatus("编码成功", "success");
-    } catch (e) {
-      showStatus("编码失败: " + e.message, "error");
-    }
-  }
+        try {
+          var mode = getMode();
+          var encoded = mode === "component" ? encodeURIComponent(text) : encodeURI(text);
+          outputEl.value = encoded;
+          showStatus("编码成功", "success");
+        } catch (e) {
+          showStatus("编码失败: " + e.message, "error");
+        }
+      }
 
-  window.decode = function () {
-    var text = inputEl.value;
-    if (!text) {
-      showStatus("请输入内容", "error");
-      return;
-    }
+      window.decode = function () {
+        var text = inputEl.value;
+        if (!text) {
+          showStatus("请输入内容", "error");
+          return;
+        }
 
-    try {
-      var mode = getMode();
-      var decoded = mode === "component" ? decodeURIComponent(text) : decodeURI(text);
-      outputEl.value = decoded;
-      showStatus("解码成功", "success");
-    } catch (e) {
-      showStatus("解码失败: 无效的编码字符串", "error");
-    }
-  };
+        try {
+          var mode = getMode();
+          var decoded = mode === "component" ? decodeURIComponent(text) : decodeURI(text);
+          outputEl.value = decoded;
+          showStatus("解码成功", "success");
+        } catch (e) {
+          showStatus("解码失败: 无效的编码字符串", "error");
+        }
+      };
 
-  // ============================================
-  // URL Parsing
-  // ============================================
-  function parseUrl() {
-    var text = inputEl.value.trim();
-    if (!text) {
-      showStatus("请输入 URL", "error");
-      return;
-    }
+      // ============================================
+      // URL Parsing
+      // ============================================
+      function parseUrl() {
+        var text = inputEl.value.trim();
+        if (!text) {
+          showStatus("请输入 URL", "error");
+          return;
+        }
 
-    try {
-      var url = new URL(text);
-      document.getElementById("urlProtocol").textContent = url.protocol;
-      document.getElementById("urlHost").textContent = url.hostname;
-      document.getElementById("urlPort").textContent = url.port || "(default)";
-      document.getElementById("urlPath").textContent = url.pathname;
-      document.getElementById("urlSearch").textContent = url.search || "(none)";
-      document.getElementById("urlHash").textContent = url.hash || "(none)";
-      parsedTable.style.display = "table";
-      showStatus("URL 解析成功", "success");
-    } catch (e) {
-      parsedTable.style.display = "none";
-      showStatus("无效的 URL 格式", "error");
-    }
-  }
+        try {
+          var url = new URL(text);
+          document.getElementById("urlProtocol").textContent = url.protocol;
+          document.getElementById("urlHost").textContent = url.hostname;
+          document.getElementById("urlPort").textContent = url.port || "(default)";
+          document.getElementById("urlPath").textContent = url.pathname;
+          document.getElementById("urlSearch").textContent = url.search || "(none)";
+          document.getElementById("urlHash").textContent = url.hash || "(none)";
+          parsedTable.style.display = "table";
+          showStatus("URL 解析成功", "success");
+        } catch (e) {
+          parsedTable.style.display = "none";
+          showStatus("无效的 URL 格式", "error");
+        }
+      }
 
-  // ============================================
-  // Event Handlers
-  // ============================================
-  document.getElementById("btnPaste").onclick = async function () {
-    try {
-      var text = await navigator.clipboard.readText();
-      inputEl.value = text;
-      saveToStorage();
-      saveToUrl();
-      showStatus("已粘贴", "success");
-    } catch (e) {
-      showStatus("无法访问剪贴板", "error");
-    }
-  };
+      // ============================================
+      // Event Handlers
+      // ============================================
+      document.getElementById("btnPaste").onclick = async function () {
+        try {
+          var text = await navigator.clipboard.readText();
+          inputEl.value = text;
+          saveToStorage();
+          saveToUrl();
+          showStatus("已粘贴", "success");
+        } catch (e) {
+          showStatus("无法访问剪贴板", "error");
+        }
+      };
 
-  document.getElementById("btnEncode").onclick = encode;
-  document.getElementById("btnDecode").onclick = decode;
-  document.getElementById("btnParse").onclick = parseUrl;
+      document.getElementById("btnEncode").onclick = encode;
+      document.getElementById("btnDecode").onclick = decode;
+      document.getElementById("btnParse").onclick = parseUrl;
 
-  document.getElementById("btnCopy").onclick = async function () {
-    if (!outputEl.value) {
-      showStatus("没有可复制的内容", "error");
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(outputEl.value);
-      showStatus("已复制到剪贴板", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+      document.getElementById("btnCopy").onclick = async function () {
+        if (!outputEl.value) {
+          showStatus("没有可复制的内容", "error");
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(outputEl.value);
+          showStatus("已复制到剪贴板", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
 
-  document.getElementById("btnShare").onclick = async function () {
-    saveToUrl();
-    try {
-      await navigator.clipboard.writeText(location.href);
-      showStatus("分享链接已复制", "success");
-    } catch (e) {
-      showStatus("复制失败", "error");
-    }
-  };
+      document.getElementById("btnShare").onclick = async function () {
+        saveToUrl();
+        try {
+          await navigator.clipboard.writeText(location.href);
+          showStatus("分享链接已复制", "success");
+        } catch (e) {
+          showStatus("复制失败", "error");
+        }
+      };
 
-  document.getElementById("btnClear").onclick = function () {
-    inputEl.value = "";
-    outputEl.value = "";
-    parsedTable.style.display = "none";
-    localStorage.removeItem(LS_KEY);
-    history.replaceState(null, "", location.pathname);
-    showStatus("已清空", "success");
-  };
+      document.getElementById("btnClear").onclick = function () {
+        inputEl.value = "";
+        outputEl.value = "";
+        parsedTable.style.display = "none";
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+        showStatus("已清空", "success");
+      };
 
-  inputEl.addEventListener("input", function () {
-    saveToStorage();
-    saveToUrl();
-  });
+      inputEl.addEventListener("input", function () {
+        saveToStorage();
+        saveToUrl();
+      });
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    var html = document.documentElement;
-    var currentTheme = html.getAttribute("data-theme") || "dark";
-    var newTheme = currentTheme === "light" ? "dark" : "light";
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        var html = document.documentElement;
+        var currentTheme = html.getAttribute("data-theme") || "dark";
+        var newTheme = currentTheme === "light" ? "dark" : "light";
 
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      }
 
-  function initTheme() {
-    var savedTheme = localStorage.getItem("theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    var theme = savedTheme || (prefersDark ? "dark" : "light");
+      function initTheme() {
+        var savedTheme = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = savedTheme || (prefersDark ? "dark" : "light");
 
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  if (!loadFromUrl()) {
-    loadFromStorage();
-  }
-</script>
-    
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      if (!loadFromUrl()) {
+        loadFromStorage();
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/food/meal-planner.html
+++ b/tools/food/meal-planner.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "餐饮食品",
-      "item": "https://tools.realtime-ai.chat/tools/food/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "周餐计划器",
-      "item": "https://tools.realtime-ai.chat/tools/food/meal-planner.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "餐饮食品",
+            "item": "https://tools.realtime-ai.chat/tools/food/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "周餐计划器",
+            "item": "https://tools.realtime-ai.chat/tools/food/meal-planner.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "周餐计划器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "周餐计划器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,856 +88,860 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg: #0a0a0f;
-    --card: #12121a;
-    --border: #2a2a3a;
-    --text: #fff;
-    --text2: #888;
-    --accent: #ec4899;
-    --accent2: #f472b6;
-  }
-  body {
-    font-family:
-      system-ui,
-      -apple-system,
-      sans-serif;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .container {
-    max-width: 1000px;
-    margin: 0 auto;
-  }
-  h1 {
-    text-align: center;
-    margin-bottom: 8px;
-    font-size: 1.8rem;
-  }
-  .subtitle {
-    text-align: center;
-    color: var(--text-secondary);
-    margin-bottom: 24px;
-  }
-  .card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 20px;
-  }
-  .week-nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-  }
-  .week-nav button {
-    padding: 8px 16px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    cursor: pointer;
-  }
-  .week-nav button:hover {
-    border-color: var(--accent-cyan);
-  }
-  .week-nav h2 {
-    font-size: 1.2rem;
-  }
-  .planner-grid {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 12px;
-  }
-  .day-column {
-    background: var(--bg-deep);
-    border-radius: 12px;
-    padding: 12px;
-    min-height: 300px;
-  }
-  .day-header {
-    text-align: center;
-    padding: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-    margin-bottom: 12px;
-  }
-  .day-header .day-name {
-    font-weight: 600;
-    font-size: 0.9rem;
-  }
-  .day-header .day-date {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-  }
-  .day-header.today {
-    color: var(--accent-cyan);
-  }
-  .meal-slot {
-    margin-bottom: 12px;
-  }
-  .meal-label {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    margin-bottom: 4px;
-    text-transform: uppercase;
-  }
-  .meal-content {
-    padding: 8px;
-    background: var(--bg-card);
-    border-radius: 6px;
-    min-height: 40px;
-    cursor: pointer;
-    font-size: 0.85rem;
-    border: 1px solid transparent;
-  }
-  .meal-content:hover {
-    border-color: var(--accent-cyan);
-  }
-  .meal-content.empty {
-    color: var(--text-secondary);
-    font-style: italic;
-  }
-  .meal-modal {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
-    z-index: 100;
-    align-items: center;
-    justify-content: center;
-  }
-  .meal-modal.show {
-    display: flex;
-  }
-  .modal-content {
-    background: var(--bg-card);
-    border-radius: 12px;
-    padding: 24px;
-    width: 90%;
-    max-width: 400px;
-  }
-  .modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-  }
-  .modal-header h3 {
-    font-size: 1.1rem;
-  }
-  .modal-close {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: 1.5rem;
-  }
-  .modal-input {
-    width: 100%;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    font-size: 1rem;
-    margin-bottom: 16px;
-  }
-  .modal-input:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-  }
-  .modal-suggestions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 16px;
-  }
-  .suggestion-btn {
-    padding: 6px 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 16px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: 0.8rem;
-  }
-  .suggestion-btn:hover {
-    border-color: var(--accent-cyan);
-  }
-  .modal-actions {
-    display: flex;
-    gap: 12px;
-  }
-  .modal-btn {
-    flex: 1;
-    padding: 12px;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
-  }
-  .modal-btn.primary {
-    background: var(--accent-cyan);
-    color: white;
-  }
-  .modal-btn.secondary {
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .summary-card {
-    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
-    border-radius: 12px;
-    padding: 20px;
-    color: white;
-  }
-  .summary-stats {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-    text-align: center;
-  }
-  .stat-value {
-    font-size: 1.8rem;
-    font-weight: 700;
-  }
-  .stat-label {
-    font-size: 0.85rem;
-    opacity: 0.9;
-  }
-  .action-btns {
-    display: flex;
-    gap: 12px;
-    margin-top: 20px;
-  }
-  .action-btn {
-    flex: 1;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    cursor: pointer;
-  }
-  .action-btn:hover {
-    border-color: var(--accent-cyan);
-  }
-  @media (max-width: 800px) {
-    .planner-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-  @media (max-width: 500px) {
-    .planner-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  .back-link {
-    display: inline-block;
-    margin-bottom: 16px;
-    color: var(--accent-cyan);
-    text-decoration: none;
-    font-size: 0.9rem;
-  }
-  .back-link:hover {
-    text-decoration: underline;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0a0f;
+        --card: #12121a;
+        --border: #2a2a3a;
+        --text: #fff;
+        --text2: #888;
+        --accent: #ec4899;
+        --accent2: #f472b6;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        min-height: 100vh;
+        padding: 20px;
+      }
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 8px;
+        font-size: 1.8rem;
+      }
+      .subtitle {
+        text-align: center;
+        color: var(--text-secondary);
+        margin-bottom: 24px;
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 24px;
+        margin-bottom: 20px;
+      }
+      .week-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+      }
+      .week-nav button {
+        padding: 8px 16px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        cursor: pointer;
+      }
+      .week-nav button:hover {
+        border-color: var(--accent-cyan);
+      }
+      .week-nav h2 {
+        font-size: 1.2rem;
+      }
+      .planner-grid {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 12px;
+      }
+      .day-column {
+        background: var(--bg-deep);
+        border-radius: 12px;
+        padding: 12px;
+        min-height: 300px;
+      }
+      .day-header {
+        text-align: center;
+        padding: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+        margin-bottom: 12px;
+      }
+      .day-header .day-name {
+        font-weight: 600;
+        font-size: 0.9rem;
+      }
+      .day-header .day-date {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+      .day-header.today {
+        color: var(--accent-cyan);
+      }
+      .meal-slot {
+        margin-bottom: 12px;
+      }
+      .meal-label {
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        margin-bottom: 4px;
+        text-transform: uppercase;
+      }
+      .meal-content {
+        padding: 8px;
+        background: var(--bg-card);
+        border-radius: 6px;
+        min-height: 40px;
+        cursor: pointer;
+        font-size: 0.85rem;
+        border: 1px solid transparent;
+      }
+      .meal-content:hover {
+        border-color: var(--accent-cyan);
+      }
+      .meal-content.empty {
+        color: var(--text-secondary);
+        font-style: italic;
+      }
+      .meal-modal {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.8);
+        z-index: 100;
+        align-items: center;
+        justify-content: center;
+      }
+      .meal-modal.show {
+        display: flex;
+      }
+      .modal-content {
+        background: var(--bg-card);
+        border-radius: 12px;
+        padding: 24px;
+        width: 90%;
+        max-width: 400px;
+      }
+      .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+      }
+      .modal-header h3 {
+        font-size: 1.1rem;
+      }
+      .modal-close {
+        width: 32px;
+        height: 32px;
+        border: none;
+        background: transparent;
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 1.5rem;
+      }
+      .modal-input {
+        width: 100%;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-size: 1rem;
+        margin-bottom: 16px;
+      }
+      .modal-input:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+      }
+      .modal-suggestions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+      .suggestion-btn {
+        padding: 6px 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 16px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 0.8rem;
+      }
+      .suggestion-btn:hover {
+        border-color: var(--accent-cyan);
+      }
+      .modal-actions {
+        display: flex;
+        gap: 12px;
+      }
+      .modal-btn {
+        flex: 1;
+        padding: 12px;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 1rem;
+      }
+      .modal-btn.primary {
+        background: var(--accent-cyan);
+        color: white;
+      }
+      .modal-btn.secondary {
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .summary-card {
+        background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
+        border-radius: 12px;
+        padding: 20px;
+        color: white;
+      }
+      .summary-stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        text-align: center;
+      }
+      .stat-value {
+        font-size: 1.8rem;
+        font-weight: 700;
+      }
+      .stat-label {
+        font-size: 0.85rem;
+        opacity: 0.9;
+      }
+      .action-btns {
+        display: flex;
+        gap: 12px;
+        margin-top: 20px;
+      }
+      .action-btn {
+        flex: 1;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        cursor: pointer;
+      }
+      .action-btn:hover {
+        border-color: var(--accent-cyan);
+      }
+      @media (max-width: 800px) {
+        .planner-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 500px) {
+        .planner-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .back-link {
+        display: inline-block;
+        margin-bottom: 16px;
+        color: var(--accent-cyan);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        text-decoration: underline;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <a href="../../index.html" class="back-link">← 返回</a>
-  <h1>周餐计划器</h1>
-  <p class="subtitle">规划一周的健康饮食</p>
+        <a href="../../index.html" class="back-link">← 返回</a>
+        <h1>周餐计划器</h1>
+        <p class="subtitle">规划一周的健康饮食</p>
 
-  <div class="card">
-    <div class="week-nav">
-      <button onclick="changeWeek(-1)">上一周</button>
-      <h2 id="weekTitle">本周</h2>
-      <button onclick="changeWeek(1)">下一周</button>
+        <div class="card">
+          <div class="week-nav">
+            <button onclick="changeWeek(-1)">上一周</button>
+            <h2 id="weekTitle">本周</h2>
+            <button onclick="changeWeek(1)">下一周</button>
+          </div>
+
+          <div class="planner-grid" id="plannerGrid"></div>
+        </div>
+
+        <div class="summary-card">
+          <div class="summary-stats">
+            <div>
+              <div class="stat-value" id="plannedMeals">0</div>
+              <div class="stat-label">已规划餐食</div>
+            </div>
+            <div>
+              <div class="stat-value" id="uniqueMeals">0</div>
+              <div class="stat-label">不同菜品</div>
+            </div>
+            <div>
+              <div class="stat-value" id="completionRate">0%</div>
+              <div class="stat-label">完成率</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="action-btns">
+          <button class="action-btn" onclick="exportPlan()">导出计划</button>
+          <button class="action-btn" onclick="generateShopping()">生成购物清单</button>
+          <button class="action-btn" onclick="clearWeek()">清空本周</button>
+        </div>
+      </div>
     </div>
 
-    <div class="planner-grid" id="plannerGrid"></div>
-  </div>
-
-  <div class="summary-card">
-    <div class="summary-stats">
-      <div>
-        <div class="stat-value" id="plannedMeals">0</div>
-        <div class="stat-label">已规划餐食</div>
-      </div>
-      <div>
-        <div class="stat-value" id="uniqueMeals">0</div>
-        <div class="stat-label">不同菜品</div>
-      </div>
-      <div>
-        <div class="stat-value" id="completionRate">0%</div>
-        <div class="stat-label">完成率</div>
-      </div>
-    </div>
-  </div>
-
-  <div class="action-btns">
-    <button class="action-btn" onclick="exportPlan()">导出计划</button>
-    <button class="action-btn" onclick="generateShopping()">生成购物清单</button>
-    <button class="action-btn" onclick="clearWeek()">清空本周</button>
-  </div>
-</div>
-    </div>
-    
     <script>
-  const days = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
-  const meals = ["breakfast", "lunch", "dinner"];
-  const mealLabels = { breakfast: "早餐", lunch: "午餐", dinner: "晚餐" };
+      const days = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
+      const meals = ["breakfast", "lunch", "dinner"];
+      const mealLabels = { breakfast: "早餐", lunch: "午餐", dinner: "晚餐" };
 
-  const suggestions = {
-    breakfast: ["牛奶麦片", "鸡蛋吐司", "豆浆油条", "小米粥", "三明治", "水果沙拉"],
-    lunch: ["红烧肉", "番茄炒蛋", "宫保鸡丁", "麻婆豆腐", "清炒时蔬", "牛肉面"],
-    dinner: ["清蒸鱼", "蔬菜沙拉", "煎牛排", "火锅", "饺子", "炒饭"]
-  };
+      const suggestions = {
+        breakfast: ["牛奶麦片", "鸡蛋吐司", "豆浆油条", "小米粥", "三明治", "水果沙拉"],
+        lunch: ["红烧肉", "番茄炒蛋", "宫保鸡丁", "麻婆豆腐", "清炒时蔬", "牛肉面"],
+        dinner: ["清蒸鱼", "蔬菜沙拉", "煎牛排", "火锅", "饺子", "炒饭"]
+      };
 
-  let weekOffset = 0;
-  let currentEdit = null;
-  let planData = JSON.parse(localStorage.getItem("mealPlan") || "{}");
+      let weekOffset = 0;
+      let currentEdit = null;
+      let planData = JSON.parse(localStorage.getItem("mealPlan") || "{}");
 
-  function getWeekDates(offset) {
-    const today = new Date();
-    const monday = new Date(today);
-    monday.setDate(today.getDate() - today.getDay() + 1 + offset * 7);
+      function getWeekDates(offset) {
+        const today = new Date();
+        const monday = new Date(today);
+        monday.setDate(today.getDate() - today.getDay() + 1 + offset * 7);
 
-    const dates = [];
-    for (let i = 0; i < 7; i++) {
-      const date = new Date(monday);
-      date.setDate(monday.getDate() + i);
-      dates.push(date);
-    }
-    return dates;
-  }
-
-  function formatDate(date) {
-    return date.getMonth() + 1 + "/" + date.getDate();
-  }
-
-  function getDateKey(date) {
-    return (
-      date.getFullYear() +
-      "-" +
-      String(date.getMonth() + 1).padStart(2, "0") +
-      "-" +
-      String(date.getDate()).padStart(2, "0")
-    );
-  }
-
-  function isToday(date) {
-    const today = new Date();
-    return date.toDateString() === today.toDateString();
-  }
-
-  function changeWeek(delta) {
-    weekOffset += delta;
-    renderPlanner();
-  }
-
-  function renderPlanner() {
-    const dates = getWeekDates(weekOffset);
-    const grid = document.getElementById("plannerGrid");
-    while (grid.firstChild) grid.removeChild(grid.firstChild);
-
-    const startDate = formatDate(dates[0]);
-    const endDate = formatDate(dates[6]);
-    document.getElementById("weekTitle").textContent = startDate + " - " + endDate;
-
-    let plannedCount = 0;
-    const uniqueSet = new Set();
-
-    dates.forEach(function (date, dayIndex) {
-      const column = document.createElement("div");
-      column.className = "day-column";
-
-      const header = document.createElement("div");
-      header.className = "day-header" + (isToday(date) ? " today" : "");
-      const dayName = document.createElement("div");
-      dayName.className = "day-name";
-      dayName.textContent = days[dayIndex];
-      const dayDate = document.createElement("div");
-      dayDate.className = "day-date";
-      dayDate.textContent = formatDate(date);
-      header.appendChild(dayName);
-      header.appendChild(dayDate);
-      column.appendChild(header);
-
-      const dateKey = getDateKey(date);
-
-      meals.forEach(function (meal) {
-        const slot = document.createElement("div");
-        slot.className = "meal-slot";
-
-        const label = document.createElement("div");
-        label.className = "meal-label";
-        label.textContent = mealLabels[meal];
-
-        const content = document.createElement("div");
-        content.className = "meal-content";
-
-        const mealKey = dateKey + "-" + meal;
-        const mealValue = planData[mealKey] || "";
-
-        if (mealValue) {
-          content.textContent = mealValue;
-          plannedCount++;
-          uniqueSet.add(mealValue);
-        } else {
-          content.className += " empty";
-          content.textContent = "点击添加";
+        const dates = [];
+        for (let i = 0; i < 7; i++) {
+          const date = new Date(monday);
+          date.setDate(monday.getDate() + i);
+          dates.push(date);
         }
+        return dates;
+      }
 
-        content.addEventListener("click", function () {
-          openModal(dateKey, meal, days[dayIndex], mealLabels[meal]);
+      function formatDate(date) {
+        return date.getMonth() + 1 + "/" + date.getDate();
+      }
+
+      function getDateKey(date) {
+        return (
+          date.getFullYear() +
+          "-" +
+          String(date.getMonth() + 1).padStart(2, "0") +
+          "-" +
+          String(date.getDate()).padStart(2, "0")
+        );
+      }
+
+      function isToday(date) {
+        const today = new Date();
+        return date.toDateString() === today.toDateString();
+      }
+
+      function changeWeek(delta) {
+        weekOffset += delta;
+        renderPlanner();
+      }
+
+      function renderPlanner() {
+        const dates = getWeekDates(weekOffset);
+        const grid = document.getElementById("plannerGrid");
+        while (grid.firstChild) grid.removeChild(grid.firstChild);
+
+        const startDate = formatDate(dates[0]);
+        const endDate = formatDate(dates[6]);
+        document.getElementById("weekTitle").textContent = startDate + " - " + endDate;
+
+        let plannedCount = 0;
+        const uniqueSet = new Set();
+
+        dates.forEach(function (date, dayIndex) {
+          const column = document.createElement("div");
+          column.className = "day-column";
+
+          const header = document.createElement("div");
+          header.className = "day-header" + (isToday(date) ? " today" : "");
+          const dayName = document.createElement("div");
+          dayName.className = "day-name";
+          dayName.textContent = days[dayIndex];
+          const dayDate = document.createElement("div");
+          dayDate.className = "day-date";
+          dayDate.textContent = formatDate(date);
+          header.appendChild(dayName);
+          header.appendChild(dayDate);
+          column.appendChild(header);
+
+          const dateKey = getDateKey(date);
+
+          meals.forEach(function (meal) {
+            const slot = document.createElement("div");
+            slot.className = "meal-slot";
+
+            const label = document.createElement("div");
+            label.className = "meal-label";
+            label.textContent = mealLabels[meal];
+
+            const content = document.createElement("div");
+            content.className = "meal-content";
+
+            const mealKey = dateKey + "-" + meal;
+            const mealValue = planData[mealKey] || "";
+
+            if (mealValue) {
+              content.textContent = mealValue;
+              plannedCount++;
+              uniqueSet.add(mealValue);
+            } else {
+              content.className += " empty";
+              content.textContent = "点击添加";
+            }
+
+            content.addEventListener("click", function () {
+              openModal(dateKey, meal, days[dayIndex], mealLabels[meal]);
+            });
+
+            slot.appendChild(label);
+            slot.appendChild(content);
+            column.appendChild(slot);
+          });
+
+          grid.appendChild(column);
         });
 
-        slot.appendChild(label);
-        slot.appendChild(content);
-        column.appendChild(slot);
+        document.getElementById("plannedMeals").textContent = plannedCount;
+        document.getElementById("uniqueMeals").textContent = uniqueSet.size;
+        document.getElementById("completionRate").textContent =
+          Math.round((plannedCount / 21) * 100) + "%";
+      }
+
+      function openModal(dateKey, meal, dayName, mealLabel) {
+        currentEdit = { dateKey: dateKey, meal: meal };
+        document.getElementById("modalTitle").textContent = dayName + " " + mealLabel;
+        document.getElementById("mealInput").value = planData[dateKey + "-" + meal] || "";
+
+        const suggestionsEl = document.getElementById("suggestions");
+        while (suggestionsEl.firstChild) suggestionsEl.removeChild(suggestionsEl.firstChild);
+
+        suggestions[meal].forEach(function (sug) {
+          const btn = document.createElement("button");
+          btn.className = "suggestion-btn";
+          btn.textContent = sug;
+          btn.addEventListener("click", function () {
+            document.getElementById("mealInput").value = sug;
+          });
+          suggestionsEl.appendChild(btn);
+        });
+
+        document.getElementById("mealModal").classList.add("show");
+        document.getElementById("mealInput").focus();
+      }
+
+      function closeModal() {
+        document.getElementById("mealModal").classList.remove("show");
+        currentEdit = null;
+      }
+
+      function saveMeal() {
+        if (!currentEdit) return;
+        const value = document.getElementById("mealInput").value.trim();
+        const key = currentEdit.dateKey + "-" + currentEdit.meal;
+
+        if (value) {
+          planData[key] = value;
+        } else {
+          delete planData[key];
+        }
+
+        localStorage.setItem("mealPlan", JSON.stringify(planData));
+        closeModal();
+        renderPlanner();
+      }
+
+      function deleteMeal() {
+        if (!currentEdit) return;
+        const key = currentEdit.dateKey + "-" + currentEdit.meal;
+        delete planData[key];
+        localStorage.setItem("mealPlan", JSON.stringify(planData));
+        closeModal();
+        renderPlanner();
+      }
+
+      function copyText(text) {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          return Promise.reject(new Error("Clipboard API unavailable"));
+        }
+        return navigator.clipboard.writeText(text);
+      }
+
+      function exportPlan() {
+        const dates = getWeekDates(weekOffset);
+        let text = "周餐计划 (" + formatDate(dates[0]) + " - " + formatDate(dates[6]) + ")\n";
+        text += "=".repeat(30) + "\n\n";
+
+        dates.forEach(function (date, dayIndex) {
+          text += days[dayIndex] + " (" + formatDate(date) + ")\n";
+          const dateKey = getDateKey(date);
+          meals.forEach(function (meal) {
+            const value = planData[dateKey + "-" + meal] || "未规划";
+            text += "  " + mealLabels[meal] + ": " + value + "\n";
+          });
+          text += "\n";
+        });
+
+        copyText(text)
+          .then(function () {
+            alert("已复制到剪贴板");
+          })
+          .catch(function () {
+            alert("复制失败，请手动复制计划内容");
+          });
+      }
+
+      function generateShopping() {
+        const dates = getWeekDates(weekOffset);
+        const mealsList = [];
+
+        dates.forEach(function (date) {
+          const dateKey = getDateKey(date);
+          meals.forEach(function (meal) {
+            const value = planData[dateKey + "-" + meal];
+            if (value) mealsList.push(value);
+          });
+        });
+
+        let text = "本周菜单\n" + "=".repeat(20) + "\n\n";
+        const unique = Array.from(new Set(mealsList));
+        unique.forEach(function (m) {
+          text += "- " + m + "\n";
+        });
+
+        copyText(text)
+          .then(function () {
+            alert("菜单已复制，可用于生成购物清单");
+          })
+          .catch(function () {
+            alert("复制失败，请手动复制菜单内容");
+          });
+      }
+
+      function clearWeek() {
+        if (!confirm("确定清空本周所有餐食规划吗？")) return;
+        const dates = getWeekDates(weekOffset);
+        dates.forEach(function (date) {
+          const dateKey = getDateKey(date);
+          meals.forEach(function (meal) {
+            delete planData[dateKey + "-" + meal];
+          });
+        });
+        localStorage.setItem("mealPlan", JSON.stringify(planData));
+        renderPlanner();
+      }
+
+      document.getElementById("mealModal")?.addEventListener("click", function (e) {
+        if (e.target === this) closeModal();
       });
 
-      grid.appendChild(column);
-    });
-
-    document.getElementById("plannedMeals").textContent = plannedCount;
-    document.getElementById("uniqueMeals").textContent = uniqueSet.size;
-    document.getElementById("completionRate").textContent =
-      Math.round((plannedCount / 21) * 100) + "%";
-  }
-
-  function openModal(dateKey, meal, dayName, mealLabel) {
-    currentEdit = { dateKey: dateKey, meal: meal };
-    document.getElementById("modalTitle").textContent = dayName + " " + mealLabel;
-    document.getElementById("mealInput").value = planData[dateKey + "-" + meal] || "";
-
-    const suggestionsEl = document.getElementById("suggestions");
-    while (suggestionsEl.firstChild) suggestionsEl.removeChild(suggestionsEl.firstChild);
-
-    suggestions[meal].forEach(function (sug) {
-      const btn = document.createElement("button");
-      btn.className = "suggestion-btn";
-      btn.textContent = sug;
-      btn.addEventListener("click", function () {
-        document.getElementById("mealInput").value = sug;
+      document.getElementById("mealInput")?.addEventListener("keypress", function (e) {
+        if (e.key === "Enter") saveMeal();
       });
-      suggestionsEl.appendChild(btn);
-    });
 
-    document.getElementById("mealModal").classList.add("show");
-    document.getElementById("mealInput").focus();
-  }
+      renderPlanner();
 
-  function closeModal() {
-    document.getElementById("mealModal").classList.remove("show");
-    currentEdit = null;
-  }
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
 
-  function saveMeal() {
-    if (!currentEdit) return;
-    const value = document.getElementById("mealInput").value.trim();
-    const key = currentEdit.dateKey + "-" + currentEdit.meal;
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
 
-    if (value) {
-      planData[key] = value;
-    } else {
-      delete planData[key];
-    }
-
-    localStorage.setItem("mealPlan", JSON.stringify(planData));
-    closeModal();
-    renderPlanner();
-  }
-
-  function deleteMeal() {
-    if (!currentEdit) return;
-    const key = currentEdit.dateKey + "-" + currentEdit.meal;
-    delete planData[key];
-    localStorage.setItem("mealPlan", JSON.stringify(planData));
-    closeModal();
-    renderPlanner();
-  }
-
-  function copyText(text) {
-    if (!navigator.clipboard || !navigator.clipboard.writeText) {
-      return Promise.reject(new Error("Clipboard API unavailable"));
-    }
-    return navigator.clipboard.writeText(text);
-  }
-
-  function exportPlan() {
-    const dates = getWeekDates(weekOffset);
-    let text = "周餐计划 (" + formatDate(dates[0]) + " - " + formatDate(dates[6]) + ")\n";
-    text += "=".repeat(30) + "\n\n";
-
-    dates.forEach(function (date, dayIndex) {
-      text += days[dayIndex] + " (" + formatDate(date) + ")\n";
-      const dateKey = getDateKey(date);
-      meals.forEach(function (meal) {
-        const value = planData[dateKey + "-" + meal] || "未规划";
-        text += "  " + mealLabels[meal] + ": " + value + "\n";
-      });
-      text += "\n";
-    });
-
-    copyText(text)
-      .then(function () {
-        alert("已复制到剪贴板");
-      })
-      .catch(function () {
-        alert("复制失败，请手动复制计划内容");
-      });
-  }
-
-  function generateShopping() {
-    const dates = getWeekDates(weekOffset);
-    const mealsList = [];
-
-    dates.forEach(function (date) {
-      const dateKey = getDateKey(date);
-      meals.forEach(function (meal) {
-        const value = planData[dateKey + "-" + meal];
-        if (value) mealsList.push(value);
-      });
-    });
-
-    let text = "本周菜单\n" + "=".repeat(20) + "\n\n";
-    const unique = Array.from(new Set(mealsList));
-    unique.forEach(function (m) {
-      text += "- " + m + "\n";
-    });
-
-    copyText(text)
-      .then(function () {
-        alert("菜单已复制，可用于生成购物清单");
-      })
-      .catch(function () {
-        alert("复制失败，请手动复制菜单内容");
-      });
-  }
-
-  function clearWeek() {
-    if (!confirm("确定清空本周所有餐食规划吗？")) return;
-    const dates = getWeekDates(weekOffset);
-    dates.forEach(function (date) {
-      const dateKey = getDateKey(date);
-      meals.forEach(function (meal) {
-        delete planData[dateKey + "-" + meal];
-      });
-    });
-    localStorage.setItem("mealPlan", JSON.stringify(planData));
-    renderPlanner();
-  }
-
-  document.getElementById("mealModal")?.addEventListener("click", function (e) {
-    if (e.target === this) closeModal();
-  });
-
-  document.getElementById("mealInput")?.addEventListener("keypress", function (e) {
-    if (e.key === "Enter") saveMeal();
-  });
-
-  renderPlanner();
-
-  // Theme toggle
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme");
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-    localStorage.setItem("theme", newTheme);
-  }
-
-  // Load saved theme
-  const savedTheme = localStorage.getItem("theme") || "dark";
-  if (savedTheme === "light") {
-    document.documentElement.setAttribute("data-theme", "light");
-    document.getElementById("theme-icon").textContent = "☀️";
-  }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/generator/password-generator.html
+++ b/tools/generator/password-generator.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="密码 password 随机 安全 生成" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/generator/password-generator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/generator/password-generator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="密码生成器 - WebUtils" />
     <meta property="og:description" content="生成安全随机密码，支持自定义长度和字符类型" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/generator/password-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/generator/password-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "密码生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/password-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "密码生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/password-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "密码生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "密码生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1172 +94,1182 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Password Display
          ============================================ */
-  .password-display {
-    background: var(--color-bg-input);
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    padding: var(--space-5);
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    word-break: break-all;
-    text-align: center;
-    margin-bottom: var(--space-5);
-    min-height: 70px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--color-accent-primary);
-    letter-spacing: 0.05em;
-  }
+      .password-display {
+        background: var(--color-bg-input);
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        padding: var(--space-5);
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        word-break: break-all;
+        text-align: center;
+        margin-bottom: var(--space-5);
+        min-height: 70px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-accent-primary);
+        letter-spacing: 0.05em;
+      }
 
-  /* ============================================
+      /* ============================================
          Strength Indicator
          ============================================ */
-  .strength-bar {
-    height: 6px;
-    background: var(--color-bg-subtle);
-    border-radius: 3px;
-    margin-bottom: var(--space-3);
-    overflow: hidden;
-  }
+      .strength-bar {
+        height: 6px;
+        background: var(--color-bg-subtle);
+        border-radius: 3px;
+        margin-bottom: var(--space-3);
+        overflow: hidden;
+      }
 
-  .strength-fill {
-    height: 100%;
-    transition:
-      width var(--transition-normal),
-      background-color var(--transition-normal);
-  }
+      .strength-fill {
+        height: 100%;
+        transition:
+          width var(--transition-normal),
+          background-color var(--transition-normal);
+      }
 
-  .strength-text {
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    text-align: center;
-    margin-bottom: var(--space-5);
-    font-weight: 500;
-  }
+      .strength-text {
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        text-align: center;
+        margin-bottom: var(--space-5);
+        font-weight: 500;
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .option-group {
-    margin-bottom: var(--space-6);
-  }
+      .option-group {
+        margin-bottom: var(--space-6);
+      }
 
-  .option-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .option-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .slider-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-  }
+      .slider-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+      }
 
-  input[type="range"] {
-    flex: 1;
-    height: 4px;
-    border-radius: 2px;
-    background: var(--color-bg-subtle);
-    outline: none;
-    -webkit-appearance: none;
-    appearance: none;
-  }
+      input[type="range"] {
+        flex: 1;
+        height: 4px;
+        border-radius: 2px;
+        background: var(--color-bg-subtle);
+        outline: none;
+        -webkit-appearance: none;
+        appearance: none;
+      }
 
-  input[type="range"]::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: var(--color-accent-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      input[type="range"]::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: var(--color-accent-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  input[type="range"]::-moz-range-thumb {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: var(--color-accent-primary);
-    cursor: pointer;
-    border: none;
-    transition: all var(--transition-fast);
-  }
+      input[type="range"]::-moz-range-thumb {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: var(--color-accent-primary);
+        cursor: pointer;
+        border: none;
+        transition: all var(--transition-fast);
+      }
 
-  input[type="range"]::-webkit-slider-thumb:hover {
-    transform: scale(1.2);
-  }
+      input[type="range"]::-webkit-slider-thumb:hover {
+        transform: scale(1.2);
+      }
 
-  input[type="range"]::-moz-range-thumb:hover {
-    transform: scale(1.2);
-  }
+      input[type="range"]::-moz-range-thumb:hover {
+        transform: scale(1.2);
+      }
 
-  .slider-row .value {
-    min-width: 50px;
-    text-align: center;
-    font-weight: 600;
-    font-family: var(--font-mono);
-    color: var(--color-accent-primary);
-    font-size: 0.9375rem;
-  }
+      .slider-row .value {
+        min-width: 50px;
+        text-align: center;
+        font-weight: 600;
+        font-family: var(--font-mono);
+        color: var(--color-accent-primary);
+        font-size: 0.9375rem;
+      }
 
-  /* ============================================
+      /* ============================================
          Checkbox Group
          ============================================ */
-  .checkbox-group {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--space-3);
-  }
+      .checkbox-group {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: var(--space-3);
+      }
 
-  .checkbox-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .checkbox-item:hover {
-    background: var(--color-bg-surface);
-    border-color: var(--color-accent-primary);
-  }
+      .checkbox-item:hover {
+        background: var(--color-bg-surface);
+        border-color: var(--color-accent-primary);
+      }
 
-  .checkbox-item input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
-    accent-color: var(--color-accent-primary);
-  }
+      .checkbox-item input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+        accent-color: var(--color-accent-primary);
+      }
 
-  .checkbox-item span {
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-    user-select: none;
-  }
+      .checkbox-item span {
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+        user-select: none;
+      }
 
-  /* ============================================
+      /* ============================================
          Button Group
          ============================================ */
-  .btn-group {
-    display: flex;
-    gap: var(--space-3);
-    margin-bottom: var(--space-6);
-    flex-wrap: wrap;
-  }
+      .btn-group {
+        display: flex;
+        gap: var(--space-3);
+        margin-bottom: var(--space-6);
+        flex-wrap: wrap;
+      }
 
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  button.btn-secondary {
-    flex: 1;
-    min-width: 120px;
-  }
+      button.btn-secondary {
+        flex: 1;
+        min-width: 120px;
+      }
 
-  /* ============================================
+      /* ============================================
          History
          ============================================ */
-  .history {
-    margin-top: var(--space-6);
-    padding-top: var(--space-6);
-    border-top: 1px solid var(--color-border-default);
-  }
+      .history {
+        margin-top: var(--space-6);
+        padding-top: var(--space-6);
+        border-top: 1px solid var(--color-border-default);
+      }
 
-  .history-title {
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    margin-bottom: var(--space-3);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
+      .history-title {
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        margin-bottom: var(--space-3);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
 
-  .history-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-    max-height: 240px;
-    overflow-y: auto;
-  }
+      .history-list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        max-height: 240px;
+        overflow-y: auto;
+      }
 
-  .history-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: var(--space-3) var(--space-4);
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    transition: all var(--transition-fast);
-  }
+      .history-item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        transition: all var(--transition-fast);
+      }
 
-  .history-item:hover {
-    background: var(--color-bg-surface);
-    border-color: var(--color-border-default);
-  }
+      .history-item:hover {
+        background: var(--color-bg-surface);
+        border-color: var(--color-border-default);
+      }
 
-  .history-item button {
-    background: none;
-    border: none;
-    color: var(--color-accent-primary);
-    cursor: pointer;
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: var(--space-1) var(--space-2);
-    transition: all var(--transition-fast);
-  }
+      .history-item button {
+        background: none;
+        border: none;
+        color: var(--color-accent-primary);
+        cursor: pointer;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: var(--space-1) var(--space-2);
+        transition: all var(--transition-fast);
+      }
 
-  .history-item button:hover {
-    transform: scale(1.1);
-  }
+      .history-item button:hover {
+        transform: scale(1.1);
+      }
 
-  /* ============================================
+      /* ============================================
          Toast Notification
          ============================================ */
-  .toast {
-    position: fixed;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--color-success);
-    color: white;
-    padding: var(--space-3) var(--space-5);
-    border-radius: var(--radius-md);
-    opacity: 0;
-    transition: all var(--transition-normal);
-    z-index: 2000;
-    font-weight: 500;
-    box-shadow: var(--shadow-lg);
-  }
+      .toast {
+        position: fixed;
+        bottom: 2rem;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--color-success);
+        color: white;
+        padding: var(--space-3) var(--space-5);
+        border-radius: var(--radius-md);
+        opacity: 0;
+        transition: all var(--transition-normal);
+        z-index: 2000;
+        font-weight: 500;
+        box-shadow: var(--shadow-lg);
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .password-display {
-      font-size: 1.25rem;
-      padding: var(--space-4);
-      min-height: 60px;
-    }
+        .password-display {
+          font-size: 1.25rem;
+          padding: var(--space-4);
+          min-height: 60px;
+        }
 
-    .checkbox-group {
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    }
+        .checkbox-group {
+          grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        }
 
-    .btn-group {
-      flex-direction: column;
-    }
+        .btn-group {
+          flex-direction: column;
+        }
 
-    button.btn-secondary {
-      width: 100%;
-    }
-  }
+        button.btn-secondary {
+          width: 100%;
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Password Generator Card -->
-    <div class="card">
-      <h2 class="card-title">生成安全密码</h2>
+        <div class="container">
+          <!-- Password Generator Card -->
+          <div class="card">
+            <h2 class="card-title">生成安全密码</h2>
 
-      <!-- Password Display -->
-      <div class="password-display" id="password">点击生成按钮</div>
+            <!-- Password Display -->
+            <div class="password-display" id="password">点击生成按钮</div>
 
-      <!-- Strength Indicator -->
-      <div class="strength-bar">
-        <div class="strength-fill" id="strengthFill"></div>
-      </div>
-      <div class="strength-text" id="strengthText">密码强度</div>
+            <!-- Strength Indicator -->
+            <div class="strength-bar">
+              <div class="strength-fill" id="strengthFill"></div>
+            </div>
+            <div class="strength-text" id="strengthText">密码强度</div>
 
-      <!-- Action Buttons -->
-      <div class="btn-group">
-        <button class="btn btn-primary primary" onclick="generate()">生成密码</button>
-        <button class="btn btn-secondary" onclick="copyPassword()">复制</button>
-      </div>
+            <!-- Action Buttons -->
+            <div class="btn-group">
+              <button class="btn btn-primary primary" onclick="generate()">生成密码</button>
+              <button class="btn btn-secondary" onclick="copyPassword()">复制</button>
+            </div>
 
-      <!-- Password Length -->
-      <div class="option-group">
-        <label>
-          密码长度:
-          <span id="lengthValue">16</span>
-        </label>
-        <div class="slider-row">
-          <input type="range" id="length" min="4" max="64" value="16" oninput="updateLength()">
-          <span class="value" id="lengthDisplay">16</span>
+            <!-- Password Length -->
+            <div class="option-group">
+              <label>
+                密码长度:
+                <span id="lengthValue">16</span>
+              </label>
+              <div class="slider-row">
+                <input
+                  type="range"
+                  id="length"
+                  min="4"
+                  max="64"
+                  value="16"
+                  oninput="updateLength()"
+                />
+                <span class="value" id="lengthDisplay">16</span>
+              </div>
+            </div>
+
+            <!-- Character Types -->
+            <div class="option-group">
+              <label>包含字符类型</label>
+              <div class="checkbox-group">
+                <label class="checkbox-item">
+                  <input type="checkbox" id="uppercase" checked="" />
+                  <span>大写字母 A-Z</span>
+                </label>
+                <label class="checkbox-item">
+                  <input type="checkbox" id="lowercase" checked="" />
+                  <span>小写字母 a-z</span>
+                </label>
+                <label class="checkbox-item">
+                  <input type="checkbox" id="numbers" checked="" />
+                  <span>数字 0-9</span>
+                </label>
+                <label class="checkbox-item">
+                  <input type="checkbox" id="symbols" checked="" />
+                  <span>特殊符号 !@#$</span>
+                </label>
+              </div>
+            </div>
+
+            <!-- History -->
+            <div class="history">
+              <div class="history-title">历史记录</div>
+              <div class="history-list" id="historyList"></div>
+            </div>
+          </div>
         </div>
-      </div>
-
-      <!-- Character Types -->
-      <div class="option-group">
-        <label>包含字符类型</label>
-        <div class="checkbox-group">
-          <label class="checkbox-item">
-            <input type="checkbox" id="uppercase" checked="">
-            <span>大写字母 A-Z</span>
-          </label>
-          <label class="checkbox-item">
-            <input type="checkbox" id="lowercase" checked="">
-            <span>小写字母 a-z</span>
-          </label>
-          <label class="checkbox-item">
-            <input type="checkbox" id="numbers" checked="">
-            <span>数字 0-9</span>
-          </label>
-          <label class="checkbox-item">
-            <input type="checkbox" id="symbols" checked="">
-            <span>特殊符号 !@#$</span>
-          </label>
-        </div>
-      </div>
-
-      <!-- History -->
-      <div class="history">
-        <div class="history-title">历史记录</div>
-        <div class="history-list" id="historyList"></div>
-      </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>这个密码生成器安全吗？生成的密码会上传到服务器吗？</summary>
+            <p>
+              完全安全。所有密码均在你的浏览器本地生成，使用 Web Crypto API
+              提供的加密级随机数，生成结果不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>密码长度应该设置多长才够安全？</summary>
+            <p>
+              一般建议至少 16
+              位，同时混合大小写字母、数字和特殊符号。对于需要长期保护的账号（如邮箱、银行），推荐使用
+              20 位以上。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>大写字母、数字、特殊符号都要勾选吗？</summary>
+            <p>
+              勾选的字符类型越多，密码的字符空间越大，暴力破解难度越高。建议全部勾选；若某些网站不允许特殊符号，则可单独取消该选项。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>密码生成器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件
+              HTML，将页面保存到本地后，即使断开网络也能正常生成密码，无需安装或注册任何账号。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>历史记录保存在哪里？别人会看到吗？</summary>
+            <p>
+              历史记录仅保存在本设备的
+              localStorage（浏览器本地存储）中，不会同步到云端，也不会被第三方读取。关闭隐私浏览窗口或手动清空历史即可删除。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>这个密码生成器安全吗？生成的密码会上传到服务器吗？</summary>
-      <p>
-        完全安全。所有密码均在你的浏览器本地生成，使用 Web Crypto API
-        提供的加密级随机数，生成结果不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>密码长度应该设置多长才够安全？</summary>
-      <p>
-        一般建议至少 16
-        位，同时混合大小写字母、数字和特殊符号。对于需要长期保护的账号（如邮箱、银行），推荐使用 20
-        位以上。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>大写字母、数字、特殊符号都要勾选吗？</summary>
-      <p>
-        勾选的字符类型越多，密码的字符空间越大，暴力破解难度越高。建议全部勾选；若某些网站不允许特殊符号，则可单独取消该选项。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>密码生成器可以离线使用吗？</summary>
-      <p>
-        可以。本工具是单文件
-        HTML，将页面保存到本地后，即使断开网络也能正常生成密码，无需安装或注册任何账号。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>历史记录保存在哪里？别人会看到吗？</summary>
-      <p>
-        历史记录仅保存在本设备的
-        localStorage（浏览器本地存储）中，不会同步到云端，也不会被第三方读取。关闭隐私浏览窗口或手动清空历史即可删除。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "生成器",
-              "item": "https://tools.realtime-ai.chat/#generator"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "密码生成器",
-              "item": "https://tools.realtime-ai.chat/tools/generator/password-generator.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/#generator"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "密码生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/password-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "这个密码生成器安全吗？生成的密码会上传到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有密码均在你的浏览器本地生成，使用 Web Crypto API 提供的加密级随机数，生成结果不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "密码长度应该设置多长才够安全？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "一般建议至少 16 位，同时混合大小写字母、数字和特殊符号。对于需要长期保护的账号（如邮箱、银行），推荐使用 20 位以上。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "大写字母、数字、特殊符号都要勾选吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "勾选的字符类型越多，密码的字符空间越大，暴力破解难度越高。建议全部勾选；若某些网站不允许特殊符号，则可单独取消该选项。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "密码生成器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成密码，无需安装或注册任何账号。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "历史记录保存在哪里？别人会看到吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "历史记录仅保存在本设备的 localStorage（浏览器本地存储）中，不会同步到云端，也不会被第三方读取。关闭隐私浏览窗口或手动清空历史即可删除。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "这个密码生成器安全吗？生成的密码会上传到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有密码均在你的浏览器本地生成，使用 Web Crypto API 提供的加密级随机数，生成结果不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "密码长度应该设置多长才够安全？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "一般建议至少 16 位，同时混合大小写字母、数字和特殊符号。对于需要长期保护的账号（如邮箱、银行），推荐使用 20 位以上。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "大写字母、数字、特殊符号都要勾选吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "勾选的字符类型越多，密码的字符空间越大，暴力破解难度越高。建议全部勾选；若某些网站不允许特殊符号，则可单独取消该选项。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "密码生成器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成密码，无需安装或注册任何账号。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "历史记录保存在哪里？别人会看到吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "历史记录仅保存在本设备的 localStorage（浏览器本地存储）中，不会同步到云端，也不会被第三方读取。关闭隐私浏览窗口或手动清空历史即可删除。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  const chars = {
-    uppercase: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    lowercase: "abcdefghijklmnopqrstuvwxyz",
-    numbers: "0123456789",
-    symbols: "!@#$%^&*()_+-=[]{}|;:,.<>?"
-  };
-  let history = JSON.parse(localStorage.getItem("pwdHistory") || "[]");
+    <script>
+      const chars = {
+        uppercase: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        lowercase: "abcdefghijklmnopqrstuvwxyz",
+        numbers: "0123456789",
+        symbols: "!@#$%^&*()_+-=[]{}|;:,.<>?"
+      };
+      let history = JSON.parse(localStorage.getItem("pwdHistory") || "[]");
 
-  window.generate = function () {
-    const length = parseInt(document.getElementById("length").value);
-    let charset = "";
+      window.generate = function () {
+        const length = parseInt(document.getElementById("length").value);
+        let charset = "";
 
-    if (document.getElementById("uppercase").checked) charset += chars.uppercase;
-    if (document.getElementById("lowercase").checked) charset += chars.lowercase;
-    if (document.getElementById("numbers").checked) charset += chars.numbers;
-    if (document.getElementById("symbols").checked) charset += chars.symbols;
+        if (document.getElementById("uppercase").checked) charset += chars.uppercase;
+        if (document.getElementById("lowercase").checked) charset += chars.lowercase;
+        if (document.getElementById("numbers").checked) charset += chars.numbers;
+        if (document.getElementById("symbols").checked) charset += chars.symbols;
 
-    if (!charset) {
-      alert("请至少选择一种字符类型");
-      return;
-    }
+        if (!charset) {
+          alert("请至少选择一种字符类型");
+          return;
+        }
 
-    let password = "";
-    const array = new Uint32Array(length);
-    crypto.getRandomValues(array);
-    for (let i = 0; i < length; i++) {
-      password += charset[array[i] % charset.length];
-    }
+        let password = "";
+        const array = new Uint32Array(length);
+        crypto.getRandomValues(array);
+        for (let i = 0; i < length; i++) {
+          password += charset[array[i] % charset.length];
+        }
 
-    document.getElementById("password").textContent = password;
-    updateStrength(password);
+        document.getElementById("password").textContent = password;
+        updateStrength(password);
 
-    history.unshift(password);
-    if (history.length > 10) history.pop();
-    localStorage.setItem("pwdHistory", JSON.stringify(history));
-    renderHistory();
-  };
+        history.unshift(password);
+        if (history.length > 10) history.pop();
+        localStorage.setItem("pwdHistory", JSON.stringify(history));
+        renderHistory();
+      };
 
-  function updateStrength(password) {
-    let score = 0;
-    if (password.length >= 8) score++;
-    if (password.length >= 12) score++;
-    if (password.length >= 16) score++;
-    if (/[a-z]/.test(password)) score++;
-    if (/[A-Z]/.test(password)) score++;
-    if (/[0-9]/.test(password)) score++;
-    if (/[^a-zA-Z0-9]/.test(password)) score++;
+      function updateStrength(password) {
+        let score = 0;
+        if (password.length >= 8) score++;
+        if (password.length >= 12) score++;
+        if (password.length >= 16) score++;
+        if (/[a-z]/.test(password)) score++;
+        if (/[A-Z]/.test(password)) score++;
+        if (/[0-9]/.test(password)) score++;
+        if (/[^a-zA-Z0-9]/.test(password)) score++;
 
-    const fill = document.getElementById("strengthFill");
-    const text = document.getElementById("strengthText");
-    const percent = (score / 7) * 100;
+        const fill = document.getElementById("strengthFill");
+        const text = document.getElementById("strengthText");
+        const percent = (score / 7) * 100;
 
-    fill.style.width = percent + "%";
-    if (score <= 2) {
-      fill.style.background = "#ef4444";
-      text.textContent = "弱";
-    } else if (score <= 4) {
-      fill.style.background = "#f59e0b";
-      text.textContent = "中等";
-    } else if (score <= 5) {
-      fill.style.background = "#22c55e";
-      text.textContent = "强";
-    } else {
-      fill.style.background = "linear-gradient(90deg, #22c55e, #10b981)";
-      text.textContent = "非常强";
-    }
-  }
+        fill.style.width = percent + "%";
+        if (score <= 2) {
+          fill.style.background = "#ef4444";
+          text.textContent = "弱";
+        } else if (score <= 4) {
+          fill.style.background = "#f59e0b";
+          text.textContent = "中等";
+        } else if (score <= 5) {
+          fill.style.background = "#22c55e";
+          text.textContent = "强";
+        } else {
+          fill.style.background = "linear-gradient(90deg, #22c55e, #10b981)";
+          text.textContent = "非常强";
+        }
+      }
 
-  window.copyPassword = function () {
-    const password = document.getElementById("password").textContent;
-    if (password && password !== "点击生成按钮") {
-      navigator.clipboard.writeText(password);
-      showToast();
-    }
-  };
+      window.copyPassword = function () {
+        const password = document.getElementById("password").textContent;
+        if (password && password !== "点击生成按钮") {
+          navigator.clipboard.writeText(password);
+          showToast();
+        }
+      };
 
-  window.copyHistoryItem = function (pwd) {
-    navigator.clipboard.writeText(pwd);
-    showToast();
-  };
+      window.copyHistoryItem = function (pwd) {
+        navigator.clipboard.writeText(pwd);
+        showToast();
+      };
 
-  window.updateLength = function () {
-    var value = document.getElementById("length").value;
-    document.getElementById("lengthValue").textContent = value;
-    document.getElementById("lengthDisplay").textContent = value;
-  };
+      window.updateLength = function () {
+        var value = document.getElementById("length").value;
+        document.getElementById("lengthValue").textContent = value;
+        document.getElementById("lengthDisplay").textContent = value;
+      };
 
-  function renderHistory() {
-    const list = document.getElementById("historyList");
-    list.innerHTML = history
-      .map(
-        (pwd) =>
-          `<div class="history-item"><span>${pwd.substring(0, 30)}${pwd.length > 30 ? "..." : ""}</span><button onclick="copyHistoryItem('${pwd}')">复制</button></div>`
-      )
-      .join("");
-  }
+      function renderHistory() {
+        const list = document.getElementById("historyList");
+        list.innerHTML = history
+          .map(
+            (pwd) =>
+              `<div class="history-item"><span>${pwd.substring(0, 30)}${pwd.length > 30 ? "..." : ""}</span><button onclick="copyHistoryItem('${pwd}')">复制</button></div>`
+          )
+          .join("");
+      }
 
-  function showToast() {
-    const toast = document.getElementById("toast");
-    toast.classList.add("show");
-    setTimeout(() => toast.classList.remove("show"), 2000);
-  }
+      function showToast() {
+        const toast = document.getElementById("toast");
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      }
 
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
 
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  renderHistory();
-</script>
-    
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      renderHistory();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/generator/qrcode-generator.html
+++ b/tools/generator/qrcode-generator.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="二维码 qrcode 生成 扫码" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="二维码生成器 - WebUtils" />
     <meta property="og:description" content="生成自定义颜色和大小的二维码" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "二维码生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "二维码生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "二维码生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "二维码生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1113 +94,1132 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  textarea,
-  input[type="text"],
-  input[type="number"],
-  input[type="color"] {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    transition: all var(--transition-fast);
-  }
+      textarea,
+      input[type="text"],
+      input[type="number"],
+      input[type="color"] {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        transition: all var(--transition-fast);
+      }
 
-  textarea {
-    width: 100%;
-    height: 120px;
-    font-family: var(--font-mono);
-    resize: vertical;
-  }
+      textarea {
+        width: 100%;
+        height: 120px;
+        font-family: var(--font-mono);
+        resize: vertical;
+      }
 
-  input[type="number"] {
-    width: 100px;
-  }
+      input[type="number"] {
+        width: 100px;
+      }
 
-  input[type="color"] {
-    width: 60px;
-    height: 40px;
-    padding: var(--space-1);
-    cursor: pointer;
-  }
+      input[type="color"] {
+        width: 60px;
+        height: 40px;
+        padding: var(--space-1);
+        cursor: pointer;
+      }
 
-  textarea:focus,
-  input:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      textarea:focus,
+      input:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  .color-row {
-    display: flex;
-    gap: var(--space-5);
-    flex-wrap: wrap;
-  }
+      .color-row {
+        display: flex;
+        gap: var(--space-5);
+        flex-wrap: wrap;
+      }
 
-  .color-group {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-  }
+      .color-group {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  button.success {
-    background: var(--color-success);
-    border-color: var(--color-success);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.success {
+        background: var(--color-success);
+        border-color: var(--color-success);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.success:hover {
-    background: #16a34a;
-    box-shadow: 0 0 20px rgba(34, 197, 94, 0.15);
-  }
+      button.success:hover {
+        background: #16a34a;
+        box-shadow: 0 0 20px rgba(34, 197, 94, 0.15);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-    justify-content: center;
-  }
+      .btn-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        justify-content: center;
+      }
 
-  /* ============================================
+      /* ============================================
          QR Code Display
          ============================================ */
-  .qr-canvas {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: white;
-    border-radius: var(--radius-md);
-    padding: var(--space-6);
-    min-height: 300px;
-  }
+      .qr-canvas {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: white;
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        min-height: 300px;
+      }
 
-  #qrCanvas {
-    display: block;
-    max-width: 100%;
-    height: auto;
-  }
+      #qrCanvas {
+        display: block;
+        max-width: 100%;
+        height: auto;
+      }
 
-  /* ============================================
+      /* ============================================
          Status/Info Messages
          ============================================ */
-  .qr-info {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    text-align: center;
-    min-height: 20px;
-    margin-top: var(--space-3);
-  }
+      .qr-info {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        text-align: center;
+        min-height: 20px;
+        margin-top: var(--space-3);
+      }
 
-  /* ============================================
+      /* ============================================
          Grid Layout
          ============================================ */
-  .grid-2col {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-6);
-  }
+      .grid-2col {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-6);
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 768px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 768px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .grid-2col {
-      grid-template-columns: 1fr;
-      gap: var(--space-4);
-    }
+        .grid-2col {
+          grid-template-columns: 1fr;
+          gap: var(--space-4);
+        }
 
-    .qr-canvas {
-      padding: var(--space-4);
-    }
-  }
+        .qr-canvas {
+          padding: var(--space-4);
+        }
+      }
 
-  @media (max-width: 480px) {
-    .color-row {
-      gap: var(--space-3);
-    }
+      @media (max-width: 480px) {
+        .color-row {
+          gap: var(--space-3);
+        }
 
-    .btn-row {
-      flex-direction: column;
-    }
+        .btn-row {
+          flex-direction: column;
+        }
 
-    button {
-      width: 100%;
-    }
-  }
+        button {
+          width: 100%;
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Two Column Layout -->
-    <div class="grid-2col">
-      <!-- Input Panel -->
-      <div class="card">
-        <h2 class="card-title">输入内容</h2>
+        <div class="container">
+          <!-- Two Column Layout -->
+          <div class="grid-2col">
+            <!-- Input Panel -->
+            <div class="card">
+              <h2 class="card-title">输入内容</h2>
 
-        <div class="input-group">
-          <label>文本或 URL</label>
-          <textarea id="textInput" placeholder="输入要编码的文本或 URL..."></textarea>
-        </div>
+              <div class="input-group">
+                <label>文本或 URL</label>
+                <textarea id="textInput" placeholder="输入要编码的文本或 URL..."></textarea>
+              </div>
 
-        <div class="input-group">
-          <label for="input--------px-">二维码大小 (px)</label>
-          <input type="number" id="qrSize" value="256" min="64" max="1024" step="32" aria-label="数字输入框" placeholder="请输入数字输入框">
-        </div>
+              <div class="input-group">
+                <label for="input--------px-">二维码大小 (px)</label>
+                <input
+                  type="number"
+                  id="qrSize"
+                  value="256"
+                  min="64"
+                  max="1024"
+                  step="32"
+                  aria-label="数字输入框"
+                  placeholder="请输入数字输入框"
+                />
+              </div>
 
-        <div class="input-group">
-          <label>颜色</label>
-          <div class="color-row">
-            <div class="color-group">
-              <span>前景色</span>
-              <input type="color" id="fgColor" value="#000000" aria-label="颜色选择器">
+              <div class="input-group">
+                <label>颜色</label>
+                <div class="color-row">
+                  <div class="color-group">
+                    <span>前景色</span>
+                    <input type="color" id="fgColor" value="#000000" aria-label="颜色选择器" />
+                  </div>
+                  <div class="color-group">
+                    <span>背景色</span>
+                    <input type="color" id="bgColor" value="#ffffff" aria-label="颜色选择器" />
+                  </div>
+                </div>
+              </div>
+
+              <div class="btn-row">
+                <button class="primary" onclick="generateQR()" aria-label="生成二维码">
+                  生成二维码
+                </button>
+                <button onclick="clearInput()" aria-label="清空">清空</button>
+              </div>
             </div>
-            <div class="color-group">
-              <span>背景色</span>
-              <input type="color" id="bgColor" value="#ffffff" aria-label="颜色选择器">
+
+            <!-- Preview Panel -->
+            <div class="card">
+              <h2 class="card-title">预览</h2>
+
+              <div class="qr-canvas">
+                <canvas id="qrCanvas" width="256" height="256"></canvas>
+              </div>
+
+              <div class="btn-row">
+                <button class="success" onclick="downloadQR()" aria-label="下载 PNG">
+                  下载 PNG
+                </button>
+                <button onclick="copyQR()" aria-label="复制到剪贴板">复制到剪贴板</button>
+              </div>
+
+              <div class="qr-info" id="qrInfo"></div>
             </div>
           </div>
         </div>
-
-        <div class="btn-row">
-          <button class="primary" onclick="generateQR()" aria-label="生成二维码">生成二维码</button>
-          <button onclick="clearInput()" aria-label="清空">清空</button>
-        </div>
-      </div>
-
-      <!-- Preview Panel -->
-      <div class="card">
-        <h2 class="card-title">预览</h2>
-
-        <div class="qr-canvas">
-          <canvas id="qrCanvas" width="256" height="256"></canvas>
-        </div>
-
-        <div class="btn-row">
-          <button class="success" onclick="downloadQR()" aria-label="下载 PNG">下载 PNG</button>
-          <button onclick="copyQR()" aria-label="复制到剪贴板">复制到剪贴板</button>
-        </div>
-
-        <div class="qr-info" id="qrInfo"></div>
-      </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>二维码生成器安全吗？输入的内容会上传服务器吗？</summary>
+            <p>
+              完全安全。所有二维码生成都在你的浏览器本地完成，输入的文本或 URL
+              不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>生成的二维码图片可以下载保存吗？</summary>
+            <p>
+              可以。点击「下载 PNG」按钮即可将二维码保存为高清 PNG
+              图片到本地；也可以点击「复制到剪贴板」直接粘贴使用。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>二维码的大小和颜色可以自定义吗？</summary>
+            <p>
+              可以。在左侧设置面板中，可以自由调整二维码的像素尺寸（64 px 到 1024
+              px），以及前景色和背景色，实时预览效果。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>二维码能存储多少内容？有字符数限制吗？</summary>
+            <p>
+              二维码的容量取决于纠错级别和内容类型。纯数字最多约 7089 字符，字母数字约 4296
+              字符，UTF-8 文本（含中文）约 1817
+              字节。内容越多，二维码越复杂，扫描难度也越大，建议尽量精简。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>二维码生成器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>二维码生成器安全吗？输入的内容会上传服务器吗？</summary>
-      <p>
-        完全安全。所有二维码生成都在你的浏览器本地完成，输入的文本或 URL
-        不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>生成的二维码图片可以下载保存吗？</summary>
-      <p>
-        可以。点击「下载 PNG」按钮即可将二维码保存为高清 PNG
-        图片到本地；也可以点击「复制到剪贴板」直接粘贴使用。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>二维码的大小和颜色可以自定义吗？</summary>
-      <p>
-        可以。在左侧设置面板中，可以自由调整二维码的像素尺寸（64 px 到 1024
-        px），以及前景色和背景色，实时预览效果。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>二维码能存储多少内容？有字符数限制吗？</summary>
-      <p>
-        二维码的容量取决于纠错级别和内容类型。纯数字最多约 7089 字符，字母数字约 4296 字符，UTF-8
-        文本（含中文）约 1817 字节。内容越多，二维码越复杂，扫描难度也越大，建议尽量精简。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>二维码生成器可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。</p>
-    </details>
-  </section>
-</main>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/@keeex/qrcodejs-kx@1.0.2/qrcode.min.js"></script>
-<script>
-  (function () {
-    var QRCodeCtor = window.QRCode;
-    window.QRCode = {
-      toCanvas: function (canvas, text, options, callback) {
-        try {
-          var temp = document.createElement("div");
-          new QRCodeCtor(temp, {
-            text: text,
-            width: options.width,
-            height: options.width,
-            colorDark: options.color.dark,
-            colorLight: options.color.light,
-            correctLevel: QRCodeCtor.CorrectLevel.M
-          });
-          var generated = temp.querySelector("canvas");
-          canvas.width = options.width;
-          canvas.height = options.width;
-          canvas.getContext("2d").drawImage(generated, 0, 0, options.width, options.width);
-          if (callback) callback(null);
-          return Promise.resolve(canvas);
-        } catch (error) {
-          if (callback) callback(error);
-          return Promise.reject(error);
-        }
-      }
-    };
-  })();
-</script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "生成器",
-              "item": "https://tools.realtime-ai.chat/#generator"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "二维码生成器",
-              "item": "https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+    <script>
+      (function () {
+        var QRCodeCtor = window.QRCode;
+        window.QRCode = {
+          toCanvas: function (canvas, text, options, callback) {
+            try {
+              var temp = document.createElement("div");
+              new QRCodeCtor(temp, {
+                text: text,
+                width: options.width,
+                height: options.width,
+                colorDark: options.color.dark,
+                colorLight: options.color.light,
+                correctLevel: QRCodeCtor.CorrectLevel.M
+              });
+              var generated = temp.querySelector("canvas");
+              canvas.width = options.width;
+              canvas.height = options.width;
+              canvas.getContext("2d").drawImage(generated, 0, 0, options.width, options.width);
+              if (callback) callback(null);
+              return Promise.resolve(canvas);
+            } catch (error) {
+              if (callback) callback(error);
+              return Promise.reject(error);
             }
-          ]
-        }
+          }
+        };
+      })();
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "二维码生成器安全吗？输入的内容会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有二维码生成都在你的浏览器本地完成，输入的文本或 URL 不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "生成的二维码图片可以下载保存吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。点击「下载 PNG」按钮即可将二维码保存为高清 PNG 图片到本地；也可以点击「复制到剪贴板」直接粘贴使用。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "二维码的大小和颜色可以自定义吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。在左侧设置面板中，可以自由调整二维码的像素尺寸（64 px 到 1024 px），以及前景色和背景色，实时预览效果。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "二维码能存储多少内容？有字符数限制吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "二维码的容量取决于纠错级别和内容类型。纯数字最多约 7089 字符，字母数字约 4296 字符，UTF-8 文本（含中文）约 1817 字节。内容越多，二维码越复杂，扫描难度也越大，建议尽量精简。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "二维码生成器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
-              }
-            }
-          ]
-        }
-    </script>
-<script>
-  // ============================================
-  // Elements
-  // ============================================
-  var textInput = document.getElementById("textInput");
-  var qrSize = document.getElementById("qrSize");
-  var fgColor = document.getElementById("fgColor");
-  var bgColor = document.getElementById("bgColor");
-  var canvas = document.getElementById("qrCanvas");
-  var qrInfo = document.getElementById("qrInfo");
-
-  // ============================================
-  // Generate QR Code
-  // ============================================
-  function generateQR() {
-    var text = textInput.value.trim();
-    if (!text) {
-      qrInfo.textContent = "请输入内容";
-      return;
-    }
-
-    var size = parseInt(qrSize.value) || 256;
-    canvas.width = size;
-    canvas.height = size;
-
-    QRCode.toCanvas(
-      canvas,
-      text,
       {
-        width: size,
-        margin: 2,
-        color: {
-          dark: fgColor.value,
-          light: bgColor.value
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/#generator"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "二维码生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "二维码生成器安全吗？输入的内容会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有二维码生成都在你的浏览器本地完成，输入的文本或 URL 不会上传到任何服务器，也不会被记录。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "生成的二维码图片可以下载保存吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。点击「下载 PNG」按钮即可将二维码保存为高清 PNG 图片到本地；也可以点击「复制到剪贴板」直接粘贴使用。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "二维码的大小和颜色可以自定义吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。在左侧设置面板中，可以自由调整二维码的像素尺寸（64 px 到 1024 px），以及前景色和背景色，实时预览效果。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "二维码能存储多少内容？有字符数限制吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "二维码的容量取决于纠错级别和内容类型。纯数字最多约 7089 字符，字母数字约 4296 字符，UTF-8 文本（含中文）约 1817 字节。内容越多，二维码越复杂，扫描难度也越大，建议尽量精简。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "二维码生成器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
+            }
+          }
+        ]
+      }
+    </script>
+    <script>
+      // ============================================
+      // Elements
+      // ============================================
+      var textInput = document.getElementById("textInput");
+      var qrSize = document.getElementById("qrSize");
+      var fgColor = document.getElementById("fgColor");
+      var bgColor = document.getElementById("bgColor");
+      var canvas = document.getElementById("qrCanvas");
+      var qrInfo = document.getElementById("qrInfo");
+
+      // ============================================
+      // Generate QR Code
+      // ============================================
+      function generateQR() {
+        var text = textInput.value.trim();
+        if (!text) {
+          qrInfo.textContent = "请输入内容";
+          return;
         }
-      },
-      function (error) {
-        if (error) {
-          qrInfo.textContent = "生成失败: " + error.message;
-        } else {
-          qrInfo.textContent = "大小: " + size + " x " + size + " px";
-          saveState();
+
+        var size = parseInt(qrSize.value) || 256;
+        canvas.width = size;
+        canvas.height = size;
+
+        QRCode.toCanvas(
+          canvas,
+          text,
+          {
+            width: size,
+            margin: 2,
+            color: {
+              dark: fgColor.value,
+              light: bgColor.value
+            }
+          },
+          function (error) {
+            if (error) {
+              qrInfo.textContent = "生成失败: " + error.message;
+            } else {
+              qrInfo.textContent = "大小: " + size + " x " + size + " px";
+              saveState();
+            }
+          }
+        );
+      }
+
+      // ============================================
+      // Download QR Code
+      // ============================================
+      window.downloadQR = function () {
+        var link = document.createElement("a");
+        link.download = "qrcode.png";
+        link.href = canvas.toDataURL("image/png");
+        link.click();
+      };
+
+      // ============================================
+      // Copy QR Code to Clipboard
+      // ============================================
+      window.copyQR = async function () {
+        try {
+          var blob = await new Promise(function (resolve) {
+            canvas.toBlob(resolve, "image/png");
+          });
+          await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+          qrInfo.textContent = "已复制到剪贴板";
+        } catch (e) {
+          qrInfo.textContent = "复制失败: " + e.message;
+        }
+      };
+
+      // ============================================
+      // Clear Input
+      // ============================================
+      window.clearInput = function () {
+        textInput.value = "";
+        var ctx = canvas.getContext("2d");
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        qrInfo.textContent = "";
+        saveState();
+      };
+
+      // ============================================
+      // State Persistence
+      // ============================================
+      function saveState() {
+        var state = {
+          text: textInput.value,
+          size: qrSize.value,
+          fg: fgColor.value,
+          bg: bgColor.value
+        };
+        try {
+          var hash = btoa(encodeURIComponent(JSON.stringify(state)));
+          history.replaceState(null, "", "#" + hash);
+        } catch (e) {
+          console.error("保存状态失败:", e);
         }
       }
-    );
-  }
 
-  // ============================================
-  // Download QR Code
-  // ============================================
-  window.downloadQR = function () {
-    var link = document.createElement("a");
-    link.download = "qrcode.png";
-    link.href = canvas.toDataURL("image/png");
-    link.click();
-  };
+      function loadState() {
+        var hash = window.location.hash.slice(1);
+        if (hash) {
+          try {
+            var state = JSON.parse(decodeURIComponent(atob(hash)));
+            if (state.text) textInput.value = state.text;
+            if (state.size) qrSize.value = state.size;
+            if (state.fg) fgColor.value = state.fg;
+            if (state.bg) bgColor.value = state.bg;
+            if (state.text) generateQR();
+          } catch (e) {
+            console.error("加载状态失败:", e);
+          }
+        }
+      }
 
-  // ============================================
-  // Copy QR Code to Clipboard
-  // ============================================
-  window.copyQR = async function () {
-    try {
-      var blob = await new Promise(function (resolve) {
-        canvas.toBlob(resolve, "image/png");
+      // ============================================
+      // Auto-generate on Input Change
+      // ============================================
+      var generateTimeout;
+      textInput.addEventListener("input", function () {
+        clearTimeout(generateTimeout);
+        generateTimeout = setTimeout(function () {
+          if (textInput.value.trim()) {
+            generateQR();
+          }
+        }, 300);
       });
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      qrInfo.textContent = "已复制到剪贴板";
-    } catch (e) {
-      qrInfo.textContent = "复制失败: " + e.message;
-    }
-  };
 
-  // ============================================
-  // Clear Input
-  // ============================================
-  window.clearInput = function () {
-    textInput.value = "";
-    var ctx = canvas.getContext("2d");
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    qrInfo.textContent = "";
-    saveState();
-  };
+      // Re-generate on Settings Change
+      [qrSize, fgColor, bgColor].forEach(function (el) {
+        el.addEventListener("change", function () {
+          if (textInput.value.trim()) {
+            generateQR();
+          }
+        });
+      });
 
-  // ============================================
-  // State Persistence
-  // ============================================
-  function saveState() {
-    var state = {
-      text: textInput.value,
-      size: qrSize.value,
-      fg: fgColor.value,
-      bg: bgColor.value
-    };
-    try {
-      var hash = btoa(encodeURIComponent(JSON.stringify(state)));
-      history.replaceState(null, "", "#" + hash);
-    } catch (e) {
-      console.error("保存状态失败:", e);
-    }
-  }
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        var html = document.documentElement;
+        var currentTheme = html.getAttribute("data-theme") || "dark";
+        var newTheme = currentTheme === "light" ? "dark" : "light";
 
-  function loadState() {
-    var hash = window.location.hash.slice(1);
-    if (hash) {
-      try {
-        var state = JSON.parse(decodeURIComponent(atob(hash)));
-        if (state.text) textInput.value = state.text;
-        if (state.size) qrSize.value = state.size;
-        if (state.fg) fgColor.value = state.fg;
-        if (state.bg) bgColor.value = state.bg;
-        if (state.text) generateQR();
-      } catch (e) {
-        console.error("加载状态失败:", e);
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
       }
-    }
-  }
 
-  // ============================================
-  // Auto-generate on Input Change
-  // ============================================
-  var generateTimeout;
-  textInput.addEventListener("input", function () {
-    clearTimeout(generateTimeout);
-    generateTimeout = setTimeout(function () {
-      if (textInput.value.trim()) {
-        generateQR();
+      function initTheme() {
+        var savedTheme = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = savedTheme || (prefersDark ? "dark" : "light");
+
+        document.documentElement.setAttribute("data-theme", theme);
       }
-    }, 300);
-  });
 
-  // Re-generate on Settings Change
-  [qrSize, fgColor, bgColor].forEach(function (el) {
-    el.addEventListener("change", function () {
-      if (textInput.value.trim()) {
-        generateQR();
-      }
-    });
-  });
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      loadState();
+    </script>
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    var html = document.documentElement;
-    var currentTheme = html.getAttribute("data-theme") || "dark";
-    var newTheme = currentTheme === "light" ? "dark" : "light";
-
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
-
-  function initTheme() {
-    var savedTheme = localStorage.getItem("theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    var theme = savedTheme || (prefersDark ? "dark" : "light");
-
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  loadState();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/generator/uuid-generator.html
+++ b/tools/generator/uuid-generator.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="uuid ulid 生成 随机 id 唯一标识" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/generator/uuid-generator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="UUID/ULID 生成器 - WebUtils" />
     <meta property="og:description" content="生成 UUID v4/v7 和 ULID，支持批量生成" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/generator/uuid-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "UUID/ULID 生成器",
-      "item": "https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "UUID/ULID 生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "UUID/ULID 生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "UUID/ULID 生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,607 +94,615 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap" rel="stylesheet">
-<style>
-  body {
-    min-height: 100vh;
-    background:
-      radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent), var(--bg-deep);
-  }
 
-  .tool-wrap {
-    max-width: 680px;
-    margin: 0 auto;
-    padding: 56px 20px 140px;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        min-height: 100vh;
+        background:
+          radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent),
+          var(--bg-deep);
+      }
 
-  .tool-head {
-    text-align: center;
-    margin-bottom: var(--space-8);
-  }
+      .tool-wrap {
+        max-width: 680px;
+        margin: 0 auto;
+        padding: 56px 20px 140px;
+      }
 
-  .tool-badge {
-    display: inline-block;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--accent-cyan);
-    background: var(--glow-cyan);
-    border: 1px solid var(--tb-glass-border);
-    border-radius: var(--radius-full);
-  }
+      .tool-head {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
 
-  .tool-head h1 {
-    margin: var(--space-4) 0 var(--space-2);
-    font-size: 29px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-  }
+      .tool-badge {
+        display: inline-block;
+        padding: 5px 12px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-cyan);
+        background: var(--glow-cyan);
+        border: 1px solid var(--tb-glass-border);
+        border-radius: var(--radius-full);
+      }
 
-  .tool-head p {
-    margin: 0;
-    font-size: 14px;
-    color: var(--text-muted);
-  }
+      .tool-head h1 {
+        margin: var(--space-4) 0 var(--space-2);
+        font-size: 29px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
 
-  .panel {
-    position: relative;
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-  }
+      .tool-head p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
 
-  .panel::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
-  }
+      .panel {
+        position: relative;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-lg);
+        overflow: hidden;
+      }
 
-  .panel-body {
-    padding: var(--space-8) var(--space-6) var(--space-6);
-  }
+      .panel::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
+      }
 
-  .options {
-    display: grid;
-    grid-template-columns: 1fr 1fr 110px;
-    gap: var(--space-3);
-    margin-bottom: var(--space-5);
-  }
+      .panel-body {
+        padding: var(--space-8) var(--space-6) var(--space-6);
+      }
 
-  .field label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    color: var(--text-secondary);
-  }
+      .options {
+        display: grid;
+        grid-template-columns: 1fr 1fr 110px;
+        gap: var(--space-3);
+        margin-bottom: var(--space-5);
+      }
 
-  .field select,
-  .field input {
-    width: 100%;
-    padding: 10px 12px;
-    font-family: var(--font-sans);
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-primary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-  }
+      .field label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: var(--text-secondary);
+      }
 
-  .field select:focus,
-  .field input:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-    box-shadow: 0 0 0 3px var(--glow-cyan);
-  }
+      .field select,
+      .field input {
+        width: 100%;
+        padding: 10px 12px;
+        font-family: var(--font-sans);
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+      }
 
-  .result {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-5);
-    background: var(--bg-input);
-    border: 1px dashed var(--border-strong);
-    border-radius: var(--radius-lg);
-  }
+      .field select:focus,
+      .field input:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+        box-shadow: 0 0 0 3px var(--glow-cyan);
+      }
 
-  .result .id {
-    flex: 1;
-    min-width: 0;
-    font-family: var(--font-mono);
-    font-size: 19px;
-    font-weight: 700;
-    color: var(--accent-cyan);
-    word-break: break-all;
-    line-height: 1.4;
-  }
+      .result {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-5);
+        background: var(--bg-input);
+        border: 1px dashed var(--border-strong);
+        border-radius: var(--radius-lg);
+      }
 
-  #batchOutput {
-    width: 100%;
-    min-height: 200px;
-    padding: var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 14px;
-    line-height: 1.7;
-    color: var(--text-primary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    resize: vertical;
-  }
+      .result .id {
+        flex: 1;
+        min-width: 0;
+        font-family: var(--font-mono);
+        font-size: 19px;
+        font-weight: 700;
+        color: var(--accent-cyan);
+        word-break: break-all;
+        line-height: 1.4;
+      }
 
-  .actions {
-    display: flex;
-    gap: var(--space-3);
-    margin-top: var(--space-4);
-  }
+      #batchOutput {
+        width: 100%;
+        min-height: 200px;
+        padding: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 14px;
+        line-height: 1.7;
+        color: var(--text-primary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        resize: vertical;
+      }
 
-  .actions button {
-    padding: 12px 20px;
-    font-family: var(--font-sans);
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-primary);
-    background: var(--bg-card-hover);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-top: var(--space-4);
+      }
 
-  .actions button:hover {
-    transform: translateY(-1px);
-    border-color: var(--accent-cyan);
-  }
+      .actions button {
+        padding: 12px 20px;
+        font-family: var(--font-sans);
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        background: var(--bg-card-hover);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .actions button.primary {
-    flex: 1;
-    color: #06121a;
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .actions button:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent-cyan);
+      }
 
-  #status {
-    margin-top: var(--space-3);
-    min-height: 18px;
-    text-align: center;
-    font-size: 13px;
-    color: var(--accent-green);
-  }
+      .actions button.primary {
+        flex: 1;
+        color: #06121a;
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .info {
-    margin-top: var(--space-6);
-    display: grid;
-    gap: var(--space-3);
-  }
+      #status {
+        margin-top: var(--space-3);
+        min-height: 18px;
+        text-align: center;
+        font-size: 13px;
+        color: var(--accent-green);
+      }
 
-  .info-item {
-    padding: var(--space-4);
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-  }
+      .info {
+        margin-top: var(--space-6);
+        display: grid;
+        gap: var(--space-3);
+      }
 
-  .info-item h3 {
-    margin: 0 0 4px;
-    font-size: 14px;
-    font-weight: 700;
-    color: var(--accent-cyan);
-  }
+      .info-item {
+        padding: var(--space-4);
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+      }
 
-  .info-item p {
-    margin: 0;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--text-secondary);
-  }
+      .info-item h3 {
+        margin: 0 0 4px;
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--accent-cyan);
+      }
 
-  @media (max-width: 520px) {
-    .tool-wrap {
-      padding: 36px 14px 140px;
-    }
+      .info-item p {
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--text-secondary);
+      }
 
-    .tool-head h1 {
-      font-size: 24px;
-    }
+      @media (max-width: 520px) {
+        .tool-wrap {
+          padding: 36px 14px 140px;
+        }
 
-    .options {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--bg-card);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--accent-cyan);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+        .tool-head h1 {
+          font-size: 24px;
+        }
+
+        .options {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--bg-card);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--accent-cyan);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="tool-wrap">
-  <header class="tool-head">
-    <span class="tool-badge">生成工具</span>
-    <h1>UUID 生成器</h1>
-    <p>生成 UUID v4 / v7 与 ULID，加密级随机、纯本地运行</p>
-  </header>
+        <header class="tool-head">
+          <span class="tool-badge">生成工具</span>
+          <h1>UUID 生成器</h1>
+          <p>生成 UUID v4 / v7 与 ULID，加密级随机、纯本地运行</p>
+        </header>
 
-  <section class="panel">
-    <div class="panel-body">
-      <div class="options">
-        <div class="field">
-          <label for="idType">类型</label>
-          <select id="idType">
-            <option value="uuid4">UUID v4（随机）</option>
-            <option value="uuid7">UUID v7（时间有序）</option>
-            <option value="ulid">ULID（时间有序）</option>
-          </select>
-        </div>
-        <div class="field">
-          <label for="format">格式</label>
-          <select id="format">
-            <option value="lower">小写</option>
-            <option value="upper">大写</option>
-            <option value="nohyphen">无连字符</option>
-          </select>
-        </div>
-        <div class="field">
-          <label for="count">数量</label>
-          <input type="number" id="count" value="1" min="1" max="100">
-        </div>
-      </div>
+        <section class="panel">
+          <div class="panel-body">
+            <div class="options">
+              <div class="field">
+                <label for="idType">类型</label>
+                <select id="idType">
+                  <option value="uuid4">UUID v4（随机）</option>
+                  <option value="uuid7">UUID v7（时间有序）</option>
+                  <option value="ulid">ULID（时间有序）</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="format">格式</label>
+                <select id="format">
+                  <option value="lower">小写</option>
+                  <option value="upper">大写</option>
+                  <option value="nohyphen">无连字符</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="count">数量</label>
+                <input type="number" id="count" value="1" min="1" max="100" />
+              </div>
+            </div>
 
-      <div class="result" id="singleResult">
-        <span class="id" id="singleId">-</span>
-        <button class="tb-btn" type="button" id="btnCopySingle">复制</button>
-      </div>
+            <div class="result" id="singleResult">
+              <span class="id" id="singleId">-</span>
+              <button class="tb-btn" type="button" id="btnCopySingle">复制</button>
+            </div>
 
-      <textarea id="batchOutput" readonly="" style="display: none" aria-label="批量生成结果"></textarea>
+            <textarea
+              id="batchOutput"
+              readonly=""
+              style="display: none"
+              aria-label="批量生成结果"
+            ></textarea>
 
-      <div class="actions">
-        <button type="button" id="btnGenerate" class="primary">生成</button>
-        <button type="button" id="btnCopy">复制</button>
-        <button type="button" id="btnClear">清空</button>
-      </div>
-      <div id="status" role="status"></div>
+            <div class="actions">
+              <button type="button" id="btnGenerate" class="primary">生成</button>
+              <button type="button" id="btnCopy">复制</button>
+              <button type="button" id="btnClear">清空</button>
+            </div>
+            <div id="status" role="status"></div>
 
-      <div class="info">
-        <div class="info-item">
-          <h3>UUID v4</h3>
-          <p>
-            完全随机的 128 位标识符，格式 xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx，适合绝大多数场景。
-          </p>
-        </div>
-        <div class="info-item">
-          <h3>UUID v7</h3>
-          <p>前 48 位为毫秒时间戳，可按生成时间排序，适合用作数据库主键以减少索引碎片。</p>
-        </div>
-        <div class="info-item">
-          <h3>ULID</h3>
-          <p>26 字符 Crockford Base32 编码，时间有序、可排序且 URL 安全，比 UUID 更紧凑。</p>
-        </div>
-      </div>
+            <div class="info">
+              <div class="info-item">
+                <h3>UUID v4</h3>
+                <p>
+                  完全随机的 128 位标识符，格式
+                  xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx，适合绝大多数场景。
+                </p>
+              </div>
+              <div class="info-item">
+                <h3>UUID v7</h3>
+                <p>前 48 位为毫秒时间戳，可按生成时间排序，适合用作数据库主键以减少索引碎片。</p>
+              </div>
+              <div class="info-item">
+                <h3>ULID</h3>
+                <p>26 字符 Crockford Base32 编码，时间有序、可排序且 URL 安全，比 UUID 更紧凑。</p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>UUID 生成器安全吗？生成的 UUID 会发送到服务器吗？</summary>
+            <p>
+              完全安全。所有 UUID 和 ULID 均在你的浏览器本地生成，使用 Web Crypto API
+              的加密级随机数，生成结果不会发送到任何服务器。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>UUID v4、UUID v7 和 ULID 有什么区别？我该选哪种？</summary>
+            <p>
+              UUID v4 完全随机，适合绝大多数场景；UUID v7 前 48
+              位为毫秒时间戳，可按时间排序，适合数据库主键以减少索引碎片；ULID 同样时间有序，采用 26
+              字符 Base32 编码，比 UUID 更紧凑且 URL 安全。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>生成的 UUID 会重复吗？</summary>
+            <p>
+              UUID v4 有 2^122 种可能值，碰撞概率极低，实际使用中可视为唯一。UUID v7 和 ULID
+              结合时间戳与随机部分，在同一毫秒内也极难碰撞。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何批量生成多个 UUID？</summary>
+            <p>
+              在「数量」输入框中填入 2 到 100
+              之间的数字，点击「生成」按钮，工具会在文本区域中输出对应数量的
+              UUID，每行一个，可一键复制全部。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>UUID 生成器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成 UUID 和
+              ULID，无需安装或注册。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </section>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>UUID 生成器安全吗？生成的 UUID 会发送到服务器吗？</summary>
-      <p>
-        完全安全。所有 UUID 和 ULID 均在你的浏览器本地生成，使用 Web Crypto API
-        的加密级随机数，生成结果不会发送到任何服务器。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>UUID v4、UUID v7 和 ULID 有什么区别？我该选哪种？</summary>
-      <p>
-        UUID v4 完全随机，适合绝大多数场景；UUID v7 前 48
-        位为毫秒时间戳，可按时间排序，适合数据库主键以减少索引碎片；ULID 同样时间有序，采用 26 字符
-        Base32 编码，比 UUID 更紧凑且 URL 安全。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>生成的 UUID 会重复吗？</summary>
-      <p>
-        UUID v4 有 2^122 种可能值，碰撞概率极低，实际使用中可视为唯一。UUID v7 和 ULID
-        结合时间戳与随机部分，在同一毫秒内也极难碰撞。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何批量生成多个 UUID？</summary>
-      <p>
-        在「数量」输入框中填入 2 到 100
-        之间的数字，点击「生成」按钮，工具会在文本区域中输出对应数量的
-        UUID，每行一个，可一键复制全部。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>UUID 生成器可以离线使用吗？</summary>
-      <p>
-        可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成 UUID 和
-        ULID，无需安装或注册。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "生成工具",
-              "item": "https://tools.realtime-ai.chat/#generator"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "UUID 生成器",
-              "item": "https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "生成工具",
+            "item": "https://tools.realtime-ai.chat/#generator"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "UUID 生成器",
+            "item": "https://tools.realtime-ai.chat/tools/generator/uuid-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "UUID 生成器安全吗？生成的 UUID 会发送到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 UUID 和 ULID 均在你的浏览器本地生成，使用 Web Crypto API 的加密级随机数，生成结果不会发送到任何服务器。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "UUID v4、UUID v7 和 ULID 有什么区别？我该选哪种？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "UUID v4 完全随机，适合绝大多数场景；UUID v7 前 48 位为毫秒时间戳，可按时间排序，适合数据库主键以减少索引碎片；ULID 同样时间有序，采用 26 字符 Base32 编码，比 UUID 更紧凑且 URL 安全。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "生成的 UUID 会重复吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "UUID v4 有 2^122 种可能值，碰撞概率极低，实际使用中可视为唯一。UUID v7 和 ULID 结合时间戳与随机部分，在同一毫秒内也极难碰撞。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何批量生成多个 UUID？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "在「数量」输入框中填入 2 到 100 之间的数字，点击「生成」按钮，工具会在文本区域中输出对应数量的 UUID，每行一个，可一键复制全部。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "UUID 生成器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成 UUID 和 ULID，无需安装或注册。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "UUID 生成器安全吗？生成的 UUID 会发送到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 UUID 和 ULID 均在你的浏览器本地生成，使用 Web Crypto API 的加密级随机数，生成结果不会发送到任何服务器。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "UUID v4、UUID v7 和 ULID 有什么区别？我该选哪种？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "UUID v4 完全随机，适合绝大多数场景；UUID v7 前 48 位为毫秒时间戳，可按时间排序，适合数据库主键以减少索引碎片；ULID 同样时间有序，采用 26 字符 Base32 编码，比 UUID 更紧凑且 URL 安全。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "生成的 UUID 会重复吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "UUID v4 有 2^122 种可能值，碰撞概率极低，实际使用中可视为唯一。UUID v7 和 ULID 结合时间戳与随机部分，在同一毫秒内也极难碰撞。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何批量生成多个 UUID？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "在「数量」输入框中填入 2 到 100 之间的数字，点击「生成」按钮，工具会在文本区域中输出对应数量的 UUID，每行一个，可一键复制全部。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "UUID 生成器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常生成 UUID 和 ULID，无需安装或注册。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
+      (function () {
+        var idTypeEl = document.getElementById("idType");
+        var formatEl = document.getElementById("format");
+        var countEl = document.getElementById("count");
+        var singleResultEl = document.getElementById("singleResult");
+        var singleIdEl = document.getElementById("singleId");
+        var batchOutputEl = document.getElementById("batchOutput");
+        var statusEl = document.getElementById("status");
+        var ULID_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+        var statusTimer;
 
-  (function () {
-          var idTypeEl = document.getElementById("idType");
-          var formatEl = document.getElementById("format");
-          var countEl = document.getElementById("count");
-          var singleResultEl = document.getElementById("singleResult");
-          var singleIdEl = document.getElementById("singleId");
-          var batchOutputEl = document.getElementById("batchOutput");
-          var statusEl = document.getElementById("status");
-          var ULID_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-          var statusTimer;
+        function randomBytes(n) {
+          var b = new Uint8Array(n);
+          crypto.getRandomValues(b);
+          return b;
+        }
 
-          function randomBytes(n) {
-            var b = new Uint8Array(n);
-            crypto.getRandomValues(b);
-            return b;
+        function bytesToUuid(bytes) {
+          var hex = Array.prototype.map
+            .call(bytes, function (b) {
+              return b.toString(16).padStart(2, "0");
+            })
+            .join("");
+          return (
+            hex.slice(0, 8) +
+            "-" +
+            hex.slice(8, 12) +
+            "-" +
+            hex.slice(12, 16) +
+            "-" +
+            hex.slice(16, 20) +
+            "-" +
+            hex.slice(20)
+          );
+        }
+
+        function uuidV4() {
+          var b = randomBytes(16);
+          b[6] = (b[6] & 0x0f) | 0x40;
+          b[8] = (b[8] & 0x3f) | 0x80;
+          return bytesToUuid(b);
+        }
+
+        function uuidV7() {
+          var now = Date.now();
+          var b = randomBytes(16);
+          b[0] = Math.floor(now / 0x10000000000) & 0xff;
+          b[1] = Math.floor(now / 0x100000000) & 0xff;
+          b[2] = Math.floor(now / 0x1000000) & 0xff;
+          b[3] = Math.floor(now / 0x10000) & 0xff;
+          b[4] = Math.floor(now / 0x100) & 0xff;
+          b[5] = now & 0xff;
+          b[6] = (b[6] & 0x0f) | 0x70;
+          b[8] = (b[8] & 0x3f) | 0x80;
+          return bytesToUuid(b);
+        }
+
+        function ulid() {
+          var t = Date.now();
+          var time = "";
+          for (var i = 0; i < 10; i++) {
+            time = ULID_CHARS[t % 32] + time;
+            t = Math.floor(t / 32);
           }
-
-          function bytesToUuid(bytes) {
-            var hex = Array.prototype.map
-              .call(bytes, function (b) {
-                return b.toString(16).padStart(2, "0");
-              })
-              .join("");
-            return (
-              hex.slice(0, 8) +
-              "-" +
-              hex.slice(8, 12) +
-              "-" +
-              hex.slice(12, 16) +
-              "-" +
-              hex.slice(16, 20) +
-              "-" +
-              hex.slice(20)
-            );
+          var rand = "";
+          var b = randomBytes(16);
+          for (var j = 0; j < 16; j++) {
+            rand += ULID_CHARS[b[j] & 0x1f];
           }
+          return time + rand;
+        }
 
-          function uuidV4() {
-            var b = randomBytes(16);
-            b[6] = (b[6] & 0x0f) | 0x40;
-            b[8] = (b[8] & 0x3f) | 0x80;
-            return bytesToUuid(b);
+        function formatId(id, type) {
+          var fmt = formatEl.value;
+          if (type === "ulid") {
+            return fmt === "upper" ? id : id.toLowerCase();
           }
+          if (fmt === "upper") return id.toUpperCase();
+          if (fmt === "nohyphen") return id.replace(/-/g, "");
+          return id;
+        }
 
-          function uuidV7() {
-            var now = Date.now();
-            var b = randomBytes(16);
-            b[0] = Math.floor(now / 0x10000000000) & 0xff;
-            b[1] = Math.floor(now / 0x100000000) & 0xff;
-            b[2] = Math.floor(now / 0x1000000) & 0xff;
-            b[3] = Math.floor(now / 0x10000) & 0xff;
-            b[4] = Math.floor(now / 0x100) & 0xff;
-            b[5] = now & 0xff;
-            b[6] = (b[6] & 0x0f) | 0x70;
-            b[8] = (b[8] & 0x3f) | 0x80;
-            return bytesToUuid(b);
-          }
+        function makeOne() {
+          var type = idTypeEl.value;
+          var raw = type === "uuid7" ? uuidV7() : type === "ulid" ? ulid() : uuidV4();
+          return formatId(raw, type);
+        }
 
-          function ulid() {
-            var t = Date.now();
-            var time = "";
-            for (var i = 0; i < 10; i++) {
-              time = ULID_CHARS[t % 32] + time;
-              t = Math.floor(t / 32);
-            }
-            var rand = "";
-            var b = randomBytes(16);
-            for (var j = 0; j < 16; j++) {
-              rand += ULID_CHARS[b[j] & 0x1f];
-            }
-            return time + rand;
-          }
+        function flash(msg, ok) {
+          statusEl.textContent = msg;
+          statusEl.style.color = ok === false ? "var(--accent-red)" : "var(--accent-green)";
+          clearTimeout(statusTimer);
+          statusTimer = setTimeout(function () {
+            statusEl.textContent = "";
+          }, 2200);
+        }
 
-          function formatId(id, type) {
-            var fmt = formatEl.value;
-            if (type === "ulid") {
-              return fmt === "upper" ? id : id.toLowerCase();
-            }
-            if (fmt === "upper") return id.toUpperCase();
-            if (fmt === "nohyphen") return id.replace(/-/g, "");
-            return id;
-          }
-
-          function makeOne() {
-            var type = idTypeEl.value;
-            var raw = type === "uuid7" ? uuidV7() : type === "ulid" ? ulid() : uuidV4();
-            return formatId(raw, type);
-          }
-
-          function flash(msg, ok) {
-            statusEl.textContent = msg;
-            statusEl.style.color = ok === false ? "var(--accent-red)" : "var(--accent-green)";
-            clearTimeout(statusTimer);
-            statusTimer = setTimeout(function () {
-              statusEl.textContent = "";
-            }, 2200);
-          }
-
-          function generate() {
-            var n = Math.min(Math.max(parseInt(countEl.value, 10) || 1, 1), 100);
-            countEl.value = n;
-            if (n === 1) {
-              singleIdEl.textContent = makeOne();
-              singleResultEl.style.display = "flex";
-              batchOutputEl.style.display = "none";
-            } else {
-              var ids = [];
-              for (var i = 0; i < n; i++) {
-                ids.push(makeOne());
-              }
-              batchOutputEl.value = ids.join("\n");
-              singleResultEl.style.display = "none";
-              batchOutputEl.style.display = "block";
-            }
-          }
-
-          function copy(text) {
-            if (!text || text === "-") return;
-            navigator.clipboard.writeText(text).then(
-              function () {
-                flash("✓ 已复制到剪贴板");
-              },
-              function () {
-                flash("复制失败，请手动选择", false);
-              }
-            );
-          }
-
-          document.getElementById("btnGenerate").addEventListener("click", generate);
-          idTypeEl.addEventListener("change", generate);
-          formatEl.addEventListener("change", generate);
-
-          document.getElementById("btnCopySingle").addEventListener("click", function () {
-            copy(singleIdEl.textContent);
-          });
-
-          document.getElementById("btnCopy").addEventListener("click", function () {
-            copy(
-              batchOutputEl.style.display !== "none" ? batchOutputEl.value : singleIdEl.textContent
-            );
-          });
-
-          document.getElementById("btnClear").addEventListener("click", function () {
-            singleIdEl.textContent = "-";
-            batchOutputEl.value = "";
-            batchOutputEl.style.display = "none";
+        function generate() {
+          var n = Math.min(Math.max(parseInt(countEl.value, 10) || 1, 1), 100);
+          countEl.value = n;
+          if (n === 1) {
+            singleIdEl.textContent = makeOne();
             singleResultEl.style.display = "flex";
-            flash("已清空");
-          });
+            batchOutputEl.style.display = "none";
+          } else {
+            var ids = [];
+            for (var i = 0; i < n; i++) {
+              ids.push(makeOne());
+            }
+            batchOutputEl.value = ids.join("\n");
+            singleResultEl.style.display = "none";
+            batchOutputEl.style.display = "block";
+          }
+        }
 
-          generate();
-        })();
-</script>
-    
+        function copy(text) {
+          if (!text || text === "-") return;
+          navigator.clipboard.writeText(text).then(
+            function () {
+              flash("✓ 已复制到剪贴板");
+            },
+            function () {
+              flash("复制失败，请手动选择", false);
+            }
+          );
+        }
+
+        document.getElementById("btnGenerate").addEventListener("click", generate);
+        idTypeEl.addEventListener("change", generate);
+        formatEl.addEventListener("change", generate);
+
+        document.getElementById("btnCopySingle").addEventListener("click", function () {
+          copy(singleIdEl.textContent);
+        });
+
+        document.getElementById("btnCopy").addEventListener("click", function () {
+          copy(
+            batchOutputEl.style.display !== "none" ? batchOutputEl.value : singleIdEl.textContent
+          );
+        });
+
+        document.getElementById("btnClear").addEventListener("click", function () {
+          singleIdEl.textContent = "-";
+          batchOutputEl.value = "";
+          batchOutputEl.style.display = "none";
+          singleResultEl.style.display = "flex";
+          flash("已清空");
+        });
+
+        generate();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/health/heart-rate-zone.html
+++ b/tools/health/heart-rate-zone.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="心率区间计算器 - WebUtils" />
     <meta property="og:description" content="计算运动心率区间" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "医疗健康",
-      "item": "https://tools.realtime-ai.chat/tools/health/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "心率区间计算器",
-      "item": "https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "医疗健康",
+            "item": "https://tools.realtime-ai.chat/tools/health/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "心率区间计算器",
+            "item": "https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "心率区间计算器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "心率区间计算器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,905 +91,922 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg: #0a0a0f;
-    --card: #12121a;
-    --border: #2a2a3a;
-    --text: #fff;
-    --text2: #888;
-    --accent: #ef4444;
-    --accent2: #f97316;
-  }
-  body {
-    font-family:
-      system-ui,
-      -apple-system,
-      sans-serif;
-    font-size: 16px;
-    line-height: 1.6;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .container {
-    max-width: 900px;
-    margin: 0 auto;
-  }
-  h1 {
-    text-align: center;
-    margin-bottom: 8px;
-    font-size: 1.8rem;
-  }
-  .subtitle {
-    text-align: center;
-    color: var(--text-secondary);
-    margin-bottom: 24px;
-  }
-  .grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-  }
-  @media (max-width: 768px) {
-    .grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  .card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 20px;
-  }
-  .card-title {
-    font-size: 1rem;
-    color: var(--text-secondary);
-    margin-bottom: 16px;
-  }
-  .form-group {
-    margin-bottom: 16px;
-  }
-  .form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-  }
-  input,
-  select {
-    width: 100%;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    font-size: 1rem;
-  }
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-  }
-  .result-hero {
-    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
-    padding: 28px;
-    border-radius: 12px;
-    text-align: center;
-    color: white;
-    margin-bottom: 20px;
-  }
-  .result-hero .label {
-    opacity: 0.9;
-    margin-bottom: 4px;
-  }
-  .result-hero .big {
-    font-size: 3rem;
-    font-weight: 700;
-  }
-  .result-hero .unit {
-    font-size: 1rem;
-    opacity: 0.8;
-  }
-  .result-hero .sub {
-    margin-top: 8px;
-    font-size: 0.9rem;
-    opacity: 0.9;
-  }
-  .stats {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-    margin-top: 16px;
-  }
-  .stat {
-    background: rgba(255, 255, 255, 0.15);
-    padding: 12px;
-    border-radius: 8px;
-    text-align: center;
-  }
-  .stat .value {
-    font-size: 1.3rem;
-    font-weight: 600;
-  }
-  .stat .label {
-    font-size: 0.75rem;
-    opacity: 0.8;
-    margin-top: 4px;
-  }
-  .zone {
-    padding: 16px;
-    border-radius: 12px;
-    margin-bottom: 12px;
-    color: white;
-    cursor: pointer;
-    transition: transform 0.2s;
-  }
-  .zone:hover {
-    transform: translateX(4px);
-  }
-  .zone-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 8px;
-  }
-  .zone-name {
-    font-weight: 600;
-    font-size: 1.1rem;
-  }
-  .zone-range {
-    font-size: 1.2rem;
-    font-weight: 700;
-  }
-  .zone-percent {
-    font-size: 0.85rem;
-    opacity: 0.9;
-  }
-  .zone-desc {
-    font-size: 0.85rem;
-    opacity: 0.9;
-    margin-top: 8px;
-  }
-  .zone-bar {
-    height: 6px;
-    background: rgba(255, 255, 255, 0.3);
-    border-radius: 3px;
-    margin-top: 8px;
-    overflow: hidden;
-  }
-  .zone-bar-fill {
-    height: 100%;
-    background: white;
-    border-radius: 3px;
-  }
-  .zone1 {
-    background: linear-gradient(135deg, #94a3b8, #64748b);
-  }
-  .zone2 {
-    background: linear-gradient(135deg, #3b82f6, #2563eb);
-  }
-  .zone3 {
-    background: linear-gradient(135deg, #22c55e, #16a34a);
-  }
-  .zone4 {
-    background: linear-gradient(135deg, #f97316, #ea580c);
-  }
-  .zone5 {
-    background: linear-gradient(135deg, #ef4444, #dc2626);
-  }
-  .result-row {
-    display: flex;
-    justify-content: space-between;
-    padding: 12px;
-    background: var(--bg-deep);
-    border-radius: 8px;
-    margin-bottom: 8px;
-  }
-  .result-row .label {
-    color: var(--text-secondary);
-  }
-  .result-row .value {
-    font-weight: 600;
-  }
-  .current-hr {
-    margin-top: 20px;
-    padding: 16px;
-    background: var(--bg-deep);
-    border-radius: 12px;
-  }
-  .current-hr input {
-    font-size: 1.5rem;
-    text-align: center;
-    font-weight: 600;
-  }
-  .current-zone {
-    margin-top: 12px;
-    padding: 12px;
-    border-radius: 8px;
-    text-align: center;
-    font-weight: 600;
-  }
-  .tips {
-    margin-top: 16px;
-  }
-  .tip {
-    padding: 12px;
-    background: var(--bg-deep);
-    border-radius: 8px;
-    margin-bottom: 8px;
-    font-size: 0.9rem;
-  }
-  .tip-title {
-    font-weight: 600;
-    color: var(--accent-cyan);
-    margin-bottom: 4px;
-  }
-  .note {
-    margin-top: 16px;
-    padding: 12px;
-    background: var(--bg-deep);
-    border-radius: 8px;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-  }
-  .back-link {
-    display: inline-block;
-    margin-bottom: 16px;
-    color: var(--accent-cyan);
-    text-decoration: none;
-    font-size: 0.9rem;
-  }
-  .back-link:hover {
-    text-decoration: underline;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0a0f;
+        --card: #12121a;
+        --border: #2a2a3a;
+        --text: #fff;
+        --text2: #888;
+        --accent: #ef4444;
+        --accent2: #f97316;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        min-height: 100vh;
+        padding: 20px;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 8px;
+        font-size: 1.8rem;
+      }
+      .subtitle {
+        text-align: center;
+        color: var(--text-secondary);
+        margin-bottom: 24px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      @media (max-width: 768px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 24px;
+        margin-bottom: 20px;
+      }
+      .card-title {
+        font-size: 1rem;
+        color: var(--text-secondary);
+        margin-bottom: 16px;
+      }
+      .form-group {
+        margin-bottom: 16px;
+      }
+      .form-group label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+      }
+      input,
+      select {
+        width: 100%;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+      }
+      .result-hero {
+        background: linear-gradient(135deg, var(--accent-cyan), var(--accent-magenta));
+        padding: 28px;
+        border-radius: 12px;
+        text-align: center;
+        color: white;
+        margin-bottom: 20px;
+      }
+      .result-hero .label {
+        opacity: 0.9;
+        margin-bottom: 4px;
+      }
+      .result-hero .big {
+        font-size: 3rem;
+        font-weight: 700;
+      }
+      .result-hero .unit {
+        font-size: 1rem;
+        opacity: 0.8;
+      }
+      .result-hero .sub {
+        margin-top: 8px;
+        font-size: 0.9rem;
+        opacity: 0.9;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .stat {
+        background: rgba(255, 255, 255, 0.15);
+        padding: 12px;
+        border-radius: 8px;
+        text-align: center;
+      }
+      .stat .value {
+        font-size: 1.3rem;
+        font-weight: 600;
+      }
+      .stat .label {
+        font-size: 0.75rem;
+        opacity: 0.8;
+        margin-top: 4px;
+      }
+      .zone {
+        padding: 16px;
+        border-radius: 12px;
+        margin-bottom: 12px;
+        color: white;
+        cursor: pointer;
+        transition: transform 0.2s;
+      }
+      .zone:hover {
+        transform: translateX(4px);
+      }
+      .zone-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+      }
+      .zone-name {
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+      .zone-range {
+        font-size: 1.2rem;
+        font-weight: 700;
+      }
+      .zone-percent {
+        font-size: 0.85rem;
+        opacity: 0.9;
+      }
+      .zone-desc {
+        font-size: 0.85rem;
+        opacity: 0.9;
+        margin-top: 8px;
+      }
+      .zone-bar {
+        height: 6px;
+        background: rgba(255, 255, 255, 0.3);
+        border-radius: 3px;
+        margin-top: 8px;
+        overflow: hidden;
+      }
+      .zone-bar-fill {
+        height: 100%;
+        background: white;
+        border-radius: 3px;
+      }
+      .zone1 {
+        background: linear-gradient(135deg, #94a3b8, #64748b);
+      }
+      .zone2 {
+        background: linear-gradient(135deg, #3b82f6, #2563eb);
+      }
+      .zone3 {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+      }
+      .zone4 {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+      }
+      .zone5 {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+      }
+      .result-row {
+        display: flex;
+        justify-content: space-between;
+        padding: 12px;
+        background: var(--bg-deep);
+        border-radius: 8px;
+        margin-bottom: 8px;
+      }
+      .result-row .label {
+        color: var(--text-secondary);
+      }
+      .result-row .value {
+        font-weight: 600;
+      }
+      .current-hr {
+        margin-top: 20px;
+        padding: 16px;
+        background: var(--bg-deep);
+        border-radius: 12px;
+      }
+      .current-hr input {
+        font-size: 1.5rem;
+        text-align: center;
+        font-weight: 600;
+      }
+      .current-zone {
+        margin-top: 12px;
+        padding: 12px;
+        border-radius: 8px;
+        text-align: center;
+        font-weight: 600;
+      }
+      .tips {
+        margin-top: 16px;
+      }
+      .tip {
+        padding: 12px;
+        background: var(--bg-deep);
+        border-radius: 8px;
+        margin-bottom: 8px;
+        font-size: 0.9rem;
+      }
+      .tip-title {
+        font-weight: 600;
+        color: var(--accent-cyan);
+        margin-bottom: 4px;
+      }
+      .note {
+        margin-top: 16px;
+        padding: 12px;
+        background: var(--bg-deep);
+        border-radius: 8px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+      .back-link {
+        display: inline-block;
+        margin-bottom: 16px;
+        color: var(--accent-cyan);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        text-decoration: underline;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <a href="../../index.html" class="back-link">← 返回</a>
-  <h1>心率区间计算器</h1>
-  <p class="subtitle">了解运动强度，优化训练效果</p>
+        <a href="../../index.html" class="back-link">← 返回</a>
+        <h1>心率区间计算器</h1>
+        <p class="subtitle">了解运动强度，优化训练效果</p>
 
-  <div class="grid">
-    <div class="card">
-      <div class="card-title">基本信息</div>
-      <div class="form-group">
-        <label>年龄 (岁)</label>
-        <input type="number" id="age" value="25" min="10" max="100" oninput="calculate()">
-      </div>
-      <div class="form-group">
-        <label>静息心率 (次/分钟, 可选)</label>
-        <input type="number" id="restingHR" placeholder="留空使用标准公式" min="40" max="100" oninput="calculate()">
-      </div>
-      <div class="form-group">
-        <label>计算方法</label>
-        <select id="method" onchange="calculate()">
-          <option value="standard">标准公式 (220-年龄)</option>
-          <option value="tanaka">Tanaka公式 (208-0.7×年龄)</option>
-          <option value="karvonen">Karvonen公式 (需静息心率)</option>
-        </select>
-      </div>
+        <div class="grid">
+          <div class="card">
+            <div class="card-title">基本信息</div>
+            <div class="form-group">
+              <label>年龄 (岁)</label>
+              <input type="number" id="age" value="25" min="10" max="100" oninput="calculate()" />
+            </div>
+            <div class="form-group">
+              <label>静息心率 (次/分钟, 可选)</label>
+              <input
+                type="number"
+                id="restingHR"
+                placeholder="留空使用标准公式"
+                min="40"
+                max="100"
+                oninput="calculate()"
+              />
+            </div>
+            <div class="form-group">
+              <label>计算方法</label>
+              <select id="method" onchange="calculate()">
+                <option value="standard">标准公式 (220-年龄)</option>
+                <option value="tanaka">Tanaka公式 (208-0.7×年龄)</option>
+                <option value="karvonen">Karvonen公式 (需静息心率)</option>
+              </select>
+            </div>
 
-      <div class="current-hr">
-        <div class="card-title">当前心率检测</div>
-        <input type="number" id="currentHR" placeholder="输入当前心率" min="40" max="220" oninput="checkCurrentZone()">
-        <div class="current-zone" id="currentZone" style="display: none"></div>
-      </div>
+            <div class="current-hr">
+              <div class="card-title">当前心率检测</div>
+              <input
+                type="number"
+                id="currentHR"
+                placeholder="输入当前心率"
+                min="40"
+                max="220"
+                oninput="checkCurrentZone()"
+              />
+              <div class="current-zone" id="currentZone" style="display: none"></div>
+            </div>
 
-      <div class="card-title" style="margin-top: 20px">心率信息</div>
-      <div class="result-row">
-        <span class="label">最大心率</span>
-        <span class="value" id="maxHR">0 bpm</span>
-      </div>
-      <div class="result-row">
-        <span class="label">静息心率</span>
-        <span class="value" id="restHR">- bpm</span>
-      </div>
-      <div class="result-row">
-        <span class="label">心率储备</span>
-        <span class="value" id="hrReserve">- bpm</span>
-      </div>
-    </div>
-
-    <div>
-      <div class="result-hero">
-        <div class="label">最大心率</div>
-        <div class="big">
-          <span id="maxHRBig">0</span>
-          <span class="unit">bpm</span>
-        </div>
-        <div class="sub">次/分钟</div>
-        <div class="stats">
-          <div class="stat">
-            <div class="value" id="fatBurnRange">0-0</div>
-            <div class="label">燃脂区间</div>
+            <div class="card-title" style="margin-top: 20px">心率信息</div>
+            <div class="result-row">
+              <span class="label">最大心率</span>
+              <span class="value" id="maxHR">0 bpm</span>
+            </div>
+            <div class="result-row">
+              <span class="label">静息心率</span>
+              <span class="value" id="restHR">- bpm</span>
+            </div>
+            <div class="result-row">
+              <span class="label">心率储备</span>
+              <span class="value" id="hrReserve">- bpm</span>
+            </div>
           </div>
-          <div class="stat">
-            <div class="value" id="cardioRange">0-0</div>
-            <div class="label">有氧区间</div>
+
+          <div>
+            <div class="result-hero">
+              <div class="label">最大心率</div>
+              <div class="big">
+                <span id="maxHRBig">0</span>
+                <span class="unit">bpm</span>
+              </div>
+              <div class="sub">次/分钟</div>
+              <div class="stats">
+                <div class="stat">
+                  <div class="value" id="fatBurnRange">0-0</div>
+                  <div class="label">燃脂区间</div>
+                </div>
+                <div class="stat">
+                  <div class="value" id="cardioRange">0-0</div>
+                  <div class="label">有氧区间</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-title">心率训练区间</div>
+              <div id="zones"></div>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="card">
-        <div class="card-title">心率训练区间</div>
-        <div id="zones"></div>
+        <div class="card">
+          <div class="card-title">训练建议</div>
+          <div class="tips" id="tips"></div>
+        </div>
+
+        <div class="note">
+          心率区间计算仅供参考，实际最大心率因人而异。如有心脏疾病或其他健康问题，请在医生指导下进行运动。建议使用心率监测设备获取准确数据。
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="card">
-    <div class="card-title">训练建议</div>
-    <div class="tips" id="tips"></div>
-  </div>
-
-  <div class="note">
-    心率区间计算仅供参考，实际最大心率因人而异。如有心脏疾病或其他健康问题，请在医生指导下进行运动。建议使用心率监测设备获取准确数据。
-  </div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "健康工具",
-              "item": "https://tools.realtime-ai.chat/#health"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "心率区间计算器",
-              "item": "https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
-            }
-          ]
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "健康工具",
+            "item": "https://tools.realtime-ai.chat/#health"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "心率区间计算器",
+            "item": "https://tools.realtime-ai.chat/tools/health/heart-rate-zone.html"
+          }
+        ]
+      }
+    </script>
+    <script>
+      const zones = [
+        {
+          zone: 1,
+          name: "热身/恢复",
+          min: 50,
+          max: 60,
+          color: "zone1",
+          desc: "轻松活动，适合热身和恢复性训练",
+          benefit: "促进血液循环，帮助恢复"
+        },
+        {
+          zone: 2,
+          name: "燃脂区",
+          min: 60,
+          max: 70,
+          color: "zone2",
+          desc: "低强度有氧，最佳燃脂效率",
+          benefit: "脂肪燃烧最高效，适合长时间运动"
+        },
+        {
+          zone: 3,
+          name: "有氧区",
+          min: 70,
+          max: 80,
+          color: "zone3",
+          desc: "中等强度，提高心肺耐力",
+          benefit: "增强心肺功能，提高耐力"
+        },
+        {
+          zone: 4,
+          name: "无氧阈值",
+          min: 80,
+          max: 90,
+          color: "zone4",
+          desc: "高强度，提高乳酸阈值",
+          benefit: "提高运动表现，增加速度"
+        },
+        {
+          zone: 5,
+          name: "极限区",
+          min: 90,
+          max: 100,
+          color: "zone5",
+          desc: "最高强度，仅适合短时间冲刺",
+          benefit: "提高最大摄氧量，仅限短时间"
+        }
+      ];
+
+      let maxHR = 0;
+      let restingHR = 0;
+
+      function calculate() {
+        const age = parseFloat(document.getElementById("age").value) || 25;
+        const restHRInput = document.getElementById("restingHR").value;
+        const method = document.getElementById("method").value;
+
+        // 计算最大心率
+        if (method === "standard") {
+          maxHR = 220 - age;
+        } else if (method === "tanaka") {
+          maxHR = Math.round(208 - 0.7 * age);
+        } else if (method === "karvonen") {
+          maxHR = 220 - age;
         }
 
-  </script>
-    <script>
-  const zones = [
+        restingHR = restHRInput ? parseFloat(restHRInput) : 0;
+        const hrReserve = restingHR ? maxHR - restingHR : 0;
+
+        document.getElementById("maxHR").textContent = maxHR + " bpm";
+        document.getElementById("maxHRBig").textContent = maxHR;
+        document.getElementById("restHR").textContent = restingHR ? restingHR + " bpm" : "- bpm";
+        document.getElementById("hrReserve").textContent = hrReserve ? hrReserve + " bpm" : "- bpm";
+
+        // 燃脂和有氧区间
+        const fatBurnLow = calculateZoneHR(60);
+        const fatBurnHigh = calculateZoneHR(70);
+        const cardioLow = calculateZoneHR(70);
+        const cardioHigh = calculateZoneHR(85);
+
+        document.getElementById("fatBurnRange").textContent = fatBurnLow + "-" + fatBurnHigh;
+        document.getElementById("cardioRange").textContent = cardioLow + "-" + cardioHigh;
+
+        renderZones();
+        renderTips();
+        checkCurrentZone();
+      }
+
+      function calculateZoneHR(percent) {
+        const method = document.getElementById("method").value;
+
+        if (method === "karvonen" && restingHR) {
+          // Karvonen公式: 目标心率 = (最大心率 - 静息心率) × 强度% + 静息心率
+          return Math.round((maxHR - restingHR) * (percent / 100) + restingHR);
+        } else {
+          // 标准公式: 目标心率 = 最大心率 × 强度%
+          return Math.round((maxHR * percent) / 100);
+        }
+      }
+
+      function renderZones() {
+        const container = document.getElementById("zones");
+        container.textContent = "";
+
+        zones.forEach((zone) => {
+          const lowHR = calculateZoneHR(zone.min);
+          const highHR = calculateZoneHR(zone.max);
+
+          const div = document.createElement("div");
+          div.className = "zone " + zone.color;
+
+          const header = document.createElement("div");
+          header.className = "zone-header";
+
+          const left = document.createElement("div");
+          const name = document.createElement("div");
+          name.className = "zone-name";
+          name.textContent = "Zone " + zone.zone + " - " + zone.name;
+          const percent = document.createElement("div");
+          percent.className = "zone-percent";
+          percent.textContent = zone.min + "% - " + zone.max + "% 最大心率";
+          left.appendChild(name);
+          left.appendChild(percent);
+
+          const range = document.createElement("div");
+          range.className = "zone-range";
+          range.textContent = lowHR + " - " + highHR + " bpm";
+
+          header.appendChild(left);
+          header.appendChild(range);
+
+          const desc = document.createElement("div");
+          desc.className = "zone-desc";
+          desc.textContent = zone.desc;
+
+          const bar = document.createElement("div");
+          bar.className = "zone-bar";
+          const barFill = document.createElement("div");
+          barFill.className = "zone-bar-fill";
+          barFill.style.width = (zone.max - zone.min) * 2 + "%";
+          bar.appendChild(barFill);
+
+          div.appendChild(header);
+          div.appendChild(desc);
+          div.appendChild(bar);
+          container.appendChild(div);
+        });
+      }
+
+      function checkCurrentZone() {
+        const currentHR = parseFloat(document.getElementById("currentHR").value);
+        const zoneDiv = document.getElementById("currentZone");
+
+        if (!currentHR || currentHR < 40) {
+          zoneDiv.style.display = "none";
+          return;
+        }
+
+        zoneDiv.style.display = "block";
+
+        let currentZone = null;
+        for (const zone of zones) {
+          const lowHR = calculateZoneHR(zone.min);
+          const highHR = calculateZoneHR(zone.max);
+          if (currentHR >= lowHR && currentHR <= highHR) {
+            currentZone = zone;
+            break;
+          }
+        }
+
+        if (currentHR < calculateZoneHR(50)) {
+          zoneDiv.textContent = "心率较低，低于训练区间";
+          zoneDiv.style.background = "var(--border-subtle)";
+          zoneDiv.style.color = "var(--text-primary)";
+        } else if (currentHR > calculateZoneHR(100)) {
+          zoneDiv.textContent = "心率过高，请注意休息！";
+          zoneDiv.style.background = "#ef4444";
+          zoneDiv.style.color = "white";
+        } else if (currentZone) {
+          zoneDiv.textContent = "当前处于 Zone " + currentZone.zone + " - " + currentZone.name;
+          const colors = {
+            zone1: "#64748b",
+            zone2: "#2563eb",
+            zone3: "#16a34a",
+            zone4: "#ea580c",
+            zone5: "#dc2626"
+          };
+          zoneDiv.style.background = colors[currentZone.color];
+          zoneDiv.style.color = "white";
+        }
+      }
+
+      function renderTips() {
+        const container = document.getElementById("tips");
+        container.textContent = "";
+
+        const tips = [
           {
-            zone: 1,
-            name: "热身/恢复",
-            min: 50,
-            max: 60,
-            color: "zone1",
-            desc: "轻松活动，适合热身和恢复性训练",
-            benefit: "促进血液循环，帮助恢复"
+            title: "减脂训练",
+            text: "在Zone 2（燃脂区）进行30-60分钟的低强度有氧运动，如慢跑、快走、骑车，燃脂效率最高。"
           },
           {
-            zone: 2,
-            name: "燃脂区",
-            min: 60,
-            max: 70,
-            color: "zone2",
-            desc: "低强度有氧，最佳燃脂效率",
-            benefit: "脂肪燃烧最高效，适合长时间运动"
+            title: "心肺耐力",
+            text: "在Zone 3（有氧区）进行训练，每周3-5次，每次30-45分钟，有效提高心肺功能。"
           },
           {
-            zone: 3,
-            name: "有氧区",
-            min: 70,
-            max: 80,
-            color: "zone3",
-            desc: "中等强度，提高心肺耐力",
-            benefit: "增强心肺功能，提高耐力"
+            title: "间歇训练",
+            text: "在Zone 4-5进行高强度间歇训练（HIIT），短时间高强度配合恢复，提高运动表现。"
           },
           {
-            zone: 4,
-            name: "无氧阈值",
-            min: 80,
-            max: 90,
-            color: "zone4",
-            desc: "高强度，提高乳酸阈值",
-            benefit: "提高运动表现，增加速度"
-          },
-          {
-            zone: 5,
-            name: "极限区",
-            min: 90,
-            max: 100,
-            color: "zone5",
-            desc: "最高强度，仅适合短时间冲刺",
-            benefit: "提高最大摄氧量，仅限短时间"
+            title: "恢复训练",
+            text: "高强度训练后，在Zone 1进行恢复性运动，促进乳酸代谢，加速身体恢复。"
           }
         ];
 
-        let maxHR = 0;
-        let restingHR = 0;
+        tips.forEach((tip) => {
+          const div = document.createElement("div");
+          div.className = "tip";
 
-        function calculate() {
-          const age = parseFloat(document.getElementById("age").value) || 25;
-          const restHRInput = document.getElementById("restingHR").value;
-          const method = document.getElementById("method").value;
+          const title = document.createElement("div");
+          title.className = "tip-title";
+          title.textContent = tip.title;
 
-          // 计算最大心率
-          if (method === "standard") {
-            maxHR = 220 - age;
-          } else if (method === "tanaka") {
-            maxHR = Math.round(208 - 0.7 * age);
-          } else if (method === "karvonen") {
-            maxHR = 220 - age;
-          }
+          const text = document.createElement("div");
+          text.textContent = tip.text;
 
-          restingHR = restHRInput ? parseFloat(restHRInput) : 0;
-          const hrReserve = restingHR ? maxHR - restingHR : 0;
+          div.appendChild(title);
+          div.appendChild(text);
+          container.appendChild(div);
+        });
+      }
 
-          document.getElementById("maxHR").textContent = maxHR + " bpm";
-          document.getElementById("maxHRBig").textContent = maxHR;
-          document.getElementById("restHR").textContent = restingHR ? restingHR + " bpm" : "- bpm";
-          document.getElementById("hrReserve").textContent = hrReserve ? hrReserve + " bpm" : "- bpm";
+      calculate();
 
-          // 燃脂和有氧区间
-          const fatBurnLow = calculateZoneHR(60);
-          const fatBurnHigh = calculateZoneHR(70);
-          const cardioLow = calculateZoneHR(70);
-          const cardioHigh = calculateZoneHR(85);
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
 
-          document.getElementById("fatBurnRange").textContent = fatBurnLow + "-" + fatBurnHigh;
-          document.getElementById("cardioRange").textContent = cardioLow + "-" + cardioHigh;
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
 
-          renderZones();
-          renderTips();
-          checkCurrentZone();
-        }
-
-        function calculateZoneHR(percent) {
-          const method = document.getElementById("method").value;
-
-          if (method === "karvonen" && restingHR) {
-            // Karvonen公式: 目标心率 = (最大心率 - 静息心率) × 强度% + 静息心率
-            return Math.round((maxHR - restingHR) * (percent / 100) + restingHR);
-          } else {
-            // 标准公式: 目标心率 = 最大心率 × 强度%
-            return Math.round((maxHR * percent) / 100);
-          }
-        }
-
-        function renderZones() {
-          const container = document.getElementById("zones");
-          container.textContent = "";
-
-          zones.forEach((zone) => {
-            const lowHR = calculateZoneHR(zone.min);
-            const highHR = calculateZoneHR(zone.max);
-
-            const div = document.createElement("div");
-            div.className = "zone " + zone.color;
-
-            const header = document.createElement("div");
-            header.className = "zone-header";
-
-            const left = document.createElement("div");
-            const name = document.createElement("div");
-            name.className = "zone-name";
-            name.textContent = "Zone " + zone.zone + " - " + zone.name;
-            const percent = document.createElement("div");
-            percent.className = "zone-percent";
-            percent.textContent = zone.min + "% - " + zone.max + "% 最大心率";
-            left.appendChild(name);
-            left.appendChild(percent);
-
-            const range = document.createElement("div");
-            range.className = "zone-range";
-            range.textContent = lowHR + " - " + highHR + " bpm";
-
-            header.appendChild(left);
-            header.appendChild(range);
-
-            const desc = document.createElement("div");
-            desc.className = "zone-desc";
-            desc.textContent = zone.desc;
-
-            const bar = document.createElement("div");
-            bar.className = "zone-bar";
-            const barFill = document.createElement("div");
-            barFill.className = "zone-bar-fill";
-            barFill.style.width = (zone.max - zone.min) * 2 + "%";
-            bar.appendChild(barFill);
-
-            div.appendChild(header);
-            div.appendChild(desc);
-            div.appendChild(bar);
-            container.appendChild(div);
-          });
-        }
-
-        function checkCurrentZone() {
-          const currentHR = parseFloat(document.getElementById("currentHR").value);
-          const zoneDiv = document.getElementById("currentZone");
-
-          if (!currentHR || currentHR < 40) {
-            zoneDiv.style.display = "none";
-            return;
-          }
-
-          zoneDiv.style.display = "block";
-
-          let currentZone = null;
-          for (const zone of zones) {
-            const lowHR = calculateZoneHR(zone.min);
-            const highHR = calculateZoneHR(zone.max);
-            if (currentHR >= lowHR && currentHR <= highHR) {
-              currentZone = zone;
-              break;
-            }
-          }
-
-          if (currentHR < calculateZoneHR(50)) {
-            zoneDiv.textContent = "心率较低，低于训练区间";
-            zoneDiv.style.background = "var(--border-subtle)";
-            zoneDiv.style.color = "var(--text-primary)";
-          } else if (currentHR > calculateZoneHR(100)) {
-            zoneDiv.textContent = "心率过高，请注意休息！";
-            zoneDiv.style.background = "#ef4444";
-            zoneDiv.style.color = "white";
-          } else if (currentZone) {
-            zoneDiv.textContent = "当前处于 Zone " + currentZone.zone + " - " + currentZone.name;
-            const colors = {
-              zone1: "#64748b",
-              zone2: "#2563eb",
-              zone3: "#16a34a",
-              zone4: "#ea580c",
-              zone5: "#dc2626"
-            };
-            zoneDiv.style.background = colors[currentZone.color];
-            zoneDiv.style.color = "white";
-          }
-        }
-
-        function renderTips() {
-          const container = document.getElementById("tips");
-          container.textContent = "";
-
-          const tips = [
-            {
-              title: "减脂训练",
-              text: "在Zone 2（燃脂区）进行30-60分钟的低强度有氧运动，如慢跑、快走、骑车，燃脂效率最高。"
-            },
-            {
-              title: "心肺耐力",
-              text: "在Zone 3（有氧区）进行训练，每周3-5次，每次30-45分钟，有效提高心肺功能。"
-            },
-            {
-              title: "间歇训练",
-              text: "在Zone 4-5进行高强度间歇训练（HIIT），短时间高强度配合恢复，提高运动表现。"
-            },
-            {
-              title: "恢复训练",
-              text: "高强度训练后，在Zone 1进行恢复性运动，促进乳酸代谢，加速身体恢复。"
-            }
-          ];
-
-          tips.forEach((tip) => {
-            const div = document.createElement("div");
-            div.className = "tip";
-
-            const title = document.createElement("div");
-            title.className = "tip-title";
-            title.textContent = tip.title;
-
-            const text = document.createElement("div");
-            text.textContent = tip.text;
-
-            div.appendChild(title);
-            div.appendChild(text);
-            container.appendChild(div);
-          });
-        }
-
-        calculate();
-
-        // Theme toggle
-        function toggleTheme() {
-          const html = document.documentElement;
-          const currentTheme = html.getAttribute("data-theme");
-          const newTheme = currentTheme === "light" ? "dark" : "light";
-          html.setAttribute("data-theme", newTheme);
-          document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-          localStorage.setItem("theme", newTheme);
-        }
-
-        // Load saved theme
-        const savedTheme = localStorage.getItem("theme") || "dark";
-        if (savedTheme === "light") {
-          document.documentElement.setAttribute("data-theme", "light");
-          document.getElementById("theme-icon").textContent = "☀️";
-        }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/health/medication-reminder.html
+++ b/tools/health/medication-reminder.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="服药 提醒 药物 健康管理" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/health/medication-reminder.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/health/medication-reminder.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="服药提醒器 - WebUtils" />
     <meta property="og:description" content="药物管理和服药提醒" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/health/medication-reminder.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/health/medication-reminder.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "医疗健康",
-      "item": "https://tools.realtime-ai.chat/tools/health/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "服药提醒器",
-      "item": "https://tools.realtime-ai.chat/tools/health/medication-reminder.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "医疗健康",
+            "item": "https://tools.realtime-ai.chat/tools/health/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "服药提醒器",
+            "item": "https://tools.realtime-ai.chat/tools/health/medication-reminder.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "服药提醒器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "服药提醒器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,973 +94,985 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg: #0a0a0f;
-    --card: #12121a;
-    --border: #2a2a3a;
-    --text: #fff;
-    --text2: #888;
-    --accent: #6366f1;
-    --accent2: #8b5cf6;
-    --success: #22c55e;
-    --warning: #f59e0b;
-    --danger: #ef4444;
-  }
-  body {
-    font-family:
-      system-ui,
-      -apple-system,
-      sans-serif;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .container {
-    max-width: 900px;
-    margin: 0 auto;
-  }
-  h1 {
-    text-align: center;
-    margin-bottom: 8px;
-    font-size: 1.8rem;
-  }
-  .subtitle {
-    text-align: center;
-    color: var(--text-secondary);
-    margin-bottom: 24px;
-  }
-  .grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-  }
-  @media (max-width: 768px) {
-    .grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  .card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 20px;
-  }
-  .card-title {
-    font-size: 1rem;
-    color: var(--text-secondary);
-    margin-bottom: 16px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .form-group {
-    margin-bottom: 16px;
-  }
-  .form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-  }
-  input,
-  select,
-  textarea {
-    width: 100%;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    font-size: 1rem;
-  }
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-  }
-  textarea {
-    resize: vertical;
-    min-height: 60px;
-  }
-  button {
-    padding: 12px 24px;
-    border: none;
-    border-radius: 8px;
-    background: var(--accent-cyan);
-    color: white;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: opacity 0.2s;
-  }
-  button:hover {
-    opacity: 0.9;
-  }
-  button.secondary {
-    background: var(--border-subtle);
-    color: var(--text-primary);
-  }
-  button.danger {
-    background: var(--accent-red);
-  }
-  .time-slots {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    margin-top: 8px;
-  }
-  .time-slot {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 12px;
-    background: var(--bg-deep);
-    border-radius: 6px;
-  }
-  .time-slot input {
-    width: 80px;
-    padding: 6px;
-  }
-  .time-slot .remove {
-    background: none;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    padding: 4px;
-  }
-  .add-time {
-    padding: 6px 12px;
-    font-size: 0.9rem;
-  }
-  .med-list {
-    margin-top: 16px;
-  }
-  .med-item {
-    padding: 16px;
-    background: var(--bg-deep);
-    border-radius: 12px;
-    margin-bottom: 12px;
-    border-left: 4px solid var(--accent-cyan);
-  }
-  .med-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 8px;
-  }
-  .med-name {
-    font-weight: 600;
-    font-size: 1.1rem;
-  }
-  .med-actions {
-    display: flex;
-    gap: 8px;
-  }
-  .med-actions button {
-    padding: 6px 12px;
-    font-size: 0.8rem;
-  }
-  .med-details {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-  }
-  .med-times {
-    display: flex;
-    gap: 8px;
-    margin-top: 8px;
-    flex-wrap: wrap;
-  }
-  .med-time {
-    padding: 4px 10px;
-    background: var(--bg-card);
-    border-radius: 4px;
-    font-size: 0.85rem;
-  }
-  .today-section {
-    margin-top: 20px;
-  }
-  .reminder-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px;
-    background: var(--bg-deep);
-    border-radius: 12px;
-    margin-bottom: 12px;
-  }
-  .reminder-item.done {
-    opacity: 0.5;
-  }
-  .reminder-time {
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: var(--accent-cyan);
-    min-width: 60px;
-  }
-  .reminder-info {
-    flex: 1;
-  }
-  .reminder-name {
-    font-weight: 600;
-  }
-  .reminder-dose {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-  }
-  .reminder-check {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    border: 2px solid var(--border-subtle);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s;
-  }
-  .reminder-check.checked {
-    background: var(--accent-green);
-    border-color: var(--accent-green);
-    color: white;
-  }
-  .stats {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 12px;
-    margin-bottom: 20px;
-  }
-  .stat {
-    padding: 16px;
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 12px;
-    text-align: center;
-  }
-  .stat .value {
-    font-size: 1.8rem;
-    font-weight: 700;
-    color: var(--accent-cyan);
-  }
-  .stat .label {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    margin-top: 4px;
-  }
-  .empty-state {
-    text-align: center;
-    padding: 40px;
-    color: var(--text-secondary);
-  }
-  .modal {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.7);
-    z-index: 100;
-    align-items: center;
-    justify-content: center;
-  }
-  .modal.show {
-    display: flex;
-  }
-  .modal-content {
-    background: var(--bg-card);
-    border-radius: 16px;
-    padding: 24px;
-    max-width: 500px;
-    width: 90%;
-    max-height: 90vh;
-    overflow-y: auto;
-  }
-  .modal-title {
-    font-size: 1.2rem;
-    font-weight: 600;
-    margin-bottom: 16px;
-  }
-  .note {
-    margin-top: 16px;
-    padding: 12px;
-    background: var(--bg-deep);
-    border-radius: 8px;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-  }
-  .back-link {
-    display: inline-block;
-    margin-bottom: 16px;
-    color: var(--accent-cyan);
-    text-decoration: none;
-    font-size: 0.9rem;
-  }
-  .back-link:hover {
-    text-decoration: underline;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0a0f;
+        --card: #12121a;
+        --border: #2a2a3a;
+        --text: #fff;
+        --text2: #888;
+        --accent: #6366f1;
+        --accent2: #8b5cf6;
+        --success: #22c55e;
+        --warning: #f59e0b;
+        --danger: #ef4444;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        min-height: 100vh;
+        padding: 20px;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 8px;
+        font-size: 1.8rem;
+      }
+      .subtitle {
+        text-align: center;
+        color: var(--text-secondary);
+        margin-bottom: 24px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      @media (max-width: 768px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 24px;
+        margin-bottom: 20px;
+      }
+      .card-title {
+        font-size: 1rem;
+        color: var(--text-secondary);
+        margin-bottom: 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .form-group {
+        margin-bottom: 16px;
+      }
+      .form-group label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+      }
+      input,
+      select,
+      textarea {
+        width: 100%;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+      }
+      textarea {
+        resize: vertical;
+        min-height: 60px;
+      }
+      button {
+        padding: 12px 24px;
+        border: none;
+        border-radius: 8px;
+        background: var(--accent-cyan);
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: opacity 0.2s;
+      }
+      button:hover {
+        opacity: 0.9;
+      }
+      button.secondary {
+        background: var(--border-subtle);
+        color: var(--text-primary);
+      }
+      button.danger {
+        background: var(--accent-red);
+      }
+      .time-slots {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .time-slot {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 6px 12px;
+        background: var(--bg-deep);
+        border-radius: 6px;
+      }
+      .time-slot input {
+        width: 80px;
+        padding: 6px;
+      }
+      .time-slot .remove {
+        background: none;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        padding: 4px;
+      }
+      .add-time {
+        padding: 6px 12px;
+        font-size: 0.9rem;
+      }
+      .med-list {
+        margin-top: 16px;
+      }
+      .med-item {
+        padding: 16px;
+        background: var(--bg-deep);
+        border-radius: 12px;
+        margin-bottom: 12px;
+        border-left: 4px solid var(--accent-cyan);
+      }
+      .med-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 8px;
+      }
+      .med-name {
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+      .med-actions {
+        display: flex;
+        gap: 8px;
+      }
+      .med-actions button {
+        padding: 6px 12px;
+        font-size: 0.8rem;
+      }
+      .med-details {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+      }
+      .med-times {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+        flex-wrap: wrap;
+      }
+      .med-time {
+        padding: 4px 10px;
+        background: var(--bg-card);
+        border-radius: 4px;
+        font-size: 0.85rem;
+      }
+      .today-section {
+        margin-top: 20px;
+      }
+      .reminder-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 16px;
+        background: var(--bg-deep);
+        border-radius: 12px;
+        margin-bottom: 12px;
+      }
+      .reminder-item.done {
+        opacity: 0.5;
+      }
+      .reminder-time {
+        font-size: 1.3rem;
+        font-weight: 700;
+        color: var(--accent-cyan);
+        min-width: 60px;
+      }
+      .reminder-info {
+        flex: 1;
+      }
+      .reminder-name {
+        font-weight: 600;
+      }
+      .reminder-dose {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+      .reminder-check {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 2px solid var(--border-subtle);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s;
+      }
+      .reminder-check.checked {
+        background: var(--accent-green);
+        border-color: var(--accent-green);
+        color: white;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+        margin-bottom: 20px;
+      }
+      .stat {
+        padding: 16px;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        text-align: center;
+      }
+      .stat .value {
+        font-size: 1.8rem;
+        font-weight: 700;
+        color: var(--accent-cyan);
+      }
+      .stat .label {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        margin-top: 4px;
+      }
+      .empty-state {
+        text-align: center;
+        padding: 40px;
+        color: var(--text-secondary);
+      }
+      .modal {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+        z-index: 100;
+        align-items: center;
+        justify-content: center;
+      }
+      .modal.show {
+        display: flex;
+      }
+      .modal-content {
+        background: var(--bg-card);
+        border-radius: 16px;
+        padding: 24px;
+        max-width: 500px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+      }
+      .modal-title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        margin-bottom: 16px;
+      }
+      .note {
+        margin-top: 16px;
+        padding: 12px;
+        background: var(--bg-deep);
+        border-radius: 8px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+      .back-link {
+        display: inline-block;
+        margin-bottom: 16px;
+        color: var(--accent-cyan);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        text-decoration: underline;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <a href="../../index.html" class="back-link">← 返回</a>
-  <h1>服药提醒器</h1>
-  <p class="subtitle">管理药物服用计划，按时服药</p>
+        <a href="../../index.html" class="back-link">← 返回</a>
+        <h1>服药提醒器</h1>
+        <p class="subtitle">管理药物服用计划，按时服药</p>
 
-  <div class="stats">
-    <div class="stat">
-      <div class="value" id="totalMeds">0</div>
-      <div class="label">药物总数</div>
-    </div>
-    <div class="stat">
-      <div class="value" id="todayDone">0</div>
-      <div class="label">今日已服</div>
-    </div>
-    <div class="stat">
-      <div class="value" id="todayRemaining">0</div>
-      <div class="label">今日待服</div>
-    </div>
-  </div>
+        <div class="stats">
+          <div class="stat">
+            <div class="value" id="totalMeds">0</div>
+            <div class="label">药物总数</div>
+          </div>
+          <div class="stat">
+            <div class="value" id="todayDone">0</div>
+            <div class="label">今日已服</div>
+          </div>
+          <div class="stat">
+            <div class="value" id="todayRemaining">0</div>
+            <div class="label">今日待服</div>
+          </div>
+        </div>
 
-  <div class="grid">
-    <div class="card">
-      <div class="card-title">
-        <span>今日服药计划</span>
-        <span style="font-size: 0.85rem; color: var(--text-secondary)" id="todayDate"></span>
+        <div class="grid">
+          <div class="card">
+            <div class="card-title">
+              <span>今日服药计划</span>
+              <span style="font-size: 0.85rem; color: var(--text-secondary)" id="todayDate"></span>
+            </div>
+            <div id="todayReminders"></div>
+          </div>
+
+          <div class="card">
+            <div class="card-title">
+              <span>我的药物</span>
+              <button onclick="showAddModal()" style="padding: 8px 16px; font-size: 0.9rem">
+                + 添加
+              </button>
+            </div>
+            <div class="med-list" id="medList"></div>
+          </div>
+        </div>
+
+        <div class="note">
+          本工具仅作为服药提醒辅助，不构成医疗建议。请严格按照医嘱服药，如有疑问请咨询医生或药师。
+        </div>
+
+        <div
+          class="modal"
+          id="addModal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modalTitle"
+        >
+          <div class="modal-content">
+            <div class="modal-title" id="modalTitle">添加药物</div>
+            <div class="form-group">
+              <label for="medName">药物名称</label>
+              <input type="text" id="medName" placeholder="例如：维生素 C" />
+            </div>
+            <div class="form-group">
+              <label for="medDose">剂量</label>
+              <input type="text" id="medDose" placeholder="例如：1 片" />
+            </div>
+            <div class="form-group">
+              <label for="medFrequency">每日次数</label>
+              <select id="medFrequency" onchange="updateTimeSlots()">
+                <option value="1">1 次</option>
+                <option value="2">2 次</option>
+                <option value="3">3 次</option>
+                <option value="4">4 次</option>
+                <option value="custom">自定义</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>提醒时间</label>
+              <div id="timeSlots"></div>
+              <button type="button" class="add-time" onclick="addTimeSlot()">+ 添加时间</button>
+            </div>
+            <div class="form-group">
+              <label for="medNotes">备注</label>
+              <textarea id="medNotes" rows="3" placeholder="例如：饭后服用"></textarea>
+            </div>
+            <div class="form-actions">
+              <button type="button" onclick="hideAddModal()">取消</button>
+              <button type="button" onclick="saveMed()">保存</button>
+            </div>
+          </div>
+        </div>
       </div>
-      <div id="todayReminders"></div>
     </div>
 
-    <div class="card">
-      <div class="card-title">
-        <span>我的药物</span>
-        <button onclick="showAddModal()" style="padding: 8px 16px; font-size: 0.9rem">
-          + 添加
-        </button>
-      </div>
-      <div class="med-list" id="medList"></div>
-    </div>
-  </div>
-
-  <div class="note">
-    本工具仅作为服药提醒辅助，不构成医疗建议。请严格按照医嘱服药，如有疑问请咨询医生或药师。
-  </div>
-
-  <div class="modal" id="addModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
-    <div class="modal-content">
-      <div class="modal-title" id="modalTitle">添加药物</div>
-      <div class="form-group">
-        <label for="medName">药物名称</label>
-        <input type="text" id="medName" placeholder="例如：维生素 C">
-      </div>
-      <div class="form-group">
-        <label for="medDose">剂量</label>
-        <input type="text" id="medDose" placeholder="例如：1 片">
-      </div>
-      <div class="form-group">
-        <label for="medFrequency">每日次数</label>
-        <select id="medFrequency" onchange="updateTimeSlots()">
-          <option value="1">1 次</option>
-          <option value="2">2 次</option>
-          <option value="3">3 次</option>
-          <option value="4">4 次</option>
-          <option value="custom">自定义</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>提醒时间</label>
-        <div id="timeSlots"></div>
-        <button type="button" class="add-time" onclick="addTimeSlot()">+ 添加时间</button>
-      </div>
-      <div class="form-group">
-        <label for="medNotes">备注</label>
-        <textarea id="medNotes" rows="3" placeholder="例如：饭后服用"></textarea>
-      </div>
-      <div class="form-actions">
-        <button type="button" onclick="hideAddModal()">取消</button>
-        <button type="button" onclick="saveMed()">保存</button>
-      </div>
-    </div>
-  </div>
-</div>
-    </div>
-    
     <script>
-  const LS_KEY = "medications";
-  const LOG_KEY = "med_logs";
-  let medications = [];
-  let logs = {};
-  let editIndex = -1;
-  let timeSlots = ["08:00"];
+      const LS_KEY = "medications";
+      const LOG_KEY = "med_logs";
+      let medications = [];
+      let logs = {};
+      let editIndex = -1;
+      let timeSlots = ["08:00"];
 
-  function loadData() {
-    const savedMeds = localStorage.getItem(LS_KEY);
-    if (savedMeds) medications = JSON.parse(savedMeds);
+      function loadData() {
+        const savedMeds = localStorage.getItem(LS_KEY);
+        if (savedMeds) medications = JSON.parse(savedMeds);
 
-    const savedLogs = localStorage.getItem(LOG_KEY);
-    if (savedLogs) logs = JSON.parse(savedLogs);
+        const savedLogs = localStorage.getItem(LOG_KEY);
+        if (savedLogs) logs = JSON.parse(savedLogs);
 
-    // 清理过期日志（保留7天）
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - 7);
-    const cutoffStr = cutoff.toISOString().split("T")[0];
-    Object.keys(logs).forEach((date) => {
-      if (date < cutoffStr) delete logs[date];
-    });
-    saveData();
+        // 清理过期日志（保留7天）
+        const cutoff = new Date();
+        cutoff.setDate(cutoff.getDate() - 7);
+        const cutoffStr = cutoff.toISOString().split("T")[0];
+        Object.keys(logs).forEach((date) => {
+          if (date < cutoffStr) delete logs[date];
+        });
+        saveData();
 
-    render();
-  }
+        render();
+      }
 
-  function saveData() {
-    localStorage.setItem(LS_KEY, JSON.stringify(medications));
-    localStorage.setItem(LOG_KEY, JSON.stringify(logs));
-  }
+      function saveData() {
+        localStorage.setItem(LS_KEY, JSON.stringify(medications));
+        localStorage.setItem(LOG_KEY, JSON.stringify(logs));
+      }
 
-  function showAddModal(index = -1) {
-    editIndex = index;
-    document.getElementById("modalTitle").textContent = index >= 0 ? "编辑药物" : "添加药物";
+      function showAddModal(index = -1) {
+        editIndex = index;
+        document.getElementById("modalTitle").textContent = index >= 0 ? "编辑药物" : "添加药物";
 
-    if (index >= 0) {
-      const med = medications[index];
-      document.getElementById("medName").value = med.name;
-      document.getElementById("medDose").value = med.dose;
-      document.getElementById("medFrequency").value =
-        med.times.length <= 4 ? med.times.length : "custom";
-      document.getElementById("medNotes").value = med.notes || "";
-      timeSlots = [...med.times];
-    } else {
-      document.getElementById("medName").value = "";
-      document.getElementById("medDose").value = "";
-      document.getElementById("medFrequency").value = "1";
-      document.getElementById("medNotes").value = "";
-      timeSlots = ["08:00"];
-    }
+        if (index >= 0) {
+          const med = medications[index];
+          document.getElementById("medName").value = med.name;
+          document.getElementById("medDose").value = med.dose;
+          document.getElementById("medFrequency").value =
+            med.times.length <= 4 ? med.times.length : "custom";
+          document.getElementById("medNotes").value = med.notes || "";
+          timeSlots = [...med.times];
+        } else {
+          document.getElementById("medName").value = "";
+          document.getElementById("medDose").value = "";
+          document.getElementById("medFrequency").value = "1";
+          document.getElementById("medNotes").value = "";
+          timeSlots = ["08:00"];
+        }
 
-    renderTimeSlots();
-    document.getElementById("addModal").classList.add("show");
-  }
+        renderTimeSlots();
+        document.getElementById("addModal").classList.add("show");
+      }
 
-  function hideAddModal() {
-    document.getElementById("addModal").classList.remove("show");
-    editIndex = -1;
-  }
+      function hideAddModal() {
+        document.getElementById("addModal").classList.remove("show");
+        editIndex = -1;
+      }
 
-  function updateTimeSlots() {
-    const freq = document.getElementById("medFrequency").value;
-    if (freq !== "custom") {
-      const count = parseInt(freq);
-      const defaultTimes = {
-        1: ["08:00"],
-        2: ["08:00", "20:00"],
-        3: ["08:00", "14:00", "20:00"],
-        4: ["08:00", "12:00", "18:00", "22:00"]
-      };
-      timeSlots = defaultTimes[count] || ["08:00"];
-      renderTimeSlots();
-    }
-  }
-
-  function renderTimeSlots() {
-    const container = document.getElementById("timeSlots");
-    container.textContent = "";
-
-    timeSlots.forEach((time, index) => {
-      const div = document.createElement("div");
-      div.className = "time-slot";
-
-      const input = document.createElement("input");
-      input.type = "time";
-      input.value = time;
-      input.onchange = (e) => {
-        timeSlots[index] = e.target.value;
-      };
-
-      const removeBtn = document.createElement("button");
-      removeBtn.className = "remove";
-      removeBtn.textContent = "×";
-      removeBtn.onclick = () => {
-        if (timeSlots.length > 1) {
-          timeSlots.splice(index, 1);
+      function updateTimeSlots() {
+        const freq = document.getElementById("medFrequency").value;
+        if (freq !== "custom") {
+          const count = parseInt(freq);
+          const defaultTimes = {
+            1: ["08:00"],
+            2: ["08:00", "20:00"],
+            3: ["08:00", "14:00", "20:00"],
+            4: ["08:00", "12:00", "18:00", "22:00"]
+          };
+          timeSlots = defaultTimes[count] || ["08:00"];
           renderTimeSlots();
         }
-      };
+      }
 
-      div.appendChild(input);
-      div.appendChild(removeBtn);
-      container.appendChild(div);
-    });
-  }
+      function renderTimeSlots() {
+        const container = document.getElementById("timeSlots");
+        container.textContent = "";
 
-  function addTimeSlot() {
-    timeSlots.push("12:00");
-    document.getElementById("medFrequency").value = "custom";
-    renderTimeSlots();
-  }
+        timeSlots.forEach((time, index) => {
+          const div = document.createElement("div");
+          div.className = "time-slot";
 
-  function saveMed() {
-    const name = document.getElementById("medName").value.trim();
-    const dose = document.getElementById("medDose").value.trim();
-    const notes = document.getElementById("medNotes").value.trim();
+          const input = document.createElement("input");
+          input.type = "time";
+          input.value = time;
+          input.onchange = (e) => {
+            timeSlots[index] = e.target.value;
+          };
 
-    if (!name) {
-      alert("请输入药物名称");
-      return;
-    }
+          const removeBtn = document.createElement("button");
+          removeBtn.className = "remove";
+          removeBtn.textContent = "×";
+          removeBtn.onclick = () => {
+            if (timeSlots.length > 1) {
+              timeSlots.splice(index, 1);
+              renderTimeSlots();
+            }
+          };
 
-    const med = {
-      name,
-      dose,
-      times: timeSlots.sort(),
-      notes,
-      id: editIndex >= 0 ? medications[editIndex].id : Date.now()
-    };
+          div.appendChild(input);
+          div.appendChild(removeBtn);
+          container.appendChild(div);
+        });
+      }
 
-    if (editIndex >= 0) {
-      medications[editIndex] = med;
-    } else {
-      medications.push(med);
-    }
+      function addTimeSlot() {
+        timeSlots.push("12:00");
+        document.getElementById("medFrequency").value = "custom";
+        renderTimeSlots();
+      }
 
-    saveData();
-    hideAddModal();
-    render();
-  }
+      function saveMed() {
+        const name = document.getElementById("medName").value.trim();
+        const dose = document.getElementById("medDose").value.trim();
+        const notes = document.getElementById("medNotes").value.trim();
 
-  function deleteMed(index) {
-    if (confirm("确定要删除这个药物吗？")) {
-      medications.splice(index, 1);
-      saveData();
-      render();
-    }
-  }
+        if (!name) {
+          alert("请输入药物名称");
+          return;
+        }
 
-  function toggleReminder(medId, time) {
-    const today = new Date().toISOString().split("T")[0];
-    if (!logs[today]) logs[today] = {};
+        const med = {
+          name,
+          dose,
+          times: timeSlots.sort(),
+          notes,
+          id: editIndex >= 0 ? medications[editIndex].id : Date.now()
+        };
 
-    const key = medId + "_" + time;
-    logs[today][key] = !logs[today][key];
+        if (editIndex >= 0) {
+          medications[editIndex] = med;
+        } else {
+          medications.push(med);
+        }
 
-    saveData();
-    render();
-  }
+        saveData();
+        hideAddModal();
+        render();
+      }
 
-  function render() {
-    const today = new Date().toISOString().split("T")[0];
-    document.getElementById("todayDate").textContent = today;
+      function deleteMed(index) {
+        if (confirm("确定要删除这个药物吗？")) {
+          medications.splice(index, 1);
+          saveData();
+          render();
+        }
+      }
 
-    // 渲染药物列表
-    const medList = document.getElementById("medList");
-    medList.textContent = "";
+      function toggleReminder(medId, time) {
+        const today = new Date().toISOString().split("T")[0];
+        if (!logs[today]) logs[today] = {};
 
-    if (medications.length === 0) {
-      const empty = document.createElement("div");
-      empty.className = "empty-state";
-      empty.textContent = '还没有添加药物，点击"添加"开始';
-      medList.appendChild(empty);
-    } else {
-      medications.forEach((med, index) => {
-        const div = document.createElement("div");
-        div.className = "med-item";
+        const key = medId + "_" + time;
+        logs[today][key] = !logs[today][key];
 
-        const header = document.createElement("div");
-        header.className = "med-header";
+        saveData();
+        render();
+      }
 
-        const name = document.createElement("div");
-        name.className = "med-name";
-        name.textContent = med.name;
+      function render() {
+        const today = new Date().toISOString().split("T")[0];
+        document.getElementById("todayDate").textContent = today;
 
-        const actions = document.createElement("div");
-        actions.className = "med-actions";
+        // 渲染药物列表
+        const medList = document.getElementById("medList");
+        medList.textContent = "";
 
-        const editBtn = document.createElement("button");
-        editBtn.className = "secondary";
-        editBtn.textContent = "编辑";
-        editBtn.onclick = () => showAddModal(index);
+        if (medications.length === 0) {
+          const empty = document.createElement("div");
+          empty.className = "empty-state";
+          empty.textContent = '还没有添加药物，点击"添加"开始';
+          medList.appendChild(empty);
+        } else {
+          medications.forEach((med, index) => {
+            const div = document.createElement("div");
+            div.className = "med-item";
 
-        const deleteBtn = document.createElement("button");
-        deleteBtn.className = "danger";
-        deleteBtn.textContent = "删除";
-        deleteBtn.onclick = () => deleteMed(index);
+            const header = document.createElement("div");
+            header.className = "med-header";
 
-        actions.appendChild(editBtn);
-        actions.appendChild(deleteBtn);
-        header.appendChild(name);
-        header.appendChild(actions);
+            const name = document.createElement("div");
+            name.className = "med-name";
+            name.textContent = med.name;
 
-        const details = document.createElement("div");
-        details.className = "med-details";
-        details.textContent = med.dose + (med.notes ? " · " + med.notes : "");
+            const actions = document.createElement("div");
+            actions.className = "med-actions";
 
-        const times = document.createElement("div");
-        times.className = "med-times";
-        med.times.forEach((time) => {
-          const span = document.createElement("span");
-          span.className = "med-time";
-          span.textContent = time;
-          times.appendChild(span);
+            const editBtn = document.createElement("button");
+            editBtn.className = "secondary";
+            editBtn.textContent = "编辑";
+            editBtn.onclick = () => showAddModal(index);
+
+            const deleteBtn = document.createElement("button");
+            deleteBtn.className = "danger";
+            deleteBtn.textContent = "删除";
+            deleteBtn.onclick = () => deleteMed(index);
+
+            actions.appendChild(editBtn);
+            actions.appendChild(deleteBtn);
+            header.appendChild(name);
+            header.appendChild(actions);
+
+            const details = document.createElement("div");
+            details.className = "med-details";
+            details.textContent = med.dose + (med.notes ? " · " + med.notes : "");
+
+            const times = document.createElement("div");
+            times.className = "med-times";
+            med.times.forEach((time) => {
+              const span = document.createElement("span");
+              span.className = "med-time";
+              span.textContent = time;
+              times.appendChild(span);
+            });
+
+            div.appendChild(header);
+            div.appendChild(details);
+            div.appendChild(times);
+            medList.appendChild(div);
+          });
+        }
+
+        // 渲染今日提醒
+        const todayReminders = document.getElementById("todayReminders");
+        todayReminders.textContent = "";
+
+        const reminders = [];
+        medications.forEach((med) => {
+          med.times.forEach((time) => {
+            reminders.push({
+              medId: med.id,
+              name: med.name,
+              dose: med.dose,
+              time: time,
+              done: logs[today] && logs[today][med.id + "_" + time]
+            });
+          });
         });
 
-        div.appendChild(header);
-        div.appendChild(details);
-        div.appendChild(times);
-        medList.appendChild(div);
-      });
-    }
+        reminders.sort((a, b) => a.time.localeCompare(b.time));
 
-    // 渲染今日提醒
-    const todayReminders = document.getElementById("todayReminders");
-    todayReminders.textContent = "";
+        if (reminders.length === 0) {
+          const empty = document.createElement("div");
+          empty.className = "empty-state";
+          empty.textContent = "今日没有服药计划";
+          todayReminders.appendChild(empty);
+        } else {
+          reminders.forEach((reminder) => {
+            const div = document.createElement("div");
+            div.className = "reminder-item" + (reminder.done ? " done" : "");
 
-    const reminders = [];
-    medications.forEach((med) => {
-      med.times.forEach((time) => {
-        reminders.push({
-          medId: med.id,
-          name: med.name,
-          dose: med.dose,
-          time: time,
-          done: logs[today] && logs[today][med.id + "_" + time]
-        });
-      });
-    });
+            const time = document.createElement("div");
+            time.className = "reminder-time";
+            time.textContent = reminder.time;
 
-    reminders.sort((a, b) => a.time.localeCompare(b.time));
+            const info = document.createElement("div");
+            info.className = "reminder-info";
 
-    if (reminders.length === 0) {
-      const empty = document.createElement("div");
-      empty.className = "empty-state";
-      empty.textContent = "今日没有服药计划";
-      todayReminders.appendChild(empty);
-    } else {
-      reminders.forEach((reminder) => {
-        const div = document.createElement("div");
-        div.className = "reminder-item" + (reminder.done ? " done" : "");
+            const name = document.createElement("div");
+            name.className = "reminder-name";
+            name.textContent = reminder.name;
 
-        const time = document.createElement("div");
-        time.className = "reminder-time";
-        time.textContent = reminder.time;
+            const dose = document.createElement("div");
+            dose.className = "reminder-dose";
+            dose.textContent = reminder.dose;
 
-        const info = document.createElement("div");
-        info.className = "reminder-info";
+            info.appendChild(name);
+            info.appendChild(dose);
 
-        const name = document.createElement("div");
-        name.className = "reminder-name";
-        name.textContent = reminder.name;
+            const check = document.createElement("div");
+            check.className = "reminder-check" + (reminder.done ? " checked" : "");
+            check.textContent = reminder.done ? "✓" : "";
+            check.onclick = () => toggleReminder(reminder.medId, reminder.time);
 
-        const dose = document.createElement("div");
-        dose.className = "reminder-dose";
-        dose.textContent = reminder.dose;
+            div.appendChild(time);
+            div.appendChild(info);
+            div.appendChild(check);
+            todayReminders.appendChild(div);
+          });
+        }
 
-        info.appendChild(name);
-        info.appendChild(dose);
+        // 更新统计
+        document.getElementById("totalMeds").textContent = medications.length;
+        document.getElementById("todayDone").textContent = reminders.filter((r) => r.done).length;
+        document.getElementById("todayRemaining").textContent = reminders.filter(
+          (r) => !r.done
+        ).length;
+      }
 
-        const check = document.createElement("div");
-        check.className = "reminder-check" + (reminder.done ? " checked" : "");
-        check.textContent = reminder.done ? "✓" : "";
-        check.onclick = () => toggleReminder(reminder.medId, reminder.time);
+      loadData();
 
-        div.appendChild(time);
-        div.appendChild(info);
-        div.appendChild(check);
-        todayReminders.appendChild(div);
-      });
-    }
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
 
-    // 更新统计
-    document.getElementById("totalMeds").textContent = medications.length;
-    document.getElementById("todayDone").textContent = reminders.filter((r) => r.done).length;
-    document.getElementById("todayRemaining").textContent = reminders.filter((r) => !r.done).length;
-  }
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
 
-  loadData();
-
-  // Theme toggle
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme");
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-    localStorage.setItem("theme", newTheme);
-  }
-
-  // Load saved theme
-  const savedTheme = localStorage.getItem("theme") || "dark";
-  if (savedTheme === "light") {
-    document.documentElement.setAttribute("data-theme", "light");
-    document.getElementById("theme-icon").textContent = "☀️";
-  }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/media/base64-image.html
+++ b/tools/media/base64-image.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="Base64 图片转换 - WebUtils" />
     <meta property="og:description" content="图片与 Base64 编码互转，支持多种格式" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/media/base64-image.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/media/base64-image.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "媒体工具",
-      "item": "https://tools.realtime-ai.chat/tools/media/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Base64 图片转换",
-      "item": "https://tools.realtime-ai.chat/tools/media/base64-image.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "媒体工具",
+            "item": "https://tools.realtime-ai.chat/tools/media/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Base64 图片转换",
+            "item": "https://tools.realtime-ai.chat/tools/media/base64-image.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Base64 图片转换 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Base64 图片转换 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1055 +91,1061 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --border-default: #2a2a3a;
-    --border-focus: #3a3a4a;
-    --color-text-primary: #e0e0e0;
-    --color-text-secondary: #888;
-    --color-accent-cyan: #00d4ff;
-    --accent-magenta: #f0f;
-    --accent-green: #0f8;
-    --accent-yellow: #fd0;
-  }
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  body {
-    font-family: "SF Mono", Consolas, Monaco, monospace;
-    font-size: 16px;
-    line-height: 1.6;
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .back-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--color-accent-cyan);
-    text-decoration: none;
-    font-size: 14px;
-    margin-bottom: 20px;
-    padding: 8px 16px;
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    transition: all 0.2s;
-  }
-  .back-link:hover {
-    background: var(--color-bg-card);
-    border-color: var(--color-accent-cyan);
-  }
-  h1 {
-    font-size: 28px;
-    margin-bottom: 8px;
-    background: linear-gradient(135deg, var(--color-accent-cyan), var(--accent-magenta));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-  .subtitle {
-    color: var(--color-text-secondary);
-    margin-bottom: 30px;
-    font-size: 14px;
-  }
-  .container {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-  .tabs {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 20px;
-  }
-  .tab-btn {
-    flex: 1;
-    padding: 14px 20px;
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 14px;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .tab-btn:hover,
-  .tab-btn.active {
-    border-color: var(--color-accent-cyan);
-    background: rgba(0, 212, 255, 0.1);
-  }
-  .tab-btn.active {
-    color: var(--color-accent-cyan);
-  }
-  .tab-content {
-    display: none;
-  }
-  .tab-content.active {
-    display: block;
-  }
-  .card {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-default);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 20px;
-  }
-  .upload-area {
-    border: 2px dashed var(--border-default);
-    border-radius: 8px;
-    padding: 40px;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .upload-area:hover,
-  .upload-area.dragover {
-    border-color: var(--color-accent-cyan);
-    background: rgba(0, 212, 255, 0.05);
-  }
-  .upload-area input {
-    display: none;
-  }
-  .upload-icon {
-    font-size: 48px;
-    margin-bottom: 16px;
-  }
-  .layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-  }
-  @media (max-width: 900px) {
-    .layout {
-      grid-template-columns: 1fr;
-    }
-  }
-  .preview-box {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    min-height: 200px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-  }
-  .preview-box img {
-    max-width: 100%;
-    max-height: 300px;
-    object-fit: contain;
-  }
-  .preview-box .placeholder {
-    color: var(--color-text-secondary);
-    font-size: 14px;
-  }
-  textarea {
-    width: 100%;
-    min-height: 200px;
-    padding: 16px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 12px;
-    resize: vertical;
-    line-height: 1.6;
-  }
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  .info-row {
-    display: flex;
-    gap: 20px;
-    flex-wrap: wrap;
-    margin-top: 16px;
-    padding-top: 16px;
-    border-top: 1px solid var(--border-default);
-  }
-  .info-item {
-    font-size: 12px;
-  }
-  .info-item span {
-    color: var(--color-text-secondary);
-  }
-  .info-item strong {
-    color: var(--color-accent-cyan);
-  }
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-top: 20px;
-  }
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 24px;
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    font-family: inherit;
-    font-size: 14px;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .btn-primary {
-    background: linear-gradient(135deg, var(--color-accent-cyan), var(--accent-magenta));
-    color: var(--color-bg-deep);
-    border: none;
-    font-weight: 600;
-  }
-  .btn-primary:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-  }
-  .btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-  }
-  .control-group {
-    margin-bottom: 16px;
-  }
-  .control-group label {
-    display: block;
-    font-size: 12px;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-  .control-group select {
-    width: 100%;
-    padding: 10px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 14px;
-  }
-  .control-group select:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  .checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    cursor: pointer;
-  }
-  .checkbox-label input {
-    width: 16px;
-    height: 16px;
-  }
-  .status {
-    padding: 12px 16px;
-    border-radius: 6px;
-    font-size: 13px;
-    margin-top: 16px;
-    display: none;
-  }
-  .status.success {
-    display: block;
-    background: rgba(0, 255, 136, 0.1);
-    border: 1px solid var(--accent-green);
-    color: var(--accent-green);
-  }
-  .status.error {
-    display: block;
-    background: rgba(255, 0, 100, 0.1);
-    border: 1px solid var(--accent-magenta);
-    color: var(--accent-magenta);
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --border-default: #2a2a3a;
+        --border-focus: #3a3a4a;
+        --color-text-primary: #e0e0e0;
+        --color-text-secondary: #888;
+        --color-accent-cyan: #00d4ff;
+        --accent-magenta: #f0f;
+        --accent-green: #0f8;
+        --accent-yellow: #fd0;
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: "SF Mono", Consolas, Monaco, monospace;
+        font-size: 16px;
+        line-height: 1.6;
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        padding: 20px;
+      }
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--color-accent-cyan);
+        text-decoration: none;
+        font-size: 14px;
+        margin-bottom: 20px;
+        padding: 8px 16px;
+        border: 1px solid var(--border-default);
+        border-radius: 6px;
+        transition: all 0.2s;
+      }
+      .back-link:hover {
+        background: var(--color-bg-card);
+        border-color: var(--color-accent-cyan);
+      }
+      h1 {
+        font-size: 28px;
+        margin-bottom: 8px;
+        background: linear-gradient(135deg, var(--color-accent-cyan), var(--accent-magenta));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+      .subtitle {
+        color: var(--color-text-secondary);
+        margin-bottom: 30px;
+        font-size: 14px;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      .tabs {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 20px;
+      }
+      .tab-btn {
+        flex: 1;
+        padding: 14px 20px;
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-default);
+        border-radius: 8px;
+        color: var(--color-text-primary);
+        font-family: inherit;
+        font-size: 14px;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .tab-btn:hover,
+      .tab-btn.active {
+        border-color: var(--color-accent-cyan);
+        background: rgba(0, 212, 255, 0.1);
+      }
+      .tab-btn.active {
+        color: var(--color-accent-cyan);
+      }
+      .tab-content {
+        display: none;
+      }
+      .tab-content.active {
+        display: block;
+      }
+      .card {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-default);
+        border-radius: 12px;
+        padding: 24px;
+        margin-bottom: 20px;
+      }
+      .upload-area {
+        border: 2px dashed var(--border-default);
+        border-radius: 8px;
+        padding: 40px;
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .upload-area:hover,
+      .upload-area.dragover {
+        border-color: var(--color-accent-cyan);
+        background: rgba(0, 212, 255, 0.05);
+      }
+      .upload-area input {
+        display: none;
+      }
+      .upload-icon {
+        font-size: 48px;
+        margin-bottom: 16px;
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      @media (max-width: 900px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+      }
+      .preview-box {
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-default);
+        border-radius: 8px;
+        min-height: 200px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+      }
+      .preview-box img {
+        max-width: 100%;
+        max-height: 300px;
+        object-fit: contain;
+      }
+      .preview-box .placeholder {
+        color: var(--color-text-secondary);
+        font-size: 14px;
+      }
+      textarea {
+        width: 100%;
+        min-height: 200px;
+        padding: 16px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-default);
+        border-radius: 8px;
+        color: var(--color-text-primary);
+        font-family: inherit;
+        font-size: 12px;
+        resize: vertical;
+        line-height: 1.6;
+      }
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      .info-row {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+        padding-top: 16px;
+        border-top: 1px solid var(--border-default);
+      }
+      .info-item {
+        font-size: 12px;
+      }
+      .info-item span {
+        color: var(--color-text-secondary);
+      }
+      .info-item strong {
+        color: var(--color-accent-cyan);
+      }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-top: 20px;
+      }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 24px;
+        border: 1px solid var(--border-default);
+        border-radius: 6px;
+        font-family: inherit;
+        font-size: 14px;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .btn-primary {
+        background: linear-gradient(135deg, var(--color-accent-cyan), var(--accent-magenta));
+        color: var(--color-bg-deep);
+        border: none;
+        font-weight: 600;
+      }
+      .btn-primary:hover {
+        opacity: 0.9;
+        transform: translateY(-1px);
+      }
+      .btn-primary:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+      }
+      .control-group {
+        margin-bottom: 16px;
+      }
+      .control-group label {
+        display: block;
+        font-size: 12px;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+      .control-group select {
+        width: 100%;
+        padding: 10px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-default);
+        border-radius: 6px;
+        color: var(--color-text-primary);
+        font-family: inherit;
+        font-size: 14px;
+      }
+      .control-group select:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      .checkbox-label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      .checkbox-label input {
+        width: 16px;
+        height: 16px;
+      }
+      .status {
+        padding: 12px 16px;
+        border-radius: 6px;
+        font-size: 13px;
+        margin-top: 16px;
+        display: none;
+      }
+      .status.success {
+        display: block;
+        background: rgba(0, 255, 136, 0.1);
+        border: 1px solid var(--accent-green);
+        color: var(--accent-green);
+      }
+      .status.error {
+        display: block;
+        background: rgba(255, 0, 100, 0.1);
+        border: 1px solid var(--accent-magenta);
+        color: var(--accent-magenta);
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <h1>Base64 图片转换</h1>
-  <p class="subtitle">图片与 Base64 编码互转</p>
+        <h1>Base64 图片转换</h1>
+        <p class="subtitle">图片与 Base64 编码互转</p>
 
-  <div class="tabs">
-    <button class="tab-btn active" data-tab="encode">图片 → Base64</button>
-    <button class="tab-btn" data-tab="decode">Base64 → 图片</button>
-  </div>
+        <div class="tabs">
+          <button class="tab-btn active" data-tab="encode">图片 → Base64</button>
+          <button class="tab-btn" data-tab="decode">Base64 → 图片</button>
+        </div>
 
-  <!-- Encode Tab -->
-  <div class="tab-content active" id="encodeTab">
-    <div class="card">
-      <div class="upload-area" id="uploadArea">
-        <div class="upload-icon">📷</div>
-        <p>点击或拖拽图片到此处</p>
-        <p style="font-size: 12px; color: var(--color-text-secondary); margin-top: 8px">
-          支持 JPG、PNG、GIF、WebP、SVG 格式
-        </p>
-        <input type="file" id="fileInput" accept="image/*">
+        <!-- Encode Tab -->
+        <div class="tab-content active" id="encodeTab">
+          <div class="card">
+            <div class="upload-area" id="uploadArea">
+              <div class="upload-icon">📷</div>
+              <p>点击或拖拽图片到此处</p>
+              <p style="font-size: 12px; color: var(--color-text-secondary); margin-top: 8px">
+                支持 JPG、PNG、GIF、WebP、SVG 格式
+              </p>
+              <input type="file" id="fileInput" accept="image/*" />
+            </div>
+          </div>
+
+          <div class="layout" id="encodeResult" style="display: none">
+            <div class="card">
+              <h3 style="font-size: 14px; margin-bottom: 16px">预览</h3>
+              <div class="preview-box">
+                <img id="encodePreview" alt="Preview" />
+              </div>
+              <div class="info-row" id="encodeInfo"></div>
+            </div>
+
+            <div class="card">
+              <h3 style="font-size: 14px; margin-bottom: 16px">Base64 输出</h3>
+              <div class="control-group">
+                <label class="checkbox-label">
+                  <input type="checkbox" id="includePrefix" checked="" />
+                  包含 Data URI 前缀
+                </label>
+              </div>
+              <textarea
+                id="encodeOutput"
+                readonly=""
+                placeholder="Base64 编码将显示在这里..."
+              ></textarea>
+              <div class="btn-row">
+                <button class="btn btn-secondary" id="copyBase64Btn">复制代码</button>
+                <button class="btn btn-secondary" id="copyImgTagBtn">复制 IMG 标签</button>
+                <button class="btn btn-secondary" id="copyCssBgBtn">复制 CSS 背景</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Decode Tab -->
+        <div class="tab-content" id="decodeTab">
+          <div class="layout">
+            <div class="card">
+              <h3 style="font-size: 14px; margin-bottom: 16px">输入 Base64</h3>
+              <textarea id="decodeInput" placeholder="粘贴 Base64 编码或 Data URI..."></textarea>
+              <div class="control-group" style="margin-top: 16px">
+                <label>输出格式</label>
+                <select id="outputFormat">
+                  <option value="auto">自动检测</option>
+                  <option value="png">PNG</option>
+                  <option value="jpeg">JPEG</option>
+                  <option value="webp">WebP</option>
+                  <option value="gif">GIF</option>
+                </select>
+              </div>
+              <div class="btn-row">
+                <button class="btn btn-secondary" id="clearDecodeBtn">清空</button>
+                <button class="btn btn-primary" id="decodeBtn">解码图片</button>
+              </div>
+              <div class="status" id="decodeStatus"></div>
+            </div>
+
+            <div class="card">
+              <h3 style="font-size: 14px; margin-bottom: 16px">预览</h3>
+              <div class="preview-box" id="decodePreviewBox">
+                <span class="placeholder">解码后的图片将显示在这里</span>
+              </div>
+              <div class="info-row" id="decodeInfo" style="display: none"></div>
+              <div class="btn-row" id="decodeActions" style="display: none">
+                <button class="btn btn-primary" id="downloadImageBtn">下载图片</button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
-    <div class="layout" id="encodeResult" style="display: none">
-      <div class="card">
-        <h3 style="font-size: 14px; margin-bottom: 16px">预览</h3>
-        <div class="preview-box">
-          <img id="encodePreview" alt="Preview">
-        </div>
-        <div class="info-row" id="encodeInfo"></div>
-      </div>
-
-      <div class="card">
-        <h3 style="font-size: 14px; margin-bottom: 16px">Base64 输出</h3>
-        <div class="control-group">
-          <label class="checkbox-label">
-            <input type="checkbox" id="includePrefix" checked="">
-            包含 Data URI 前缀
-          </label>
-        </div>
-        <textarea id="encodeOutput" readonly="" placeholder="Base64 编码将显示在这里..."></textarea>
-        <div class="btn-row">
-          <button class="btn btn-secondary" id="copyBase64Btn">复制代码</button>
-          <button class="btn btn-secondary" id="copyImgTagBtn">复制 IMG 标签</button>
-          <button class="btn btn-secondary" id="copyCssBgBtn">复制 CSS 背景</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Decode Tab -->
-  <div class="tab-content" id="decodeTab">
-    <div class="layout">
-      <div class="card">
-        <h3 style="font-size: 14px; margin-bottom: 16px">输入 Base64</h3>
-        <textarea id="decodeInput" placeholder="粘贴 Base64 编码或 Data URI..."></textarea>
-        <div class="control-group" style="margin-top: 16px">
-          <label>输出格式</label>
-          <select id="outputFormat">
-            <option value="auto">自动检测</option>
-            <option value="png">PNG</option>
-            <option value="jpeg">JPEG</option>
-            <option value="webp">WebP</option>
-            <option value="gif">GIF</option>
-          </select>
-        </div>
-        <div class="btn-row">
-          <button class="btn btn-secondary" id="clearDecodeBtn">清空</button>
-          <button class="btn btn-primary" id="decodeBtn">解码图片</button>
-        </div>
-        <div class="status" id="decodeStatus"></div>
-      </div>
-
-      <div class="card">
-        <h3 style="font-size: 14px; margin-bottom: 16px">预览</h3>
-        <div class="preview-box" id="decodePreviewBox">
-          <span class="placeholder">解码后的图片将显示在这里</span>
-        </div>
-        <div class="info-row" id="decodeInfo" style="display: none"></div>
-        <div class="btn-row" id="decodeActions" style="display: none">
-          <button class="btn btn-primary" id="downloadImageBtn">下载图片</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "媒体工具",
-              "item": "https://tools.realtime-ai.chat/#media"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "Base64 图片转换",
-              "item": "https://tools.realtime-ai.chat/tools/media/base64-image.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "媒体工具",
+            "item": "https://tools.realtime-ai.chat/#media"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Base64 图片转换",
+            "item": "https://tools.realtime-ai.chat/tools/media/base64-image.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Base64 图片转换工具安全吗？上传的图片会存到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有图片编解码都在你的浏览器本地完成，上传的图片文件和生成的 Base64 数据不会传输到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "支持哪些图片格式？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "支持 JPG、PNG、GIF、WebP、SVG 等常见图片格式。拖拽或点击上传区域选取图片后，工具会自动识别格式并进行编码。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Base64 图片数据可以直接用在 HTML 或 CSS 中吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。工具提供三种一键复制：完整 Data URI（可直接作为 img src）、HTML img 标签，以及 CSS background-image 属性，粘贴即用，无需额外修改。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何将 Base64 字符串还原为图片文件？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "切换到「Base64 → 图片」标签页，粘贴 Base64 字符串或完整 Data URI，点击「解码图片」即可预览，再点击「下载图片」保存为本地文件。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "图片转 Base64 后体积会增大多少？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Base64 编码会将图片体积增加约 33%。例如一张 100 KB 的图片，编码后的 Base64 字符串约为 136 KB。建议仅对小图标或小图片使用 Base64 内嵌，大图片仍应使用普通 URL 引用。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Base64 图片转换工具安全吗？上传的图片会存到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有图片编解码都在你的浏览器本地完成，上传的图片文件和生成的 Base64 数据不会传输到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "支持哪些图片格式？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "支持 JPG、PNG、GIF、WebP、SVG 等常见图片格式。拖拽或点击上传区域选取图片后，工具会自动识别格式并进行编码。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Base64 图片数据可以直接用在 HTML 或 CSS 中吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。工具提供三种一键复制：完整 Data URI（可直接作为 img src）、HTML img 标签，以及 CSS background-image 属性，粘贴即用，无需额外修改。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何将 Base64 字符串还原为图片文件？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "切换到「Base64 → 图片」标签页，粘贴 Base64 字符串或完整 Data URI，点击「解码图片」即可预览，再点击「下载图片」保存为本地文件。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "图片转 Base64 后体积会增大多少？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Base64 编码会将图片体积增加约 33%。例如一张 100 KB 的图片，编码后的 Base64 字符串约为 136 KB。建议仅对小图标或小图片使用 Base64 内嵌，大图片仍应使用普通 URL 引用。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
-
-  // Tab switching
-        document.querySelectorAll(".tab-btn").forEach((btn) => {
-          btn.addEventListener("click", () => {
-            document.querySelectorAll(".tab-btn").forEach((b) => b.classList.remove("active"));
-            document.querySelectorAll(".tab-content").forEach((c) => c.classList.remove("active"));
-            btn.classList.add("active");
-            document.getElementById(btn.dataset.tab + "Tab").classList.add("active");
-          });
+      // Tab switching
+      document.querySelectorAll(".tab-btn").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          document.querySelectorAll(".tab-btn").forEach((b) => b.classList.remove("active"));
+          document.querySelectorAll(".tab-content").forEach((c) => c.classList.remove("active"));
+          btn.classList.add("active");
+          document.getElementById(btn.dataset.tab + "Tab").classList.add("active");
         });
+      });
 
-        // === ENCODE ===
-        const uploadArea = document.getElementById("uploadArea");
-        const fileInput = document.getElementById("fileInput");
-        const encodeResult = document.getElementById("encodeResult");
-        const encodePreview = document.getElementById("encodePreview");
-        const encodeOutput = document.getElementById("encodeOutput");
-        const encodeInfo = document.getElementById("encodeInfo");
-        const includePrefix = document.getElementById("includePrefix");
+      // === ENCODE ===
+      const uploadArea = document.getElementById("uploadArea");
+      const fileInput = document.getElementById("fileInput");
+      const encodeResult = document.getElementById("encodeResult");
+      const encodePreview = document.getElementById("encodePreview");
+      const encodeOutput = document.getElementById("encodeOutput");
+      const encodeInfo = document.getElementById("encodeInfo");
+      const includePrefix = document.getElementById("includePrefix");
 
-        let currentBase64 = "";
-        let currentMimeType = "";
+      let currentBase64 = "";
+      let currentMimeType = "";
 
-        uploadArea.addEventListener("click", () => fileInput.click());
-        uploadArea.addEventListener("dragover", (e) => {
-          e.preventDefault();
-          uploadArea.classList.add("dragover");
-        });
-        uploadArea.addEventListener("dragleave", () => uploadArea.classList.remove("dragover"));
-        uploadArea.addEventListener("drop", (e) => {
-          e.preventDefault();
-          uploadArea.classList.remove("dragover");
-          if (e.dataTransfer.files[0]) encodeImage(e.dataTransfer.files[0]);
-        });
-        fileInput.addEventListener("change", (e) => {
-          if (e.target.files[0]) encodeImage(e.target.files[0]);
-        });
+      uploadArea.addEventListener("click", () => fileInput.click());
+      uploadArea.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        uploadArea.classList.add("dragover");
+      });
+      uploadArea.addEventListener("dragleave", () => uploadArea.classList.remove("dragover"));
+      uploadArea.addEventListener("drop", (e) => {
+        e.preventDefault();
+        uploadArea.classList.remove("dragover");
+        if (e.dataTransfer.files[0]) encodeImage(e.dataTransfer.files[0]);
+      });
+      fileInput.addEventListener("change", (e) => {
+        if (e.target.files[0]) encodeImage(e.target.files[0]);
+      });
 
-        function encodeImage(file) {
-          const reader = new FileReader();
-          reader.onload = (e) => {
-            currentBase64 = e.target.result;
-            currentMimeType = file.type;
+      function encodeImage(file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          currentBase64 = e.target.result;
+          currentMimeType = file.type;
 
-            encodePreview.src = currentBase64;
-            updateEncodeOutput();
+          encodePreview.src = currentBase64;
+          updateEncodeOutput();
 
-            const img = new Image();
-            img.onload = () => {
-              renderEncodeInfo(
-                file.name,
-                img.width,
-                img.height,
-                file.size,
-                file.type,
-                currentBase64.length
-              );
-            };
-            img.src = currentBase64;
-
-            encodeResult.style.display = "grid";
+          const img = new Image();
+          img.onload = () => {
+            renderEncodeInfo(
+              file.name,
+              img.width,
+              img.height,
+              file.size,
+              file.type,
+              currentBase64.length
+            );
           };
-          reader.readAsDataURL(file);
+          img.src = currentBase64;
+
+          encodeResult.style.display = "grid";
+        };
+        reader.readAsDataURL(file);
+      }
+
+      function renderEncodeInfo(name, width, height, originalSize, type, base64Length) {
+        while (encodeInfo.firstChild) {
+          encodeInfo.removeChild(encodeInfo.firstChild);
         }
 
-        function renderEncodeInfo(name, width, height, originalSize, type, base64Length) {
-          while (encodeInfo.firstChild) {
-            encodeInfo.removeChild(encodeInfo.firstChild);
+        const items = [
+          { label: "文件名", value: name },
+          { label: "尺寸", value: width + " × " + height },
+          { label: "原始大小", value: formatFileSize(originalSize) },
+          { label: "类型", value: type },
+          { label: "Base64 长度", value: base64Length.toLocaleString() + " 字符" }
+        ];
+
+        items.forEach((item) => {
+          const div = document.createElement("div");
+          div.className = "info-item";
+          const span = document.createElement("span");
+          span.textContent = item.label + "：";
+          const strong = document.createElement("strong");
+          strong.textContent = item.value;
+          div.appendChild(span);
+          div.appendChild(strong);
+          encodeInfo.appendChild(div);
+        });
+      }
+
+      function updateEncodeOutput() {
+        if (includePrefix.checked) {
+          encodeOutput.value = currentBase64;
+        } else {
+          encodeOutput.value = currentBase64.split(",")[1] || "";
+        }
+      }
+
+      includePrefix.addEventListener("change", updateEncodeOutput);
+
+      document.getElementById("copyBase64Btn").addEventListener("click", () => {
+        navigator.clipboard.writeText(encodeOutput.value).then(() => {
+          showCopyFeedback("copyBase64Btn", "已复制!");
+        });
+      });
+
+      document.getElementById("copyImgTagBtn").addEventListener("click", () => {
+        const tag = '<img src="' + currentBase64 + '" alt="image">';
+        navigator.clipboard.writeText(tag).then(() => {
+          showCopyFeedback("copyImgTagBtn", "已复制!");
+        });
+      });
+
+      document.getElementById("copyCssBgBtn").addEventListener("click", () => {
+        const css = "background-image: url('" + currentBase64 + "');";
+        navigator.clipboard.writeText(css).then(() => {
+          showCopyFeedback("copyCssBgBtn", "已复制!");
+        });
+      });
+
+      function showCopyFeedback(btnId, msg) {
+        const btn = document.getElementById(btnId);
+        const original = btn.textContent;
+        btn.textContent = msg;
+        setTimeout(() => (btn.textContent = original), 2000);
+      }
+
+      // === DECODE ===
+      const decodeInput = document.getElementById("decodeInput");
+      const decodePreviewBox = document.getElementById("decodePreviewBox");
+      const decodeInfo = document.getElementById("decodeInfo");
+      const decodeActions = document.getElementById("decodeActions");
+      const decodeStatus = document.getElementById("decodeStatus");
+      const outputFormat = document.getElementById("outputFormat");
+
+      let decodedDataUrl = "";
+
+      document.getElementById("clearDecodeBtn").addEventListener("click", () => {
+        decodeInput.value = "";
+        resetDecodePreview();
+      });
+
+      document.getElementById("decodeBtn").addEventListener("click", function () {
+        window.decodeBase64();
+      });
+
+      function resetDecodePreview() {
+        while (decodePreviewBox.firstChild) {
+          decodePreviewBox.removeChild(decodePreviewBox.firstChild);
+        }
+        const placeholder = document.createElement("span");
+        placeholder.className = "placeholder";
+        placeholder.textContent = "解码后的图片将显示在这里";
+        decodePreviewBox.appendChild(placeholder);
+
+        decodeInfo.style.display = "none";
+        decodeActions.style.display = "none";
+        decodeStatus.className = "status";
+        decodedDataUrl = "";
+      }
+
+      window.decodeBase64 = function () {
+        let input = decodeInput.value.trim();
+        if (!input) {
+          showDecodeError("请输入 Base64 编码");
+          return;
+        }
+
+        // Detect format
+        let mimeType = "image/png";
+        const format = outputFormat.value;
+
+        if (input.startsWith("data:")) {
+          // Has Data URI prefix
+          const match = input.match(/^data:(image\/[^;]+);base64,/);
+          if (match) {
+            mimeType = match[1];
           }
-
-          const items = [
-            { label: "文件名", value: name },
-            { label: "尺寸", value: width + " × " + height },
-            { label: "原始大小", value: formatFileSize(originalSize) },
-            { label: "类型", value: type },
-            { label: "Base64 长度", value: base64Length.toLocaleString() + " 字符" }
-          ];
-
-          items.forEach((item) => {
-            const div = document.createElement("div");
-            div.className = "info-item";
-            const span = document.createElement("span");
-            span.textContent = item.label + "：";
-            const strong = document.createElement("strong");
-            strong.textContent = item.value;
-            div.appendChild(span);
-            div.appendChild(strong);
-            encodeInfo.appendChild(div);
-          });
-        }
-
-        function updateEncodeOutput() {
-          if (includePrefix.checked) {
-            encodeOutput.value = currentBase64;
+          decodedDataUrl = input;
+        } else {
+          // Raw Base64
+          if (format === "auto") {
+            // Try to detect from magic bytes
+            try {
+              const decoded = atob(input.substring(0, 16));
+              if (decoded.startsWith("\x89PNG")) mimeType = "image/png";
+              else if (decoded.startsWith("\xFF\xD8\xFF")) mimeType = "image/jpeg";
+              else if (decoded.startsWith("GIF8")) mimeType = "image/gif";
+              else if (decoded.startsWith("RIFF")) mimeType = "image/webp";
+            } catch (e) {
+              // Keep default
+            }
           } else {
-            encodeOutput.value = currentBase64.split(",")[1] || "";
+            mimeType = "image/" + format;
           }
+          decodedDataUrl = "data:" + mimeType + ";base64," + input;
         }
 
-        includePrefix.addEventListener("change", updateEncodeOutput);
-
-        document.getElementById("copyBase64Btn").addEventListener("click", () => {
-          navigator.clipboard.writeText(encodeOutput.value).then(() => {
-            showCopyFeedback("copyBase64Btn", "已复制!");
-          });
-        });
-
-        document.getElementById("copyImgTagBtn").addEventListener("click", () => {
-          const tag = '<img src="' + currentBase64 + '" alt="image">';
-          navigator.clipboard.writeText(tag).then(() => {
-            showCopyFeedback("copyImgTagBtn", "已复制!");
-          });
-        });
-
-        document.getElementById("copyCssBgBtn").addEventListener("click", () => {
-          const css = "background-image: url('" + currentBase64 + "');";
-          navigator.clipboard.writeText(css).then(() => {
-            showCopyFeedback("copyCssBgBtn", "已复制!");
-          });
-        });
-
-        function showCopyFeedback(btnId, msg) {
-          const btn = document.getElementById(btnId);
-          const original = btn.textContent;
-          btn.textContent = msg;
-          setTimeout(() => (btn.textContent = original), 2000);
-        }
-
-        // === DECODE ===
-        const decodeInput = document.getElementById("decodeInput");
-        const decodePreviewBox = document.getElementById("decodePreviewBox");
-        const decodeInfo = document.getElementById("decodeInfo");
-        const decodeActions = document.getElementById("decodeActions");
-        const decodeStatus = document.getElementById("decodeStatus");
-        const outputFormat = document.getElementById("outputFormat");
-
-        let decodedDataUrl = "";
-
-        document.getElementById("clearDecodeBtn").addEventListener("click", () => {
-          decodeInput.value = "";
-          resetDecodePreview();
-        });
-
-        document.getElementById("decodeBtn").addEventListener("click", function () {
-          window.decodeBase64();
-        });
-
-        function resetDecodePreview() {
+        // Try to load image
+        const img = new Image();
+        img.onload = () => {
           while (decodePreviewBox.firstChild) {
             decodePreviewBox.removeChild(decodePreviewBox.firstChild);
           }
-          const placeholder = document.createElement("span");
-          placeholder.className = "placeholder";
-          placeholder.textContent = "解码后的图片将显示在这里";
-          decodePreviewBox.appendChild(placeholder);
 
-          decodeInfo.style.display = "none";
-          decodeActions.style.display = "none";
-          decodeStatus.className = "status";
-          decodedDataUrl = "";
-        }
+          const previewImg = document.createElement("img");
+          previewImg.src = decodedDataUrl;
+          decodePreviewBox.appendChild(previewImg);
 
-        window.decodeBase64 = function () {
-          let input = decodeInput.value.trim();
-          if (!input) {
-            showDecodeError("请输入 Base64 编码");
-            return;
-          }
+          renderDecodeInfo(img.width, img.height, mimeType, input.length);
 
-          // Detect format
-          let mimeType = "image/png";
-          const format = outputFormat.value;
+          decodeInfo.style.display = "flex";
+          decodeActions.style.display = "flex";
 
-          if (input.startsWith("data:")) {
-            // Has Data URI prefix
-            const match = input.match(/^data:(image\/[^;]+);base64,/);
-            if (match) {
-              mimeType = match[1];
-            }
-            decodedDataUrl = input;
-          } else {
-            // Raw Base64
-            if (format === "auto") {
-              // Try to detect from magic bytes
-              try {
-                const decoded = atob(input.substring(0, 16));
-                if (decoded.startsWith("\x89PNG")) mimeType = "image/png";
-                else if (decoded.startsWith("\xFF\xD8\xFF")) mimeType = "image/jpeg";
-                else if (decoded.startsWith("GIF8")) mimeType = "image/gif";
-                else if (decoded.startsWith("RIFF")) mimeType = "image/webp";
-              } catch (e) {
-                // Keep default
-              }
-            } else {
-              mimeType = "image/" + format;
-            }
-            decodedDataUrl = "data:" + mimeType + ";base64," + input;
-          }
-
-          // Try to load image
-          const img = new Image();
-          img.onload = () => {
-            while (decodePreviewBox.firstChild) {
-              decodePreviewBox.removeChild(decodePreviewBox.firstChild);
-            }
-
-            const previewImg = document.createElement("img");
-            previewImg.src = decodedDataUrl;
-            decodePreviewBox.appendChild(previewImg);
-
-            renderDecodeInfo(img.width, img.height, mimeType, input.length);
-
-            decodeInfo.style.display = "flex";
-            decodeActions.style.display = "flex";
-
-            decodeStatus.className = "status success";
-            decodeStatus.textContent = "解码成功!";
-          };
-
-          img.onerror = () => {
-            showDecodeError("无效的图片数据，请检查 Base64 编码");
-          };
-
-          img.src = decodedDataUrl;
+          decodeStatus.className = "status success";
+          decodeStatus.textContent = "解码成功!";
         };
 
-        function renderDecodeInfo(width, height, type, base64Length) {
-          while (decodeInfo.firstChild) {
-            decodeInfo.removeChild(decodeInfo.firstChild);
-          }
+        img.onerror = () => {
+          showDecodeError("无效的图片数据，请检查 Base64 编码");
+        };
 
-          const items = [
-            { label: "尺寸", value: width + " × " + height },
-            { label: "类型", value: type },
-            { label: "Base64 长度", value: base64Length.toLocaleString() + " 字符" }
-          ];
+        img.src = decodedDataUrl;
+      };
 
-          items.forEach((item) => {
-            const div = document.createElement("div");
-            div.className = "info-item";
-            const span = document.createElement("span");
-            span.textContent = item.label + "：";
-            const strong = document.createElement("strong");
-            strong.textContent = item.value;
-            div.appendChild(span);
-            div.appendChild(strong);
-            decodeInfo.appendChild(div);
-          });
+      function renderDecodeInfo(width, height, type, base64Length) {
+        while (decodeInfo.firstChild) {
+          decodeInfo.removeChild(decodeInfo.firstChild);
         }
 
-        function showDecodeError(msg) {
-          decodeStatus.className = "status error";
-          decodeStatus.textContent = msg;
-        }
+        const items = [
+          { label: "尺寸", value: width + " × " + height },
+          { label: "类型", value: type },
+          { label: "Base64 长度", value: base64Length.toLocaleString() + " 字符" }
+        ];
 
-        document.getElementById("downloadImageBtn").addEventListener("click", () => {
-          if (!decodedDataUrl) return;
-
-          // Extract extension from mime type
-          const match = decodedDataUrl.match(/^data:image\/([^;]+);/);
-          const ext = match ? match[1].replace("jpeg", "jpg") : "png";
-
-          const link = document.createElement("a");
-          link.href = decodedDataUrl;
-          link.download = "decoded_image." + ext;
-          link.click();
+        items.forEach((item) => {
+          const div = document.createElement("div");
+          div.className = "info-item";
+          const span = document.createElement("span");
+          span.textContent = item.label + "：";
+          const strong = document.createElement("strong");
+          strong.textContent = item.value;
+          div.appendChild(span);
+          div.appendChild(strong);
+          decodeInfo.appendChild(div);
         });
+      }
 
-        window.formatFileSize = function (bytes) {
-          if (bytes < 1024) return bytes + " B";
-          if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
-          return (bytes / (1024 * 1024)).toFixed(2) + " MB";
-        };
+      function showDecodeError(msg) {
+        decodeStatus.className = "status error";
+        decodeStatus.textContent = msg;
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          const html = document.documentElement;
-          const currentTheme = html.getAttribute("data-theme");
-          const newTheme = currentTheme === "light" ? "dark" : "light";
-          html.setAttribute("data-theme", newTheme);
-          document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-          localStorage.setItem("theme", newTheme);
-        }
+      document.getElementById("downloadImageBtn").addEventListener("click", () => {
+        if (!decodedDataUrl) return;
 
-        // Load saved theme
-        const savedTheme = localStorage.getItem("theme") || "dark";
-        if (savedTheme === "light") {
-          document.documentElement.setAttribute("data-theme", "light");
-          document.getElementById("theme-icon").textContent = "☀️";
-        }
-</script>
-    
+        // Extract extension from mime type
+        const match = decodedDataUrl.match(/^data:image\/([^;]+);/);
+        const ext = match ? match[1].replace("jpeg", "jpg") : "png";
+
+        const link = document.createElement("a");
+        link.href = decodedDataUrl;
+        link.download = "decoded_image." + ext;
+        link.click();
+      });
+
+      window.formatFileSize = function (bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+      };
+
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
+
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/media/image-compressor.html
+++ b/tools/media/image-compressor.html
@@ -1148,78 +1148,77 @@
 
     <script type="application/ld+json">
       {
-              "@context": "https://schema.org",
-              "@type": "BreadcrumbList",
-              "itemListElement": [
-                {
-                  "@type": "ListItem",
-                  "position": 1,
-                  "name": "首页",
-                  "item": "https://tools.realtime-ai.chat/"
-                },
-                {
-                  "@type": "ListItem",
-                  "position": 2,
-                  "name": "媒体工具",
-                  "item": "https://tools.realtime-ai.chat/#media"
-                },
-                {
-                  "@type": "ListItem",
-                  "position": 3,
-                  "name": "图片压缩",
-                  "item": "https://tools.realtime-ai.chat/tools/media/image-compressor.html"
-                }
-              ]
-            }
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "媒体工具",
+            "item": "https://tools.realtime-ai.chat/#media"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "图片压缩",
+            "item": "https://tools.realtime-ai.chat/tools/media/image-compressor.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
       {
-              "@context": "https://schema.org",
-              "@type": "FAQPage",
-              "mainEntity": [
-                {
-                  "@type": "Question",
-                  "name": "这个图片压缩工具安全吗？图片会上传到服务器吗？",
-                  "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "完全安全。所有图片压缩都在你的浏览器本地完成，使用 HTML5 Canvas API 处理，图片数据不会上传到任何服务器，也不会被保存或记录。"
-                  }
-                },
-                {
-                  "@type": "Question",
-                  "name": "压缩质量滑块设置多少合适？",
-                  "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "对于日常照片分享，建议将质量设置在 70%~85% 之间，能在文件大小与视觉效果之间取得良好平衡。若追求最小体积可降至 50%，若要保留最高画质则设置 90% 以上。"
-                  }
-                },
-                {
-                  "@type": "Question",
-                  "name": "JPEG、PNG 和 WebP 输出格式有什么区别？",
-                  "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "JPEG 适合照片类图片，压缩率高但不支持透明；PNG 支持透明背景，适合图标和截图，体积通常较大；WebP 是现代格式，在相同质量下比 JPEG 小约 30%，且支持透明，推荐优先选用。"
-                  }
-                },
-                {
-                  "@type": "Question",
-                  "name": "最大尺寸选项有什么作用？",
-                  "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "「最大尺寸」会按比例缩放图片，使宽和高均不超过所设定的像素值，适合将大尺寸图片压缩到适合网页或社交媒体分发的尺寸。选择「原尺寸」则只压缩质量，不改变分辨率。"
-                  }
-                },
-                {
-                  "@type": "Question",
-                  "name": "图片压缩工具可以离线使用吗？",
-                  "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常压缩图片，无需安装或注册任何账号。"
-                  }
-                }
-              ]
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "这个图片压缩工具安全吗？图片会上传到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有图片压缩都在你的浏览器本地完成，使用 HTML5 Canvas API 处理，图片数据不会上传到任何服务器，也不会被保存或记录。"
             }
+          },
+          {
+            "@type": "Question",
+            "name": "压缩质量滑块设置多少合适？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "对于日常照片分享，建议将质量设置在 70%~85% 之间，能在文件大小与视觉效果之间取得良好平衡。若追求最小体积可降至 50%，若要保留最高画质则设置 90% 以上。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "JPEG、PNG 和 WebP 输出格式有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "JPEG 适合照片类图片，压缩率高但不支持透明；PNG 支持透明背景，适合图标和截图，体积通常较大；WebP 是现代格式，在相同质量下比 JPEG 小约 30%，且支持透明，推荐优先选用。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "最大尺寸选项有什么作用？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "「最大尺寸」会按比例缩放图片，使宽和高均不超过所设定的像素值，适合将大尺寸图片压缩到适合网页或社交媒体分发的尺寸。选择「原尺寸」则只压缩质量，不改变分辨率。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "图片压缩工具可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常压缩图片，无需安装或注册任何账号。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
       let originalFile = null;

--- a/tools/office/invoice-maker.html
+++ b/tools/office/invoice-maker.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Invoice Maker - WebUtils" />
-    <meta property="og:description" content="Invoice Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Invoice Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/invoice-maker.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Invoice Maker - WebUtils" />
-    <meta name="twitter:description" content="Invoice Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Invoice Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Invoice Maker",
-      "item": "https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Invoice Maker",
+            "item": "https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Invoice Maker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Invoice Maker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1117 +97,1128 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
-  }
-
-  .form-grid-2 {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  input[type="email"],
-  input[type="tel"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 80px;
-    resize: vertical;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-danger {
-    background: var(--accent-red);
-    color: #fff;
-  }
-
-  .btn-danger:hover {
-    opacity: 0.9;
-  }
-
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
-
-  /* Line Items Table */
-  .line-items-container {
-    overflow-x: auto;
-  }
-
-  .line-items-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 16px;
-  }
-
-  .line-items-table th,
-  .line-items-table td {
-    padding: 12px;
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-
-  .line-items-table th {
-    color: var(--color-text-secondary);
-    font-weight: 500;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.5px;
-  }
-
-  .line-items-table input {
-    width: 100%;
-    min-width: 80px;
-  }
-
-  .line-items-table .desc-col {
-    min-width: 200px;
-  }
-
-  .line-items-table .num-col {
-    width: 100px;
-  }
-
-  .line-items-table .amount-col {
-    width: 120px;
-    text-align: right;
-    color: var(--color-accent-cyan);
-    font-weight: 500;
-  }
-
-  .line-items-table .action-col {
-    width: 60px;
-    text-align: center;
-  }
-
-  .btn-remove {
-    background: transparent;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 1.2rem;
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    transition: background 0.2s;
-  }
-
-  .btn-remove:hover {
-    background: rgba(244, 63, 94, 0.1);
-  }
-
-  /* Summary Section */
-  .summary-section {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 16px;
-  }
-
-  .summary-box {
-    min-width: 300px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-  }
-
-  .summary-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 0;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  .summary-row.total {
-    border-top: 2px solid var(--border-strong);
-    margin-top: 8px;
-    padding-top: 16px;
-    font-size: 1.1rem;
-    font-weight: 600;
-  }
-
-  .summary-row .label {
-    color: var(--color-text-secondary);
-  }
-
-  .summary-row .value {
-    color: var(--color-text-primary);
-  }
-
-  .summary-row.total .value {
-    color: var(--color-accent-cyan);
-  }
-
-  .tax-input {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .tax-input input {
-    width: 80px;
-    text-align: right;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
-
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .btn-remove,
-    .no-print {
-      display: none !important;
-    }
-
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
-
-    .tool-section {
-      page-break-inside: avoid;
-    }
-
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
-
-    input,
-    textarea,
-    select {
-      border: none !important;
-      background: transparent !important;
-      padding: 4px 0 !important;
-      color: #000 !important;
-    }
-
-    .line-items-table {
-      border: 1px solid #ddd;
-    }
-
-    .line-items-table th,
-    .line-items-table td {
-      border: 1px solid #ddd;
-      color: #000;
-    }
-
-    .line-items-table .amount-col {
-      color: #000;
-    }
-
-    .summary-box {
-      background: #f9f9f9;
-      border-color: #ddd;
-    }
-
-    .summary-row .label,
-    .summary-row .value,
-    .summary-row.total .value {
-      color: #000;
-    }
-
-    .input-label {
-      display: none;
-    }
-
-    .form-grid,
-    .form-grid-2 {
-      display: block;
-    }
-
-    .input-group {
-      display: inline-block;
-      margin-right: 16px;
-    }
-
-    .invoice-header-print {
-      display: flex !important;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 32px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
-
-    .print-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #000;
-    }
-
-    .print-info {
-      text-align: right;
-    }
-  }
-
-  .invoice-header-print {
-    display: none;
-  }
-
-  @media (max-width: 768px) {
-    .form-grid-2 {
-      grid-template-columns: 1fr;
-    }
-
-    .summary-section {
-      justify-content: stretch;
-    }
-
-    .summary-box {
-      width: 100%;
-      min-width: auto;
-    }
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .line-items-table .desc-col {
-      min-width: 150px;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 16px;
+      }
+
+      .form-grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      input[type="date"],
+      input[type="email"],
+      input[type="tel"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 80px;
+        resize: vertical;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-danger {
+        background: var(--accent-red);
+        color: #fff;
+      }
+
+      .btn-danger:hover {
+        opacity: 0.9;
+      }
+
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
+
+      /* Line Items Table */
+      .line-items-container {
+        overflow-x: auto;
+      }
+
+      .line-items-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 16px;
+      }
+
+      .line-items-table th,
+      .line-items-table td {
+        padding: 12px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-subtle);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+
+      .line-items-table th {
+        color: var(--color-text-secondary);
+        font-weight: 500;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.5px;
+      }
+
+      .line-items-table input {
+        width: 100%;
+        min-width: 80px;
+      }
+
+      .line-items-table .desc-col {
+        min-width: 200px;
+      }
+
+      .line-items-table .num-col {
+        width: 100px;
+      }
+
+      .line-items-table .amount-col {
+        width: 120px;
+        text-align: right;
+        color: var(--color-accent-cyan);
+        font-weight: 500;
+      }
+
+      .line-items-table .action-col {
+        width: 60px;
+        text-align: center;
+      }
+
+      .btn-remove {
+        background: transparent;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 1.2rem;
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        transition: background 0.2s;
+      }
+
+      .btn-remove:hover {
+        background: rgba(244, 63, 94, 0.1);
+      }
+
+      /* Summary Section */
+      .summary-section {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 16px;
+      }
+
+      .summary-box {
+        min-width: 300px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+      }
+
+      .summary-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 0;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .summary-row.total {
+        border-top: 2px solid var(--border-strong);
+        margin-top: 8px;
+        padding-top: 16px;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+
+      .summary-row .label {
+        color: var(--color-text-secondary);
+      }
+
+      .summary-row .value {
+        color: var(--color-text-primary);
+      }
+
+      .summary-row.total .value {
+        color: var(--color-accent-cyan);
+      }
+
+      .tax-input {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .tax-input input {
+        width: 80px;
+        text-align: right;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
+
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .btn-remove,
+        .no-print {
+          display: none !important;
+        }
+
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
+
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
+
+        .tool-section {
+          page-break-inside: avoid;
+        }
+
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
+
+        input,
+        textarea,
+        select {
+          border: none !important;
+          background: transparent !important;
+          padding: 4px 0 !important;
+          color: #000 !important;
+        }
+
+        .line-items-table {
+          border: 1px solid #ddd;
+        }
+
+        .line-items-table th,
+        .line-items-table td {
+          border: 1px solid #ddd;
+          color: #000;
+        }
+
+        .line-items-table .amount-col {
+          color: #000;
+        }
+
+        .summary-box {
+          background: #f9f9f9;
+          border-color: #ddd;
+        }
+
+        .summary-row .label,
+        .summary-row .value,
+        .summary-row.total .value {
+          color: #000;
+        }
+
+        .input-label {
+          display: none;
+        }
+
+        .form-grid,
+        .form-grid-2 {
+          display: block;
+        }
+
+        .input-group {
+          display: inline-block;
+          margin-right: 16px;
+        }
+
+        .invoice-header-print {
+          display: flex !important;
+          justify-content: space-between;
+          align-items: flex-start;
+          margin-bottom: 32px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
+
+        .print-title {
+          font-size: 2rem;
+          font-weight: 700;
+          color: #000;
+        }
+
+        .print-info {
+          text-align: right;
+        }
+      }
+
+      .invoice-header-print {
+        display: none;
+      }
+
+      @media (max-width: 768px) {
+        .form-grid-2 {
+          grid-template-columns: 1fr;
+        }
+
+        .summary-section {
+          justify-content: stretch;
+        }
+
+        .summary-box {
+          width: 100%;
+          min-width: auto;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .line-items-table .desc-col {
+          min-width: 150px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">发票生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🧾</span>
-        发票生成器
-      </h1>
-      <p>创建专业发票，支持明细项目、税率计算、打印导出</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <!-- Print Header (only visible when printing) -->
-    <div class="invoice-header-print">
-      <div class="print-title">发 票</div>
-      <div class="print-info">
-        <div id="printInvoiceNo"></div>
-        <div id="printInvoiceDate"></div>
-      </div>
-    </div>
-
-    <!-- Company Info -->
-    <div class="tool-section">
-      <div class="section-title">公司信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">公司名称</label>
-          <input type="text" id="companyName" placeholder="您的公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">公司地址</label>
-          <input type="text" id="companyAddress" placeholder="公司地址">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="companyPhone" placeholder="联系电话">
-        </div>
-        <div class="input-group">
-          <label class="input-label">电子邮箱</label>
-          <input type="email" id="companyEmail" placeholder="company@example.com">
-        </div>
-      </div>
-    </div>
-
-    <!-- Client Info -->
-    <div class="tool-section">
-      <div class="section-title">客户信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">客户名称</label>
-          <input type="text" id="clientName" placeholder="客户/公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">客户地址</label>
-          <input type="text" id="clientAddress" placeholder="客户地址">
-        </div>
-      </div>
-    </div>
-
-    <!-- Invoice Details -->
-    <div class="tool-section">
-      <div class="section-title">发票信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">发票编号</label>
-          <input type="text" id="invoiceNo" readonly="">
-        </div>
-        <div class="input-group">
-          <label class="input-label">开票日期</label>
-          <input type="date" id="invoiceDate">
-        </div>
-        <div class="input-group">
-          <label class="input-label">付款截止日期</label>
-          <input type="date" id="dueDate">
-        </div>
-      </div>
-    </div>
-
-    <!-- Line Items -->
-    <div class="tool-section">
-      <div class="section-title">明细项目</div>
-      <div class="line-items-container">
-        <table class="line-items-table">
-          <thead>
-            <tr>
-              <th class="desc-col">描述</th>
-              <th class="num-col">数量</th>
-              <th class="num-col">单价</th>
-              <th class="amount-col">金额</th>
-              <th class="action-col no-print"></th>
-            </tr>
-          </thead>
-          <tbody id="lineItemsBody">
-            <!-- Line items will be added here -->
-          </tbody>
-        </table>
-      </div>
-      <div class="btn-row no-print">
-        <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
-      </div>
-
-      <!-- Summary -->
-      <div class="summary-section">
-        <div class="summary-box">
-          <div class="summary-row">
-            <span class="label">小计</span>
-            <span class="value" id="subtotal">¥0.00</span>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">发票生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🧾</span>
+              发票生成器
+            </h1>
+            <p>创建专业发票，支持明细项目、税率计算、打印导出</p>
           </div>
-          <div class="summary-row">
-            <span class="label">税率</span>
-            <span class="tax-input no-print">
-              <input type="number" id="taxRate" value="0" min="0" max="100" step="0.1" onchange="calculateTotals()">
-              <span>%</span>
-            </span>
-            <span class="value print-only" id="taxRateDisplay" style="display: none"></span>
+        </header>
+
+        <main class="main-content">
+          <!-- Print Header (only visible when printing) -->
+          <div class="invoice-header-print">
+            <div class="print-title">发 票</div>
+            <div class="print-info">
+              <div id="printInvoiceNo"></div>
+              <div id="printInvoiceDate"></div>
+            </div>
           </div>
-          <div class="summary-row">
-            <span class="label">税额</span>
-            <span class="value" id="taxAmount">¥0.00</span>
+
+          <!-- Company Info -->
+          <div class="tool-section">
+            <div class="section-title">公司信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">公司名称</label>
+                <input type="text" id="companyName" placeholder="您的公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">公司地址</label>
+                <input type="text" id="companyAddress" placeholder="公司地址" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="companyPhone" placeholder="联系电话" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">电子邮箱</label>
+                <input type="email" id="companyEmail" placeholder="company@example.com" />
+              </div>
+            </div>
           </div>
-          <div class="summary-row total">
-            <span class="label">总计</span>
-            <span class="value" id="total">¥0.00</span>
+
+          <!-- Client Info -->
+          <div class="tool-section">
+            <div class="section-title">客户信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">客户名称</label>
+                <input type="text" id="clientName" placeholder="客户/公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">客户地址</label>
+                <input type="text" id="clientAddress" placeholder="客户地址" />
+              </div>
+            </div>
           </div>
-        </div>
+
+          <!-- Invoice Details -->
+          <div class="tool-section">
+            <div class="section-title">发票信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">发票编号</label>
+                <input type="text" id="invoiceNo" readonly="" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">开票日期</label>
+                <input type="date" id="invoiceDate" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">付款截止日期</label>
+                <input type="date" id="dueDate" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Line Items -->
+          <div class="tool-section">
+            <div class="section-title">明细项目</div>
+            <div class="line-items-container">
+              <table class="line-items-table">
+                <thead>
+                  <tr>
+                    <th class="desc-col">描述</th>
+                    <th class="num-col">数量</th>
+                    <th class="num-col">单价</th>
+                    <th class="amount-col">金额</th>
+                    <th class="action-col no-print"></th>
+                  </tr>
+                </thead>
+                <tbody id="lineItemsBody">
+                  <!-- Line items will be added here -->
+                </tbody>
+              </table>
+            </div>
+            <div class="btn-row no-print">
+              <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
+            </div>
+
+            <!-- Summary -->
+            <div class="summary-section">
+              <div class="summary-box">
+                <div class="summary-row">
+                  <span class="label">小计</span>
+                  <span class="value" id="subtotal">¥0.00</span>
+                </div>
+                <div class="summary-row">
+                  <span class="label">税率</span>
+                  <span class="tax-input no-print">
+                    <input
+                      type="number"
+                      id="taxRate"
+                      value="0"
+                      min="0"
+                      max="100"
+                      step="0.1"
+                      onchange="calculateTotals()"
+                    />
+                    <span>%</span>
+                  </span>
+                  <span class="value print-only" id="taxRateDisplay" style="display: none"></span>
+                </div>
+                <div class="summary-row">
+                  <span class="label">税额</span>
+                  <span class="value" id="taxAmount">¥0.00</span>
+                </div>
+                <div class="summary-row total">
+                  <span class="label">总计</span>
+                  <span class="value" id="total">¥0.00</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Notes -->
+          <div class="tool-section">
+            <div class="section-title">备注/条款</div>
+            <div class="input-group">
+              <textarea id="notes" placeholder="付款条款、备注说明等..."></textarea>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printInvoice()">🖨️ 打印发票</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- Notes -->
-    <div class="tool-section">
-      <div class="section-title">备注/条款</div>
-      <div class="input-group">
-        <textarea id="notes" placeholder="付款条款、备注说明等..."></textarea>
-      </div>
-    </div>
-
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printInvoice()">🖨️ 打印发票</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "发票生成器",
-              "item": "https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "发票生成器",
+            "item": "https://tools.realtime-ai.chat/tools/office/invoice-maker.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "invoice_maker_data_v1";
+      var lineItems = [];
+      var itemIdCounter = 0;
 
-  var LS_KEY = "invoice_maker_data_v1";
-        var lineItems = [];
-        var itemIdCounter = 0;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-
-          // Generate invoice number if empty
-          var invoiceNoEl = document.getElementById("invoiceNo");
-          if (!invoiceNoEl.value) {
-            invoiceNoEl.value = generateInvoiceNumber();
-          }
-
-          // Set default dates if empty
-          var today = new Date().toISOString().split("T")[0];
-          var invoiceDateEl = document.getElementById("invoiceDate");
-          if (!invoiceDateEl.value) {
-            invoiceDateEl.value = today;
-          }
-
-          var dueDateEl = document.getElementById("dueDate");
-          if (!dueDateEl.value) {
-            var dueDate = new Date();
-            dueDate.setDate(dueDate.getDate() + 30);
-            dueDateEl.value = dueDate.toISOString().split("T")[0];
-          }
-
-          // Add initial line item if none exist
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-          }
-
-          // Add input listeners for auto-save
-          var inputs = document.querySelectorAll("input, textarea");
-          for (var i = 0; i < inputs.length; i++) {
-            inputs[i].addEventListener("input", debounce(saveToStorage, 500));
-          }
+        // Generate invoice number if empty
+        var invoiceNoEl = document.getElementById("invoiceNo");
+        if (!invoiceNoEl.value) {
+          invoiceNoEl.value = generateInvoiceNumber();
         }
 
-        // Generate unique invoice number
-        function generateInvoiceNumber() {
-          var date = new Date();
-          var year = date.getFullYear();
-          var month = String(date.getMonth() + 1).padStart(2, "0");
-          var day = String(date.getDate()).padStart(2, "0");
-          var random = Math.floor(Math.random() * 1000)
-            .toString()
-            .padStart(3, "0");
-          return "INV-" + year + month + day + "-" + random;
+        // Set default dates if empty
+        var today = new Date().toISOString().split("T")[0];
+        var invoiceDateEl = document.getElementById("invoiceDate");
+        if (!invoiceDateEl.value) {
+          invoiceDateEl.value = today;
         }
 
-        // Add new line item
-        function addLineItem() {
-          var item = {
-            id: ++itemIdCounter,
-            description: "",
-            quantity: 1,
-            unitPrice: 0
-          };
-          lineItems.push(item);
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Remove line item
-        function removeLineItem(id) {
-          lineItems = lineItems.filter(function (item) {
-            return item.id !== id;
-          });
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-            calculateTotals();
-            saveToStorage();
-          }
-        }
-
-        // Create line item row using DOM methods
-        function createLineItemRow(item) {
-          var row = document.createElement("tr");
-          var amount = item.quantity * item.unitPrice;
-
-          // Description cell
-          var descCell = document.createElement("td");
-          descCell.className = "desc-col";
-          var descInput = document.createElement("input");
-          descInput.type = "text";
-          descInput.value = item.description;
-          descInput.placeholder = "项目描述";
-          descInput.addEventListener("change", function () {
-            updateLineItem(item.id, "description", this.value);
-          });
-          descCell.appendChild(descInput);
-          row.appendChild(descCell);
-
-          // Quantity cell
-          var qtyCell = document.createElement("td");
-          qtyCell.className = "num-col";
-          var qtyInput = document.createElement("input");
-          qtyInput.type = "number";
-          qtyInput.value = item.quantity;
-          qtyInput.min = "0";
-          qtyInput.step = "1";
-          qtyInput.addEventListener("change", function () {
-            updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
-          });
-          qtyCell.appendChild(qtyInput);
-          row.appendChild(qtyCell);
-
-          // Unit price cell
-          var priceCell = document.createElement("td");
-          priceCell.className = "num-col";
-          var priceInput = document.createElement("input");
-          priceInput.type = "number";
-          priceInput.value = item.unitPrice;
-          priceInput.min = "0";
-          priceInput.step = "0.01";
-          priceInput.addEventListener("change", function () {
-            updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
-          });
-          priceCell.appendChild(priceInput);
-          row.appendChild(priceCell);
-
-          // Amount cell
-          var amountCell = document.createElement("td");
-          amountCell.className = "amount-col";
-          amountCell.textContent = "¥" + formatNumber(amount);
-          row.appendChild(amountCell);
-
-          // Action cell
-          var actionCell = document.createElement("td");
-          actionCell.className = "action-col no-print";
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove";
-          removeBtn.title = "删除";
-          removeBtn.textContent = "×";
-          removeBtn.addEventListener("click", function () {
-            removeLineItem(item.id);
-          });
-          actionCell.appendChild(removeBtn);
-          row.appendChild(actionCell);
-
-          return row;
-        }
-
-        // Render line items
-        function renderLineItems() {
-          var tbody = document.getElementById("lineItemsBody");
-          tbody.textContent = "";
-
-          for (var i = 0; i < lineItems.length; i++) {
-            var row = createLineItemRow(lineItems[i]);
-            tbody.appendChild(row);
-          }
-
-          calculateTotals();
-        }
-
-        // Update line item
-        function updateLineItem(id, field, value) {
-          for (var i = 0; i < lineItems.length; i++) {
-            if (lineItems[i].id === id) {
-              lineItems[i][field] = value;
-              break;
-            }
-          }
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Calculate totals
-        function calculateTotals() {
-          var subtotal = 0;
-          for (var i = 0; i < lineItems.length; i++) {
-            subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
-          }
-
-          var taxRate = parseFloat(document.getElementById("taxRate").value) || 0;
-          var taxAmount = subtotal * (taxRate / 100);
-          var total = subtotal + taxAmount;
-
-          document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
-          document.getElementById("taxAmount").textContent = "¥" + formatNumber(taxAmount);
-          document.getElementById("total").textContent = "¥" + formatNumber(total);
-
-          saveToStorage();
-        }
-
-        // Format number
-        function formatNumber(num) {
-          return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-          };
-        }
-
-        // Print invoice
-        function printInvoice() {
-          // Update print header info
-          document.getElementById("printInvoiceNo").textContent =
-            "发票编号: " + document.getElementById("invoiceNo").value;
-          document.getElementById("printInvoiceDate").textContent =
-            "日期: " + document.getElementById("invoiceDate").value;
-
-          // Show tax rate as text for print
-          var taxRateDisplay = document.getElementById("taxRateDisplay");
-          taxRateDisplay.textContent = document.getElementById("taxRate").value + "%";
-          taxRateDisplay.style.display = "inline";
-
-          window.print();
-
-          // Hide after print
-          setTimeout(function () {
-            taxRateDisplay.style.display = "none";
-          }, 100);
-        }
-
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
-
-          // Clear inputs
-          document.getElementById("companyName").value = "";
-          document.getElementById("companyAddress").value = "";
-          document.getElementById("companyPhone").value = "";
-          document.getElementById("companyEmail").value = "";
-          document.getElementById("clientName").value = "";
-          document.getElementById("clientAddress").value = "";
-          document.getElementById("invoiceNo").value = generateInvoiceNumber();
-          document.getElementById("invoiceDate").value = new Date().toISOString().split("T")[0];
+        var dueDateEl = document.getElementById("dueDate");
+        if (!dueDateEl.value) {
           var dueDate = new Date();
           dueDate.setDate(dueDate.getDate() + 30);
-          document.getElementById("dueDate").value = dueDate.toISOString().split("T")[0];
-          document.getElementById("taxRate").value = "0";
-          document.getElementById("notes").value = "";
+          dueDateEl.value = dueDate.toISOString().split("T")[0];
+        }
 
-          // Reset line items
-          lineItems = [];
-          itemIdCounter = 0;
+        // Add initial line item if none exist
+        if (lineItems.length === 0) {
           addLineItem();
-
-          // Clear storage
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
+        } else {
+          renderLineItems();
         }
 
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            companyName: document.getElementById("companyName").value,
-            companyAddress: document.getElementById("companyAddress").value,
-            companyPhone: document.getElementById("companyPhone").value,
-            companyEmail: document.getElementById("companyEmail").value,
-            clientName: document.getElementById("clientName").value,
-            clientAddress: document.getElementById("clientAddress").value,
-            invoiceNo: document.getElementById("invoiceNo").value,
-            invoiceDate: document.getElementById("invoiceDate").value,
-            dueDate: document.getElementById("dueDate").value,
-            taxRate: document.getElementById("taxRate").value,
-            notes: document.getElementById("notes").value,
-            lineItems: lineItems,
-            itemIdCounter: itemIdCounter
+        // Add input listeners for auto-save
+        var inputs = document.querySelectorAll("input, textarea");
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].addEventListener("input", debounce(saveToStorage, 500));
+        }
+      }
+
+      // Generate unique invoice number
+      function generateInvoiceNumber() {
+        var date = new Date();
+        var year = date.getFullYear();
+        var month = String(date.getMonth() + 1).padStart(2, "0");
+        var day = String(date.getDate()).padStart(2, "0");
+        var random = Math.floor(Math.random() * 1000)
+          .toString()
+          .padStart(3, "0");
+        return "INV-" + year + month + day + "-" + random;
+      }
+
+      // Add new line item
+      function addLineItem() {
+        var item = {
+          id: ++itemIdCounter,
+          description: "",
+          quantity: 1,
+          unitPrice: 0
+        };
+        lineItems.push(item);
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Remove line item
+      function removeLineItem(id) {
+        lineItems = lineItems.filter(function (item) {
+          return item.id !== id;
+        });
+        if (lineItems.length === 0) {
+          addLineItem();
+        } else {
+          renderLineItems();
+          calculateTotals();
+          saveToStorage();
+        }
+      }
+
+      // Create line item row using DOM methods
+      function createLineItemRow(item) {
+        var row = document.createElement("tr");
+        var amount = item.quantity * item.unitPrice;
+
+        // Description cell
+        var descCell = document.createElement("td");
+        descCell.className = "desc-col";
+        var descInput = document.createElement("input");
+        descInput.type = "text";
+        descInput.value = item.description;
+        descInput.placeholder = "项目描述";
+        descInput.addEventListener("change", function () {
+          updateLineItem(item.id, "description", this.value);
+        });
+        descCell.appendChild(descInput);
+        row.appendChild(descCell);
+
+        // Quantity cell
+        var qtyCell = document.createElement("td");
+        qtyCell.className = "num-col";
+        var qtyInput = document.createElement("input");
+        qtyInput.type = "number";
+        qtyInput.value = item.quantity;
+        qtyInput.min = "0";
+        qtyInput.step = "1";
+        qtyInput.addEventListener("change", function () {
+          updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
+        });
+        qtyCell.appendChild(qtyInput);
+        row.appendChild(qtyCell);
+
+        // Unit price cell
+        var priceCell = document.createElement("td");
+        priceCell.className = "num-col";
+        var priceInput = document.createElement("input");
+        priceInput.type = "number";
+        priceInput.value = item.unitPrice;
+        priceInput.min = "0";
+        priceInput.step = "0.01";
+        priceInput.addEventListener("change", function () {
+          updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
+        });
+        priceCell.appendChild(priceInput);
+        row.appendChild(priceCell);
+
+        // Amount cell
+        var amountCell = document.createElement("td");
+        amountCell.className = "amount-col";
+        amountCell.textContent = "¥" + formatNumber(amount);
+        row.appendChild(amountCell);
+
+        // Action cell
+        var actionCell = document.createElement("td");
+        actionCell.className = "action-col no-print";
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove";
+        removeBtn.title = "删除";
+        removeBtn.textContent = "×";
+        removeBtn.addEventListener("click", function () {
+          removeLineItem(item.id);
+        });
+        actionCell.appendChild(removeBtn);
+        row.appendChild(actionCell);
+
+        return row;
+      }
+
+      // Render line items
+      function renderLineItems() {
+        var tbody = document.getElementById("lineItemsBody");
+        tbody.textContent = "";
+
+        for (var i = 0; i < lineItems.length; i++) {
+          var row = createLineItemRow(lineItems[i]);
+          tbody.appendChild(row);
+        }
+
+        calculateTotals();
+      }
+
+      // Update line item
+      function updateLineItem(id, field, value) {
+        for (var i = 0; i < lineItems.length; i++) {
+          if (lineItems[i].id === id) {
+            lineItems[i][field] = value;
+            break;
+          }
+        }
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Calculate totals
+      function calculateTotals() {
+        var subtotal = 0;
+        for (var i = 0; i < lineItems.length; i++) {
+          subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
+        }
+
+        var taxRate = parseFloat(document.getElementById("taxRate").value) || 0;
+        var taxAmount = subtotal * (taxRate / 100);
+        var total = subtotal + taxAmount;
+
+        document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
+        document.getElementById("taxAmount").textContent = "¥" + formatNumber(taxAmount);
+        document.getElementById("total").textContent = "¥" + formatNumber(total);
+
+        saveToStorage();
+      }
+
+      // Format number
+      function formatNumber(num) {
+        return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      }
+
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
+            clearTimeout(timeout);
+            func.apply(context, args);
           };
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
 
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
+      // Print invoice
+      function printInvoice() {
+        // Update print header info
+        document.getElementById("printInvoiceNo").textContent =
+          "发票编号: " + document.getElementById("invoiceNo").value;
+        document.getElementById("printInvoiceDate").textContent =
+          "日期: " + document.getElementById("invoiceDate").value;
 
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
+        // Show tax rate as text for print
+        var taxRateDisplay = document.getElementById("taxRateDisplay");
+        taxRateDisplay.textContent = document.getElementById("taxRate").value + "%";
+        taxRateDisplay.style.display = "inline";
 
-          try {
-            var data = JSON.parse(saved);
+        window.print();
 
-            document.getElementById("companyName").value = data.companyName || "";
-            document.getElementById("companyAddress").value = data.companyAddress || "";
-            document.getElementById("companyPhone").value = data.companyPhone || "";
-            document.getElementById("companyEmail").value = data.companyEmail || "";
-            document.getElementById("clientName").value = data.clientName || "";
-            document.getElementById("clientAddress").value = data.clientAddress || "";
-            document.getElementById("invoiceNo").value = data.invoiceNo || "";
-            document.getElementById("invoiceDate").value = data.invoiceDate || "";
-            document.getElementById("dueDate").value = data.dueDate || "";
-            document.getElementById("taxRate").value = data.taxRate || "0";
-            document.getElementById("notes").value = data.notes || "";
+        // Hide after print
+        setTimeout(function () {
+          taxRateDisplay.style.display = "none";
+        }, 100);
+      }
 
-            if (data.lineItems && data.lineItems.length > 0) {
-              lineItems = data.lineItems;
-              itemIdCounter = data.itemIdCounter || lineItems.length;
-            }
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
+
+        // Clear inputs
+        document.getElementById("companyName").value = "";
+        document.getElementById("companyAddress").value = "";
+        document.getElementById("companyPhone").value = "";
+        document.getElementById("companyEmail").value = "";
+        document.getElementById("clientName").value = "";
+        document.getElementById("clientAddress").value = "";
+        document.getElementById("invoiceNo").value = generateInvoiceNumber();
+        document.getElementById("invoiceDate").value = new Date().toISOString().split("T")[0];
+        var dueDate = new Date();
+        dueDate.setDate(dueDate.getDate() + 30);
+        document.getElementById("dueDate").value = dueDate.toISOString().split("T")[0];
+        document.getElementById("taxRate").value = "0";
+        document.getElementById("notes").value = "";
+
+        // Reset line items
+        lineItems = [];
+        itemIdCounter = 0;
+        addLineItem();
+
+        // Clear storage
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          companyName: document.getElementById("companyName").value,
+          companyAddress: document.getElementById("companyAddress").value,
+          companyPhone: document.getElementById("companyPhone").value,
+          companyEmail: document.getElementById("companyEmail").value,
+          clientName: document.getElementById("clientName").value,
+          clientAddress: document.getElementById("clientAddress").value,
+          invoiceNo: document.getElementById("invoiceNo").value,
+          invoiceDate: document.getElementById("invoiceDate").value,
+          dueDate: document.getElementById("dueDate").value,
+          taxRate: document.getElementById("taxRate").value,
+          notes: document.getElementById("notes").value,
+          lineItems: lineItems,
+          itemIdCounter: itemIdCounter
+        };
+
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          document.getElementById("companyName").value = data.companyName || "";
+          document.getElementById("companyAddress").value = data.companyAddress || "";
+          document.getElementById("companyPhone").value = data.companyPhone || "";
+          document.getElementById("companyEmail").value = data.companyEmail || "";
+          document.getElementById("clientName").value = data.clientName || "";
+          document.getElementById("clientAddress").value = data.clientAddress || "";
+          document.getElementById("invoiceNo").value = data.invoiceNo || "";
+          document.getElementById("invoiceDate").value = data.invoiceDate || "";
+          document.getElementById("dueDate").value = data.dueDate || "";
+          document.getElementById("taxRate").value = data.taxRate || "0";
+          document.getElementById("notes").value = data.notes || "";
+
+          if (data.lineItems && data.lineItems.length > 0) {
+            lineItems = data.lineItems;
+            itemIdCounter = data.itemIdCounter || lineItems.length;
           }
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
         }
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      }
 
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        }
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
 
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+      // Initialize on load
+      init();
+    </script>
 
-        // Initialize on load
-        init();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/meeting-timer.html
+++ b/tools/office/meeting-timer.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Meeting Timer - WebUtils" />
-    <meta property="og:description" content="Meeting Timer，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Meeting Timer，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/meeting-timer.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Meeting Timer - WebUtils" />
-    <meta name="twitter:description" content="Meeting Timer，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Meeting Timer，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Meeting Timer",
-      "item": "https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Meeting Timer",
+            "item": "https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Meeting Timer - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Meeting Timer - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,604 +97,607 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 600px;
-    width: 100%;
-    padding: 24px;
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .header {
-    text-align: center;
-    margin-bottom: 32px;
-  }
-  .breadcrumb {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 16px;
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--text-muted);
-    user-select: none;
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  h1 {
-    font-family: var(--font-mono);
-    font-size: 2rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
-  }
-  h1 .icon {
-    font-size: 2.5rem;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 600px;
+        width: 100%;
+        padding: 24px;
+      }
 
-  .timer-display {
-    font-family: var(--font-mono);
-    font-size: 6rem;
-    font-weight: 700;
-    text-align: center;
-    margin: 48px 0;
-    color: var(--color-accent-cyan);
-    text-shadow: 0 0 30px var(--color-accent-cyan);
-  }
-  .timer-display.warning {
-    color: var(--accent-red);
-    text-shadow: 0 0 30px var(--accent-red);
-  }
+      .header {
+        text-align: center;
+        margin-bottom: 32px;
+      }
+      .breadcrumb {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        margin-bottom: 16px;
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--text-muted);
+        user-select: none;
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      h1 {
+        font-family: var(--font-mono);
+        font-size: 2rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+      }
+      h1 .icon {
+        font-size: 2.5rem;
+      }
 
-  .controls {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-  }
-  .input-group {
-    display: flex;
-    gap: 12px;
-  }
-  .input-group input {
-    flex: 1;
-    padding: 12px;
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    text-align: center;
-  }
-  .input-group input:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-  .input-label {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    text-align: center;
-    margin-top: 4px;
-  }
+      .timer-display {
+        font-family: var(--font-mono);
+        font-size: 6rem;
+        font-weight: 700;
+        text-align: center;
+        margin: 48px 0;
+        color: var(--color-accent-cyan);
+        text-shadow: 0 0 30px var(--color-accent-cyan);
+      }
+      .timer-display.warning {
+        color: var(--accent-red);
+        text-shadow: 0 0 30px var(--accent-red);
+      }
 
-  .btn-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-  }
-  .btn {
-    padding: 16px;
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    font-weight: 600;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(0, 245, 212, 0.3);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-  .btn-danger {
-    background: var(--accent-red);
-    color: var(--color-bg-deep);
-  }
+      .controls {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+      }
+      .input-group {
+        display: flex;
+        gap: 12px;
+      }
+      .input-group input {
+        flex: 1;
+        padding: 12px;
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        text-align: center;
+      }
+      .input-group input:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+      .input-label {
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        text-align: center;
+        margin-top: 4px;
+      }
 
-  .presets {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 12px;
-    margin-top: 16px;
-  }
-  .preset-btn {
-    padding: 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s;
-    color: var(--color-text-primary);
-  }
-  .preset-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+      .btn {
+        padding: 16px;
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        font-weight: 600;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px rgba(0, 245, 212, 0.3);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+      .btn-danger {
+        background: var(--accent-red);
+        color: var(--color-bg-deep);
+      }
 
-  @media (max-width: 600px) {
-    .timer-display {
-      font-size: 4rem;
-    }
-  }
-</style>
+      .presets {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .preset-btn {
+        padding: 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s;
+        color: var(--color-text-primary);
+      }
+      .preset-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      @media (max-width: 600px) {
+        .timer-display {
+          font-size: 4rem;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">会议计时器</span>
-    </nav>
-    <h1>
-      <span class="icon">⏱️</span>
-      会议计时器
-    </h1>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">会议计时器</span>
+          </nav>
+          <h1>
+            <span class="icon">⏱️</span>
+            会议计时器
+          </h1>
+        </header>
 
-  <div class="timer-display" id="timerDisplay">00:00</div>
+        <div class="timer-display" id="timerDisplay">00:00</div>
 
-  <div class="controls">
-    <div class="input-group">
-      <div style="flex: 1">
-        <input type="number" id="minutes" min="0" max="999" value="30" placeholder="分钟">
-        <div class="input-label">分钟</div>
+        <div class="controls">
+          <div class="input-group">
+            <div style="flex: 1">
+              <input type="number" id="minutes" min="0" max="999" value="30" placeholder="分钟" />
+              <div class="input-label">分钟</div>
+            </div>
+            <div style="flex: 1">
+              <input type="number" id="seconds" min="0" max="59" value="0" placeholder="秒" />
+              <div class="input-label">秒</div>
+            </div>
+          </div>
+
+          <div class="btn-row">
+            <button class="btn btn-primary" id="startBtn" onclick="startTimer()">▶️ 开始</button>
+            <button class="btn btn-danger" id="stopBtn" onclick="stopTimer()" style="display: none">
+              ⏸️ 暂停
+            </button>
+            <button class="btn btn-secondary" onclick="resetTimer()">🔄 重置</button>
+          </div>
+
+          <div class="presets">
+            <button class="preset-btn" onclick="setTime(5, 0)">5 分钟</button>
+            <button class="preset-btn" onclick="setTime(15, 0)">15 分钟</button>
+            <button class="preset-btn" onclick="setTime(30, 0)">30 分钟</button>
+            <button class="preset-btn" onclick="setTime(45, 0)">45 分钟</button>
+            <button class="preset-btn" onclick="setTime(60, 0)">60 分钟</button>
+            <button class="preset-btn" onclick="setTime(90, 0)">90 分钟</button>
+          </div>
+        </div>
       </div>
-      <div style="flex: 1">
-        <input type="number" id="seconds" min="0" max="59" value="0" placeholder="秒">
-        <div class="input-label">秒</div>
-      </div>
     </div>
 
-    <div class="btn-row">
-      <button class="btn btn-primary" id="startBtn" onclick="startTimer()">▶️ 开始</button>
-      <button class="btn btn-danger" id="stopBtn" onclick="stopTimer()" style="display: none">
-        ⏸️ 暂停
-      </button>
-      <button class="btn btn-secondary" onclick="resetTimer()">🔄 重置</button>
-    </div>
-
-    <div class="presets">
-      <button class="preset-btn" onclick="setTime(5, 0)">5 分钟</button>
-      <button class="preset-btn" onclick="setTime(15, 0)">15 分钟</button>
-      <button class="preset-btn" onclick="setTime(30, 0)">30 分钟</button>
-      <button class="preset-btn" onclick="setTime(45, 0)">45 分钟</button>
-      <button class="preset-btn" onclick="setTime(60, 0)">60 分钟</button>
-      <button class="preset-btn" onclick="setTime(90, 0)">90 分钟</button>
-    </div>
-  </div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "会议计时器",
-              "item": "https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "会议计时器",
+            "item": "https://tools.realtime-ai.chat/tools/office/meeting-timer.html"
+          }
+        ]
+      }
+    </script>
     <script>
-  let timer = null;
-        let totalSeconds = 0;
-        let remainingSeconds = 0;
+      let timer = null;
+      let totalSeconds = 0;
+      let remainingSeconds = 0;
 
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") document.body.setAttribute("data-theme", "light");
+      })();
+
+      function updateDisplay() {
+        const mins = Math.floor(remainingSeconds / 60);
+        const secs = remainingSeconds % 60;
+        const display = document.getElementById("timerDisplay");
+        display.textContent = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+
+        if (remainingSeconds <= 60 && remainingSeconds > 0) {
+          display.classList.add("warning");
+        } else {
+          display.classList.remove("warning");
         }
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") document.body.setAttribute("data-theme", "light");
-        })();
+      }
 
-        function updateDisplay() {
-          const mins = Math.floor(remainingSeconds / 60);
-          const secs = remainingSeconds % 60;
-          const display = document.getElementById("timerDisplay");
-          display.textContent = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+      function startTimer() {
+        if (!timer) {
+          const m = parseInt(document.getElementById("minutes").value) || 0;
+          const s = parseInt(document.getElementById("seconds").value) || 0;
+          totalSeconds = m * 60 + s;
+          if (remainingSeconds === 0) remainingSeconds = totalSeconds;
 
-          if (remainingSeconds <= 60 && remainingSeconds > 0) {
-            display.classList.add("warning");
-          } else {
-            display.classList.remove("warning");
-          }
+          if (remainingSeconds <= 0) return;
+
+          document.getElementById("startBtn").style.display = "none";
+          document.getElementById("stopBtn").style.display = "block";
+
+          timer = setInterval(() => {
+            remainingSeconds--;
+            updateDisplay();
+
+            if (remainingSeconds <= 0) {
+              stopTimer();
+              playAlert();
+            }
+          }, 1000);
         }
+      }
 
-        function startTimer() {
-          if (!timer) {
-            const m = parseInt(document.getElementById("minutes").value) || 0;
-            const s = parseInt(document.getElementById("seconds").value) || 0;
-            totalSeconds = m * 60 + s;
-            if (remainingSeconds === 0) remainingSeconds = totalSeconds;
-
-            if (remainingSeconds <= 0) return;
-
-            document.getElementById("startBtn").style.display = "none";
-            document.getElementById("stopBtn").style.display = "block";
-
-            timer = setInterval(() => {
-              remainingSeconds--;
-              updateDisplay();
-
-              if (remainingSeconds <= 0) {
-                stopTimer();
-                playAlert();
-              }
-            }, 1000);
-          }
+      function stopTimer() {
+        if (timer) {
+          clearInterval(timer);
+          timer = null;
+          document.getElementById("startBtn").style.display = "block";
+          document.getElementById("stopBtn").style.display = "none";
         }
+      }
 
-        function stopTimer() {
-          if (timer) {
-            clearInterval(timer);
-            timer = null;
-            document.getElementById("startBtn").style.display = "block";
-            document.getElementById("stopBtn").style.display = "none";
-          }
-        }
+      function resetTimer() {
+        stopTimer();
+        remainingSeconds = 0;
+        document.getElementById("timerDisplay").textContent = "00:00";
+        document.getElementById("timerDisplay").classList.remove("warning");
+      }
 
-        function resetTimer() {
-          stopTimer();
-          remainingSeconds = 0;
-          document.getElementById("timerDisplay").textContent = "00:00";
-          document.getElementById("timerDisplay").classList.remove("warning");
-        }
+      function setTime(m, s) {
+        resetTimer();
+        document.getElementById("minutes").value = m;
+        document.getElementById("seconds").value = s;
+        remainingSeconds = m * 60 + s;
+        updateDisplay();
+      }
 
-        function setTime(m, s) {
-          resetTimer();
-          document.getElementById("minutes").value = m;
-          document.getElementById("seconds").value = s;
-          remainingSeconds = m * 60 + s;
-          updateDisplay();
+      function playAlert() {
+        if ("Notification" in window && Notification.permission === "granted") {
+          new Notification("⏱️ 会议时间到！", { body: "计时器已结束" });
         }
+        alert("⏱️ 会议时间到！");
+      }
 
-        function playAlert() {
-          if ("Notification" in window && Notification.permission === "granted") {
-            new Notification("⏱️ 会议时间到！", { body: "计时器已结束" });
-          }
-          alert("⏱️ 会议时间到！");
-        }
+      if ("Notification" in window && Notification.permission === "default") {
+        Notification.requestPermission();
+      }
+    </script>
 
-        if ("Notification" in window && Notification.permission === "default") {
-          Notification.requestPermission();
-        }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/purchase-order.html
+++ b/tools/office/purchase-order.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Purchase Order - WebUtils" />
-    <meta property="og:description" content="Purchase Order，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Purchase Order，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/purchase-order.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/purchase-order.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Purchase Order - WebUtils" />
-    <meta name="twitter:description" content="Purchase Order，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Purchase Order，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Purchase Order",
-      "item": "https://tools.realtime-ai.chat/tools/office/purchase-order.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Purchase Order",
+            "item": "https://tools.realtime-ai.chat/tools/office/purchase-order.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Purchase Order - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Purchase Order - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1110 +97,1113 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-
-    /* 字体变量 */
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  input[type="email"],
-  input[type="tel"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 80px;
-    resize: vertical;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
-
-  /* Line Items Table */
-  .line-items-container {
-    overflow-x: auto;
-  }
-
-  .line-items-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 16px;
-  }
-
-  .line-items-table th,
-  .line-items-table td {
-    padding: 12px;
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-
-  .line-items-table th {
-    color: var(--color-text-secondary);
-    font-weight: 500;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.5px;
-  }
-
-  .line-items-table input {
-    width: 100%;
-    min-width: 80px;
-  }
-
-  .line-items-table .desc-col {
-    min-width: 200px;
-  }
-
-  .line-items-table .num-col {
-    width: 100px;
-  }
-
-  .line-items-table .amount-col {
-    width: 120px;
-    text-align: right;
-    color: var(--color-accent-cyan);
-    font-weight: 500;
-  }
-
-  .line-items-table .action-col {
-    width: 60px;
-    text-align: center;
-  }
-
-  .btn-remove {
-    background: transparent;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 1.2rem;
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    transition: background 0.2s;
-  }
-
-  .btn-remove:hover {
-    background: rgba(244, 63, 94, 0.1);
-  }
-
-  /* Summary Section */
-  .summary-section {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 16px;
-  }
-
-  .summary-box {
-    min-width: 300px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-  }
-
-  .summary-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 0;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  .summary-row.total {
-    border-top: 2px solid var(--border-strong);
-    margin-top: 8px;
-    padding-top: 16px;
-    font-size: 1.1rem;
-    font-weight: 600;
-  }
-
-  .summary-row .label {
-    color: var(--color-text-secondary);
-  }
-
-  .summary-row .value {
-    color: var(--color-text-primary);
-  }
-
-  .summary-row.total .value {
-    color: var(--color-accent-cyan);
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
-
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .btn-remove,
-    .no-print {
-      display: none !important;
-    }
-
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
-
-    .tool-section {
-      page-break-inside: avoid;
-    }
-
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
-
-    input,
-    textarea,
-    select {
-      border: none !important;
-      background: transparent !important;
-      padding: 4px 0 !important;
-      color: #000 !important;
-    }
-
-    .line-items-table {
-      border: 1px solid #ddd;
-    }
-
-    .line-items-table th,
-    .line-items-table td {
-      border: 1px solid #ddd;
-      color: #000;
-    }
-
-    .line-items-table .amount-col {
-      color: #000;
-    }
-
-    .summary-box {
-      background: #f9f9f9;
-      border-color: #ddd;
-    }
-
-    .summary-row .label,
-    .summary-row .value,
-    .summary-row.total .value {
-      color: #000;
-    }
-
-    .input-label {
-      display: none;
-    }
-
-    .form-grid {
-      display: block;
-    }
-
-    .input-group {
-      display: inline-block;
-      margin-right: 16px;
-    }
-
-    .po-header-print {
-      display: flex !important;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 32px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
-
-    .print-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #000;
-    }
-
-    .print-info {
-      text-align: right;
-    }
-  }
-
-  .po-header-print {
-    display: none;
-  }
-
-  @media (max-width: 768px) {
-    .summary-section {
-      justify-content: stretch;
-    }
-
-    .summary-box {
-      width: 100%;
-      min-width: auto;
-    }
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .line-items-table .desc-col {
-      min-width: 150px;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+
+        /* 字体变量 */
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 16px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      input[type="date"],
+      input[type="email"],
+      input[type="tel"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 80px;
+        resize: vertical;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
+
+      /* Line Items Table */
+      .line-items-container {
+        overflow-x: auto;
+      }
+
+      .line-items-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 16px;
+      }
+
+      .line-items-table th,
+      .line-items-table td {
+        padding: 12px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-subtle);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+
+      .line-items-table th {
+        color: var(--color-text-secondary);
+        font-weight: 500;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.5px;
+      }
+
+      .line-items-table input {
+        width: 100%;
+        min-width: 80px;
+      }
+
+      .line-items-table .desc-col {
+        min-width: 200px;
+      }
+
+      .line-items-table .num-col {
+        width: 100px;
+      }
+
+      .line-items-table .amount-col {
+        width: 120px;
+        text-align: right;
+        color: var(--color-accent-cyan);
+        font-weight: 500;
+      }
+
+      .line-items-table .action-col {
+        width: 60px;
+        text-align: center;
+      }
+
+      .btn-remove {
+        background: transparent;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 1.2rem;
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        transition: background 0.2s;
+      }
+
+      .btn-remove:hover {
+        background: rgba(244, 63, 94, 0.1);
+      }
+
+      /* Summary Section */
+      .summary-section {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 16px;
+      }
+
+      .summary-box {
+        min-width: 300px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+      }
+
+      .summary-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 0;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .summary-row.total {
+        border-top: 2px solid var(--border-strong);
+        margin-top: 8px;
+        padding-top: 16px;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+
+      .summary-row .label {
+        color: var(--color-text-secondary);
+      }
+
+      .summary-row .value {
+        color: var(--color-text-primary);
+      }
+
+      .summary-row.total .value {
+        color: var(--color-accent-cyan);
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
+
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .btn-remove,
+        .no-print {
+          display: none !important;
+        }
+
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
+
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
+
+        .tool-section {
+          page-break-inside: avoid;
+        }
+
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
+
+        input,
+        textarea,
+        select {
+          border: none !important;
+          background: transparent !important;
+          padding: 4px 0 !important;
+          color: #000 !important;
+        }
+
+        .line-items-table {
+          border: 1px solid #ddd;
+        }
+
+        .line-items-table th,
+        .line-items-table td {
+          border: 1px solid #ddd;
+          color: #000;
+        }
+
+        .line-items-table .amount-col {
+          color: #000;
+        }
+
+        .summary-box {
+          background: #f9f9f9;
+          border-color: #ddd;
+        }
+
+        .summary-row .label,
+        .summary-row .value,
+        .summary-row.total .value {
+          color: #000;
+        }
+
+        .input-label {
+          display: none;
+        }
+
+        .form-grid {
+          display: block;
+        }
+
+        .input-group {
+          display: inline-block;
+          margin-right: 16px;
+        }
+
+        .po-header-print {
+          display: flex !important;
+          justify-content: space-between;
+          align-items: flex-start;
+          margin-bottom: 32px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
+
+        .print-title {
+          font-size: 2rem;
+          font-weight: 700;
+          color: #000;
+        }
+
+        .print-info {
+          text-align: right;
+        }
+      }
+
+      .po-header-print {
+        display: none;
+      }
+
+      @media (max-width: 768px) {
+        .summary-section {
+          justify-content: stretch;
+        }
+
+        .summary-box {
+          width: 100%;
+          min-width: auto;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .line-items-table .desc-col {
+          min-width: 150px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">采购订单</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🛒</span>
-        采购订单
-      </h1>
-      <p>创建专业采购订单，支持供应商信息、明细项目、自动计算总价</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <!-- Print Header -->
-    <div class="po-header-print">
-      <div class="print-title">采购订单</div>
-      <div class="print-info">
-        <div id="printPoNo"></div>
-        <div id="printPoDate"></div>
-      </div>
-    </div>
-
-    <!-- Buyer Info -->
-    <div class="tool-section">
-      <div class="section-title">采购方信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">公司名称</label>
-          <input type="text" id="buyerName" placeholder="您的公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">公司地址</label>
-          <input type="text" id="buyerAddress" placeholder="公司地址">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系人</label>
-          <input type="text" id="buyerContact" placeholder="联系人姓名">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="buyerPhone" placeholder="联系电话">
-        </div>
-      </div>
-    </div>
-
-    <!-- Vendor Info -->
-    <div class="tool-section">
-      <div class="section-title">供应商信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">供应商名称</label>
-          <input type="text" id="vendorName" placeholder="供应商公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">供应商地址</label>
-          <input type="text" id="vendorAddress" placeholder="供应商地址">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系人</label>
-          <input type="text" id="vendorContact" placeholder="供应商联系人">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="vendorPhone" placeholder="供应商电话">
-        </div>
-      </div>
-    </div>
-
-    <!-- PO Details -->
-    <div class="tool-section">
-      <div class="section-title">订单信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">订单编号</label>
-          <input type="text" id="poNumber" readonly="">
-        </div>
-        <div class="input-group">
-          <label class="input-label">订单日期</label>
-          <input type="date" id="poDate">
-        </div>
-        <div class="input-group">
-          <label class="input-label">交货日期</label>
-          <input type="date" id="deliveryDate">
-        </div>
-        <div class="input-group">
-          <label class="input-label">付款方式</label>
-          <select id="paymentTerms">
-            <option value="预付款">预付款</option>
-            <option value="货到付款">货到付款</option>
-            <option value="30天账期">30天账期</option>
-            <option value="60天账期">60天账期</option>
-            <option value="月结">月结</option>
-          </select>
-        </div>
-      </div>
-    </div>
-
-    <!-- Line Items -->
-    <div class="tool-section">
-      <div class="section-title">订单明细</div>
-      <div class="line-items-container">
-        <table class="line-items-table">
-          <thead>
-            <tr>
-              <th class="desc-col">物品名称/规格</th>
-              <th class="num-col">数量</th>
-              <th>单位</th>
-              <th class="num-col">单价</th>
-              <th class="amount-col">金额</th>
-              <th class="action-col no-print"></th>
-            </tr>
-          </thead>
-          <tbody id="lineItemsBody">
-            <!-- Line items will be added here -->
-          </tbody>
-        </table>
-      </div>
-      <div class="btn-row no-print">
-        <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
-      </div>
-
-      <!-- Summary -->
-      <div class="summary-section">
-        <div class="summary-box">
-          <div class="summary-row">
-            <span class="label">小计</span>
-            <span class="value" id="subtotal">¥0.00</span>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">采购订单</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🛒</span>
+              采购订单
+            </h1>
+            <p>创建专业采购订单，支持供应商信息、明细项目、自动计算总价</p>
           </div>
-          <div class="summary-row total">
-            <span class="label">总计</span>
-            <span class="value" id="total">¥0.00</span>
+        </header>
+
+        <main class="main-content">
+          <!-- Print Header -->
+          <div class="po-header-print">
+            <div class="print-title">采购订单</div>
+            <div class="print-info">
+              <div id="printPoNo"></div>
+              <div id="printPoDate"></div>
+            </div>
           </div>
-        </div>
+
+          <!-- Buyer Info -->
+          <div class="tool-section">
+            <div class="section-title">采购方信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">公司名称</label>
+                <input type="text" id="buyerName" placeholder="您的公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">公司地址</label>
+                <input type="text" id="buyerAddress" placeholder="公司地址" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系人</label>
+                <input type="text" id="buyerContact" placeholder="联系人姓名" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="buyerPhone" placeholder="联系电话" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Vendor Info -->
+          <div class="tool-section">
+            <div class="section-title">供应商信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">供应商名称</label>
+                <input type="text" id="vendorName" placeholder="供应商公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">供应商地址</label>
+                <input type="text" id="vendorAddress" placeholder="供应商地址" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系人</label>
+                <input type="text" id="vendorContact" placeholder="供应商联系人" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="vendorPhone" placeholder="供应商电话" />
+              </div>
+            </div>
+          </div>
+
+          <!-- PO Details -->
+          <div class="tool-section">
+            <div class="section-title">订单信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">订单编号</label>
+                <input type="text" id="poNumber" readonly="" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">订单日期</label>
+                <input type="date" id="poDate" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">交货日期</label>
+                <input type="date" id="deliveryDate" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">付款方式</label>
+                <select id="paymentTerms">
+                  <option value="预付款">预付款</option>
+                  <option value="货到付款">货到付款</option>
+                  <option value="30天账期">30天账期</option>
+                  <option value="60天账期">60天账期</option>
+                  <option value="月结">月结</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <!-- Line Items -->
+          <div class="tool-section">
+            <div class="section-title">订单明细</div>
+            <div class="line-items-container">
+              <table class="line-items-table">
+                <thead>
+                  <tr>
+                    <th class="desc-col">物品名称/规格</th>
+                    <th class="num-col">数量</th>
+                    <th>单位</th>
+                    <th class="num-col">单价</th>
+                    <th class="amount-col">金额</th>
+                    <th class="action-col no-print"></th>
+                  </tr>
+                </thead>
+                <tbody id="lineItemsBody">
+                  <!-- Line items will be added here -->
+                </tbody>
+              </table>
+            </div>
+            <div class="btn-row no-print">
+              <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
+            </div>
+
+            <!-- Summary -->
+            <div class="summary-section">
+              <div class="summary-box">
+                <div class="summary-row">
+                  <span class="label">小计</span>
+                  <span class="value" id="subtotal">¥0.00</span>
+                </div>
+                <div class="summary-row total">
+                  <span class="label">总计</span>
+                  <span class="value" id="total">¥0.00</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Shipping Info -->
+          <div class="tool-section">
+            <div class="section-title">送货地址</div>
+            <div class="input-group">
+              <textarea id="shippingAddress" placeholder="送货地址详情..."></textarea>
+            </div>
+          </div>
+
+          <!-- Notes -->
+          <div class="tool-section">
+            <div class="section-title">备注</div>
+            <div class="input-group">
+              <textarea id="notes" placeholder="其他备注说明..."></textarea>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printPO()">🖨️ 打印订单</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- Shipping Info -->
-    <div class="tool-section">
-      <div class="section-title">送货地址</div>
-      <div class="input-group">
-        <textarea id="shippingAddress" placeholder="送货地址详情..."></textarea>
-      </div>
-    </div>
-
-    <!-- Notes -->
-    <div class="tool-section">
-      <div class="section-title">备注</div>
-      <div class="input-group">
-        <textarea id="notes" placeholder="其他备注说明..."></textarea>
-      </div>
-    </div>
-
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printPO()">🖨️ 打印订单</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "采购订单",
-              "item": "https://tools.realtime-ai.chat/tools/office/purchase-order.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "采购订单",
+            "item": "https://tools.realtime-ai.chat/tools/office/purchase-order.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "purchase_order_data_v1";
+      var lineItems = [];
+      var itemIdCounter = 0;
 
-  var LS_KEY = "purchase_order_data_v1";
-        var lineItems = [];
-        var itemIdCounter = 0;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-
-          // Generate PO number if empty
-          var poNoEl = document.getElementById("poNumber");
-          if (!poNoEl.value) {
-            poNoEl.value = generatePONumber();
-          }
-
-          // Set default dates if empty
-          var today = new Date().toISOString().split("T")[0];
-          var poDateEl = document.getElementById("poDate");
-          if (!poDateEl.value) {
-            poDateEl.value = today;
-          }
-
-          var deliveryDateEl = document.getElementById("deliveryDate");
-          if (!deliveryDateEl.value) {
-            var deliveryDate = new Date();
-            deliveryDate.setDate(deliveryDate.getDate() + 14);
-            deliveryDateEl.value = deliveryDate.toISOString().split("T")[0];
-          }
-
-          // Add initial line item if none exist
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-          }
-
-          // Add input listeners for auto-save
-          var inputs = document.querySelectorAll("input, textarea, select");
-          for (var i = 0; i < inputs.length; i++) {
-            inputs[i].addEventListener("input", debounce(saveToStorage, 500));
-            inputs[i].addEventListener("change", debounce(saveToStorage, 500));
-          }
+        // Generate PO number if empty
+        var poNoEl = document.getElementById("poNumber");
+        if (!poNoEl.value) {
+          poNoEl.value = generatePONumber();
         }
 
-        // Generate unique PO number
-        function generatePONumber() {
-          var date = new Date();
-          var year = date.getFullYear();
-          var month = String(date.getMonth() + 1).padStart(2, "0");
-          var day = String(date.getDate()).padStart(2, "0");
-          var random = Math.floor(Math.random() * 1000)
-            .toString()
-            .padStart(3, "0");
-          return "PO-" + year + month + day + "-" + random;
+        // Set default dates if empty
+        var today = new Date().toISOString().split("T")[0];
+        var poDateEl = document.getElementById("poDate");
+        if (!poDateEl.value) {
+          poDateEl.value = today;
         }
 
-        // Add new line item
-        function addLineItem() {
-          var item = {
-            id: ++itemIdCounter,
-            description: "",
-            quantity: 1,
-            unit: "个",
-            unitPrice: 0
-          };
-          lineItems.push(item);
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Remove line item
-        function removeLineItem(id) {
-          lineItems = lineItems.filter(function (item) {
-            return item.id !== id;
-          });
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-            calculateTotals();
-            saveToStorage();
-          }
-        }
-
-        // Create line item row
-        function createLineItemRow(item) {
-          var row = document.createElement("tr");
-          var amount = item.quantity * item.unitPrice;
-
-          // Description cell
-          var descCell = document.createElement("td");
-          descCell.className = "desc-col";
-          var descInput = document.createElement("input");
-          descInput.type = "text";
-          descInput.value = item.description;
-          descInput.placeholder = "物品名称/规格";
-          descInput.addEventListener("change", function () {
-            updateLineItem(item.id, "description", this.value);
-          });
-          descCell.appendChild(descInput);
-          row.appendChild(descCell);
-
-          // Quantity cell
-          var qtyCell = document.createElement("td");
-          qtyCell.className = "num-col";
-          var qtyInput = document.createElement("input");
-          qtyInput.type = "number";
-          qtyInput.value = item.quantity;
-          qtyInput.min = "0";
-          qtyInput.step = "1";
-          qtyInput.addEventListener("change", function () {
-            updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
-          });
-          qtyCell.appendChild(qtyInput);
-          row.appendChild(qtyCell);
-
-          // Unit cell
-          var unitCell = document.createElement("td");
-          var unitSelect = document.createElement("select");
-          var units = ["个", "件", "套", "台", "箱", "包", "千克", "米", "平方米"];
-          for (var i = 0; i < units.length; i++) {
-            var opt = document.createElement("option");
-            opt.value = units[i];
-            opt.textContent = units[i];
-            if (units[i] === item.unit) opt.selected = true;
-            unitSelect.appendChild(opt);
-          }
-          unitSelect.addEventListener("change", function () {
-            updateLineItem(item.id, "unit", this.value);
-          });
-          unitCell.appendChild(unitSelect);
-          row.appendChild(unitCell);
-
-          // Unit price cell
-          var priceCell = document.createElement("td");
-          priceCell.className = "num-col";
-          var priceInput = document.createElement("input");
-          priceInput.type = "number";
-          priceInput.value = item.unitPrice;
-          priceInput.min = "0";
-          priceInput.step = "0.01";
-          priceInput.addEventListener("change", function () {
-            updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
-          });
-          priceCell.appendChild(priceInput);
-          row.appendChild(priceCell);
-
-          // Amount cell
-          var amountCell = document.createElement("td");
-          amountCell.className = "amount-col";
-          amountCell.textContent = "¥" + formatNumber(amount);
-          row.appendChild(amountCell);
-
-          // Action cell
-          var actionCell = document.createElement("td");
-          actionCell.className = "action-col no-print";
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove";
-          removeBtn.title = "删除";
-          removeBtn.textContent = "×";
-          removeBtn.addEventListener("click", function () {
-            removeLineItem(item.id);
-          });
-          actionCell.appendChild(removeBtn);
-          row.appendChild(actionCell);
-
-          return row;
-        }
-
-        // Render line items
-        function renderLineItems() {
-          var tbody = document.getElementById("lineItemsBody");
-          tbody.textContent = "";
-
-          for (var i = 0; i < lineItems.length; i++) {
-            var row = createLineItemRow(lineItems[i]);
-            tbody.appendChild(row);
-          }
-
-          calculateTotals();
-        }
-
-        // Update line item
-        function updateLineItem(id, field, value) {
-          for (var i = 0; i < lineItems.length; i++) {
-            if (lineItems[i].id === id) {
-              lineItems[i][field] = value;
-              break;
-            }
-          }
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Calculate totals
-        function calculateTotals() {
-          var subtotal = 0;
-          for (var i = 0; i < lineItems.length; i++) {
-            subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
-          }
-
-          document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
-          document.getElementById("total").textContent = "¥" + formatNumber(subtotal);
-
-          saveToStorage();
-        }
-
-        // Format number
-        function formatNumber(num) {
-          return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-          };
-        }
-
-        // Print PO
-        function printPO() {
-          document.getElementById("printPoNo").textContent =
-            "订单编号: " + document.getElementById("poNumber").value;
-          document.getElementById("printPoDate").textContent =
-            "日期: " + document.getElementById("poDate").value;
-
-          window.print();
-        }
-
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
-
-          document.getElementById("buyerName").value = "";
-          document.getElementById("buyerAddress").value = "";
-          document.getElementById("buyerContact").value = "";
-          document.getElementById("buyerPhone").value = "";
-          document.getElementById("vendorName").value = "";
-          document.getElementById("vendorAddress").value = "";
-          document.getElementById("vendorContact").value = "";
-          document.getElementById("vendorPhone").value = "";
-          document.getElementById("poNumber").value = generatePONumber();
-          document.getElementById("poDate").value = new Date().toISOString().split("T")[0];
+        var deliveryDateEl = document.getElementById("deliveryDate");
+        if (!deliveryDateEl.value) {
           var deliveryDate = new Date();
           deliveryDate.setDate(deliveryDate.getDate() + 14);
-          document.getElementById("deliveryDate").value = deliveryDate.toISOString().split("T")[0];
-          document.getElementById("paymentTerms").value = "预付款";
-          document.getElementById("shippingAddress").value = "";
-          document.getElementById("notes").value = "";
+          deliveryDateEl.value = deliveryDate.toISOString().split("T")[0];
+        }
 
-          lineItems = [];
-          itemIdCounter = 0;
+        // Add initial line item if none exist
+        if (lineItems.length === 0) {
           addLineItem();
-
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
+        } else {
+          renderLineItems();
         }
 
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            buyerName: document.getElementById("buyerName").value,
-            buyerAddress: document.getElementById("buyerAddress").value,
-            buyerContact: document.getElementById("buyerContact").value,
-            buyerPhone: document.getElementById("buyerPhone").value,
-            vendorName: document.getElementById("vendorName").value,
-            vendorAddress: document.getElementById("vendorAddress").value,
-            vendorContact: document.getElementById("vendorContact").value,
-            vendorPhone: document.getElementById("vendorPhone").value,
-            poNumber: document.getElementById("poNumber").value,
-            poDate: document.getElementById("poDate").value,
-            deliveryDate: document.getElementById("deliveryDate").value,
-            paymentTerms: document.getElementById("paymentTerms").value,
-            shippingAddress: document.getElementById("shippingAddress").value,
-            notes: document.getElementById("notes").value,
-            lineItems: lineItems,
-            itemIdCounter: itemIdCounter
+        // Add input listeners for auto-save
+        var inputs = document.querySelectorAll("input, textarea, select");
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].addEventListener("input", debounce(saveToStorage, 500));
+          inputs[i].addEventListener("change", debounce(saveToStorage, 500));
+        }
+      }
+
+      // Generate unique PO number
+      function generatePONumber() {
+        var date = new Date();
+        var year = date.getFullYear();
+        var month = String(date.getMonth() + 1).padStart(2, "0");
+        var day = String(date.getDate()).padStart(2, "0");
+        var random = Math.floor(Math.random() * 1000)
+          .toString()
+          .padStart(3, "0");
+        return "PO-" + year + month + day + "-" + random;
+      }
+
+      // Add new line item
+      function addLineItem() {
+        var item = {
+          id: ++itemIdCounter,
+          description: "",
+          quantity: 1,
+          unit: "个",
+          unitPrice: 0
+        };
+        lineItems.push(item);
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Remove line item
+      function removeLineItem(id) {
+        lineItems = lineItems.filter(function (item) {
+          return item.id !== id;
+        });
+        if (lineItems.length === 0) {
+          addLineItem();
+        } else {
+          renderLineItems();
+          calculateTotals();
+          saveToStorage();
+        }
+      }
+
+      // Create line item row
+      function createLineItemRow(item) {
+        var row = document.createElement("tr");
+        var amount = item.quantity * item.unitPrice;
+
+        // Description cell
+        var descCell = document.createElement("td");
+        descCell.className = "desc-col";
+        var descInput = document.createElement("input");
+        descInput.type = "text";
+        descInput.value = item.description;
+        descInput.placeholder = "物品名称/规格";
+        descInput.addEventListener("change", function () {
+          updateLineItem(item.id, "description", this.value);
+        });
+        descCell.appendChild(descInput);
+        row.appendChild(descCell);
+
+        // Quantity cell
+        var qtyCell = document.createElement("td");
+        qtyCell.className = "num-col";
+        var qtyInput = document.createElement("input");
+        qtyInput.type = "number";
+        qtyInput.value = item.quantity;
+        qtyInput.min = "0";
+        qtyInput.step = "1";
+        qtyInput.addEventListener("change", function () {
+          updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
+        });
+        qtyCell.appendChild(qtyInput);
+        row.appendChild(qtyCell);
+
+        // Unit cell
+        var unitCell = document.createElement("td");
+        var unitSelect = document.createElement("select");
+        var units = ["个", "件", "套", "台", "箱", "包", "千克", "米", "平方米"];
+        for (var i = 0; i < units.length; i++) {
+          var opt = document.createElement("option");
+          opt.value = units[i];
+          opt.textContent = units[i];
+          if (units[i] === item.unit) opt.selected = true;
+          unitSelect.appendChild(opt);
+        }
+        unitSelect.addEventListener("change", function () {
+          updateLineItem(item.id, "unit", this.value);
+        });
+        unitCell.appendChild(unitSelect);
+        row.appendChild(unitCell);
+
+        // Unit price cell
+        var priceCell = document.createElement("td");
+        priceCell.className = "num-col";
+        var priceInput = document.createElement("input");
+        priceInput.type = "number";
+        priceInput.value = item.unitPrice;
+        priceInput.min = "0";
+        priceInput.step = "0.01";
+        priceInput.addEventListener("change", function () {
+          updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
+        });
+        priceCell.appendChild(priceInput);
+        row.appendChild(priceCell);
+
+        // Amount cell
+        var amountCell = document.createElement("td");
+        amountCell.className = "amount-col";
+        amountCell.textContent = "¥" + formatNumber(amount);
+        row.appendChild(amountCell);
+
+        // Action cell
+        var actionCell = document.createElement("td");
+        actionCell.className = "action-col no-print";
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove";
+        removeBtn.title = "删除";
+        removeBtn.textContent = "×";
+        removeBtn.addEventListener("click", function () {
+          removeLineItem(item.id);
+        });
+        actionCell.appendChild(removeBtn);
+        row.appendChild(actionCell);
+
+        return row;
+      }
+
+      // Render line items
+      function renderLineItems() {
+        var tbody = document.getElementById("lineItemsBody");
+        tbody.textContent = "";
+
+        for (var i = 0; i < lineItems.length; i++) {
+          var row = createLineItemRow(lineItems[i]);
+          tbody.appendChild(row);
+        }
+
+        calculateTotals();
+      }
+
+      // Update line item
+      function updateLineItem(id, field, value) {
+        for (var i = 0; i < lineItems.length; i++) {
+          if (lineItems[i].id === id) {
+            lineItems[i][field] = value;
+            break;
+          }
+        }
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Calculate totals
+      function calculateTotals() {
+        var subtotal = 0;
+        for (var i = 0; i < lineItems.length; i++) {
+          subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
+        }
+
+        document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
+        document.getElementById("total").textContent = "¥" + formatNumber(subtotal);
+
+        saveToStorage();
+      }
+
+      // Format number
+      function formatNumber(num) {
+        return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      }
+
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
+            clearTimeout(timeout);
+            func.apply(context, args);
           };
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
 
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
+      // Print PO
+      function printPO() {
+        document.getElementById("printPoNo").textContent =
+          "订单编号: " + document.getElementById("poNumber").value;
+        document.getElementById("printPoDate").textContent =
+          "日期: " + document.getElementById("poDate").value;
 
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
+        window.print();
+      }
 
-          try {
-            var data = JSON.parse(saved);
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
 
-            document.getElementById("buyerName").value = data.buyerName || "";
-            document.getElementById("buyerAddress").value = data.buyerAddress || "";
-            document.getElementById("buyerContact").value = data.buyerContact || "";
-            document.getElementById("buyerPhone").value = data.buyerPhone || "";
-            document.getElementById("vendorName").value = data.vendorName || "";
-            document.getElementById("vendorAddress").value = data.vendorAddress || "";
-            document.getElementById("vendorContact").value = data.vendorContact || "";
-            document.getElementById("vendorPhone").value = data.vendorPhone || "";
-            document.getElementById("poNumber").value = data.poNumber || "";
-            document.getElementById("poDate").value = data.poDate || "";
-            document.getElementById("deliveryDate").value = data.deliveryDate || "";
-            document.getElementById("paymentTerms").value = data.paymentTerms || "预付款";
-            document.getElementById("shippingAddress").value = data.shippingAddress || "";
-            document.getElementById("notes").value = data.notes || "";
+        document.getElementById("buyerName").value = "";
+        document.getElementById("buyerAddress").value = "";
+        document.getElementById("buyerContact").value = "";
+        document.getElementById("buyerPhone").value = "";
+        document.getElementById("vendorName").value = "";
+        document.getElementById("vendorAddress").value = "";
+        document.getElementById("vendorContact").value = "";
+        document.getElementById("vendorPhone").value = "";
+        document.getElementById("poNumber").value = generatePONumber();
+        document.getElementById("poDate").value = new Date().toISOString().split("T")[0];
+        var deliveryDate = new Date();
+        deliveryDate.setDate(deliveryDate.getDate() + 14);
+        document.getElementById("deliveryDate").value = deliveryDate.toISOString().split("T")[0];
+        document.getElementById("paymentTerms").value = "预付款";
+        document.getElementById("shippingAddress").value = "";
+        document.getElementById("notes").value = "";
 
-            if (data.lineItems && data.lineItems.length > 0) {
-              lineItems = data.lineItems;
-              itemIdCounter = data.itemIdCounter || lineItems.length;
-            }
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
+        lineItems = [];
+        itemIdCounter = 0;
+        addLineItem();
+
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          buyerName: document.getElementById("buyerName").value,
+          buyerAddress: document.getElementById("buyerAddress").value,
+          buyerContact: document.getElementById("buyerContact").value,
+          buyerPhone: document.getElementById("buyerPhone").value,
+          vendorName: document.getElementById("vendorName").value,
+          vendorAddress: document.getElementById("vendorAddress").value,
+          vendorContact: document.getElementById("vendorContact").value,
+          vendorPhone: document.getElementById("vendorPhone").value,
+          poNumber: document.getElementById("poNumber").value,
+          poDate: document.getElementById("poDate").value,
+          deliveryDate: document.getElementById("deliveryDate").value,
+          paymentTerms: document.getElementById("paymentTerms").value,
+          shippingAddress: document.getElementById("shippingAddress").value,
+          notes: document.getElementById("notes").value,
+          lineItems: lineItems,
+          itemIdCounter: itemIdCounter
+        };
+
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          document.getElementById("buyerName").value = data.buyerName || "";
+          document.getElementById("buyerAddress").value = data.buyerAddress || "";
+          document.getElementById("buyerContact").value = data.buyerContact || "";
+          document.getElementById("buyerPhone").value = data.buyerPhone || "";
+          document.getElementById("vendorName").value = data.vendorName || "";
+          document.getElementById("vendorAddress").value = data.vendorAddress || "";
+          document.getElementById("vendorContact").value = data.vendorContact || "";
+          document.getElementById("vendorPhone").value = data.vendorPhone || "";
+          document.getElementById("poNumber").value = data.poNumber || "";
+          document.getElementById("poDate").value = data.poDate || "";
+          document.getElementById("deliveryDate").value = data.deliveryDate || "";
+          document.getElementById("paymentTerms").value = data.paymentTerms || "预付款";
+          document.getElementById("shippingAddress").value = data.shippingAddress || "";
+          document.getElementById("notes").value = data.notes || "";
+
+          if (data.lineItems && data.lineItems.length > 0) {
+            lineItems = data.lineItems;
+            itemIdCounter = data.itemIdCounter || lineItems.length;
           }
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
         }
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      }
 
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        }
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
 
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+      // Initialize on load
+      init();
+    </script>
 
-        // Initialize on load
-        init();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/quotation-maker.html
+++ b/tools/office/quotation-maker.html
@@ -6,7 +6,10 @@
     <title>Quotation Maker - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="quotation maker" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Quotation Maker - WebUtils" />
-    <meta property="og:description" content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/quotation-maker.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Quotation Maker - WebUtils" />
-    <meta name="twitter:description" content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Quotation Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Quotation Maker",
-      "item": "https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Quotation Maker",
+            "item": "https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Quotation Maker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Quotation Maker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1175 +100,1188 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  input[type="email"],
-  input[type="tel"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 80px;
-    resize: vertical;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
-
-  /* Line Items Table */
-  .line-items-container {
-    overflow-x: auto;
-  }
-
-  .line-items-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 16px;
-  }
-
-  .line-items-table th,
-  .line-items-table td {
-    padding: 12px;
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-
-  .line-items-table th {
-    color: var(--color-text-secondary);
-    font-weight: 500;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.5px;
-  }
-
-  .line-items-table input,
-  .line-items-table textarea {
-    width: 100%;
-    min-width: 80px;
-  }
-
-  .line-items-table textarea {
-    min-height: 40px;
-  }
-
-  .line-items-table .desc-col {
-    min-width: 250px;
-  }
-
-  .line-items-table .num-col {
-    width: 100px;
-  }
-
-  .line-items-table .amount-col {
-    width: 120px;
-    text-align: right;
-    color: var(--color-accent-cyan);
-    font-weight: 500;
-  }
-
-  .line-items-table .action-col {
-    width: 60px;
-    text-align: center;
-  }
-
-  .btn-remove {
-    background: transparent;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 1.2rem;
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    transition: background 0.2s;
-  }
-
-  .btn-remove:hover {
-    background: rgba(244, 63, 94, 0.1);
-  }
-
-  /* Summary Section */
-  .summary-section {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 16px;
-  }
-
-  .summary-box {
-    min-width: 300px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-  }
-
-  .summary-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 0;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  .summary-row.total {
-    border-top: 2px solid var(--border-strong);
-    margin-top: 8px;
-    padding-top: 16px;
-    font-size: 1.1rem;
-    font-weight: 600;
-  }
-
-  .summary-row .label {
-    color: var(--color-text-secondary);
-  }
-
-  .summary-row .value {
-    color: var(--color-text-primary);
-  }
-
-  .summary-row.total .value {
-    color: var(--color-accent-cyan);
-  }
-
-  .tax-input {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .tax-input input {
-    width: 80px;
-    text-align: right;
-  }
-
-  .validity-box {
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid var(--accent-yellow);
-    border-radius: var(--radius-md);
-    padding: 12px 16px;
-    margin-top: 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--accent-yellow);
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
-
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .btn-remove,
-    .no-print {
-      display: none !important;
-    }
-
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
-
-    .tool-section {
-      page-break-inside: avoid;
-    }
-
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
-
-    input,
-    textarea,
-    select {
-      border: none !important;
-      background: transparent !important;
-      padding: 4px 0 !important;
-      color: #000 !important;
-    }
-
-    .line-items-table {
-      border: 1px solid #ddd;
-    }
-
-    .line-items-table th,
-    .line-items-table td {
-      border: 1px solid #ddd;
-      color: #000;
-    }
-
-    .line-items-table .amount-col {
-      color: #000;
-    }
-
-    .summary-box {
-      background: #f9f9f9;
-      border-color: #ddd;
-    }
-
-    .summary-row .label,
-    .summary-row .value,
-    .summary-row.total .value {
-      color: #000;
-    }
-
-    .validity-box {
-      background: #fffbe6;
-      border-color: #d4b106;
-      color: #8c6e00;
-    }
-
-    .input-label {
-      display: none;
-    }
-
-    .form-grid {
-      display: block;
-    }
-
-    .input-group {
-      display: inline-block;
-      margin-right: 16px;
-    }
-
-    .quote-header-print {
-      display: flex !important;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 32px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
-
-    .print-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #000;
-    }
-
-    .print-info {
-      text-align: right;
-    }
-  }
-
-  .quote-header-print {
-    display: none;
-  }
-
-  @media (max-width: 768px) {
-    .summary-section {
-      justify-content: stretch;
-    }
-
-    .summary-box {
-      width: 100%;
-      min-width: auto;
-    }
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .line-items-table .desc-col {
-      min-width: 150px;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 16px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      input[type="date"],
+      input[type="email"],
+      input[type="tel"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 80px;
+        resize: vertical;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
+
+      /* Line Items Table */
+      .line-items-container {
+        overflow-x: auto;
+      }
+
+      .line-items-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 16px;
+      }
+
+      .line-items-table th,
+      .line-items-table td {
+        padding: 12px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-subtle);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+
+      .line-items-table th {
+        color: var(--color-text-secondary);
+        font-weight: 500;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.5px;
+      }
+
+      .line-items-table input,
+      .line-items-table textarea {
+        width: 100%;
+        min-width: 80px;
+      }
+
+      .line-items-table textarea {
+        min-height: 40px;
+      }
+
+      .line-items-table .desc-col {
+        min-width: 250px;
+      }
+
+      .line-items-table .num-col {
+        width: 100px;
+      }
+
+      .line-items-table .amount-col {
+        width: 120px;
+        text-align: right;
+        color: var(--color-accent-cyan);
+        font-weight: 500;
+      }
+
+      .line-items-table .action-col {
+        width: 60px;
+        text-align: center;
+      }
+
+      .btn-remove {
+        background: transparent;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 1.2rem;
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        transition: background 0.2s;
+      }
+
+      .btn-remove:hover {
+        background: rgba(244, 63, 94, 0.1);
+      }
+
+      /* Summary Section */
+      .summary-section {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 16px;
+      }
+
+      .summary-box {
+        min-width: 300px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+      }
+
+      .summary-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 0;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .summary-row.total {
+        border-top: 2px solid var(--border-strong);
+        margin-top: 8px;
+        padding-top: 16px;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+
+      .summary-row .label {
+        color: var(--color-text-secondary);
+      }
+
+      .summary-row .value {
+        color: var(--color-text-primary);
+      }
+
+      .summary-row.total .value {
+        color: var(--color-accent-cyan);
+      }
+
+      .tax-input {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .tax-input input {
+        width: 80px;
+        text-align: right;
+      }
+
+      .validity-box {
+        background: rgba(251, 191, 36, 0.1);
+        border: 1px solid var(--accent-yellow);
+        border-radius: var(--radius-md);
+        padding: 12px 16px;
+        margin-top: 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--accent-yellow);
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
+
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .btn-remove,
+        .no-print {
+          display: none !important;
+        }
+
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
+
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
+
+        .tool-section {
+          page-break-inside: avoid;
+        }
+
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
+
+        input,
+        textarea,
+        select {
+          border: none !important;
+          background: transparent !important;
+          padding: 4px 0 !important;
+          color: #000 !important;
+        }
+
+        .line-items-table {
+          border: 1px solid #ddd;
+        }
+
+        .line-items-table th,
+        .line-items-table td {
+          border: 1px solid #ddd;
+          color: #000;
+        }
+
+        .line-items-table .amount-col {
+          color: #000;
+        }
+
+        .summary-box {
+          background: #f9f9f9;
+          border-color: #ddd;
+        }
+
+        .summary-row .label,
+        .summary-row .value,
+        .summary-row.total .value {
+          color: #000;
+        }
+
+        .validity-box {
+          background: #fffbe6;
+          border-color: #d4b106;
+          color: #8c6e00;
+        }
+
+        .input-label {
+          display: none;
+        }
+
+        .form-grid {
+          display: block;
+        }
+
+        .input-group {
+          display: inline-block;
+          margin-right: 16px;
+        }
+
+        .quote-header-print {
+          display: flex !important;
+          justify-content: space-between;
+          align-items: flex-start;
+          margin-bottom: 32px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
+
+        .print-title {
+          font-size: 2rem;
+          font-weight: 700;
+          color: #000;
+        }
+
+        .print-info {
+          text-align: right;
+        }
+      }
+
+      .quote-header-print {
+        display: none;
+      }
+
+      @media (max-width: 768px) {
+        .summary-section {
+          justify-content: stretch;
+        }
+
+        .summary-box {
+          width: 100%;
+          min-width: auto;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .line-items-table .desc-col {
+          min-width: 150px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">报价单生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">💵</span>
-        报价单生成器
-      </h1>
-      <p>创建专业报价单，支持明细项目、税率计算、有效期、条款</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <!-- Print Header -->
-    <div class="quote-header-print">
-      <div class="print-title">报价单</div>
-      <div class="print-info">
-        <div id="printQuoteNo"></div>
-        <div id="printQuoteDate"></div>
-      </div>
-    </div>
-
-    <!-- Company Info -->
-    <div class="tool-section">
-      <div class="section-title">公司信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">公司名称</label>
-          <input type="text" id="companyName" placeholder="您的公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">公司地址</label>
-          <input type="text" id="companyAddress" placeholder="公司地址">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="companyPhone" placeholder="联系电话">
-        </div>
-        <div class="input-group">
-          <label class="input-label">电子邮箱</label>
-          <input type="email" id="companyEmail" placeholder="company@example.com">
-        </div>
-      </div>
-    </div>
-
-    <!-- Client Info -->
-    <div class="tool-section">
-      <div class="section-title">客户信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">客户名称</label>
-          <input type="text" id="clientName" placeholder="客户/公司名称">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系人</label>
-          <input type="text" id="clientContact" placeholder="联系人姓名">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="clientPhone" placeholder="客户电话">
-        </div>
-        <div class="input-group">
-          <label class="input-label">电子邮箱</label>
-          <input type="email" id="clientEmail" placeholder="client@example.com">
-        </div>
-      </div>
-    </div>
-
-    <!-- Quote Details -->
-    <div class="tool-section">
-      <div class="section-title">报价单信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">报价单编号</label>
-          <input type="text" id="quoteNumber" readonly="">
-        </div>
-        <div class="input-group">
-          <label class="input-label">报价日期</label>
-          <input type="date" id="quoteDate">
-        </div>
-        <div class="input-group">
-          <label class="input-label">有效期至</label>
-          <input type="date" id="validUntil">
-        </div>
-        <div class="input-group">
-          <label class="input-label">项目名称</label>
-          <input type="text" id="projectName" placeholder="项目/产品名称">
-        </div>
-      </div>
-    </div>
-
-    <!-- Line Items -->
-    <div class="tool-section">
-      <div class="section-title">报价明细</div>
-      <div class="line-items-container">
-        <table class="line-items-table">
-          <thead>
-            <tr>
-              <th class="desc-col">项目描述</th>
-              <th class="num-col">数量</th>
-              <th class="num-col">单价</th>
-              <th class="amount-col">金额</th>
-              <th class="action-col no-print"></th>
-            </tr>
-          </thead>
-          <tbody id="lineItemsBody">
-            <!-- Line items will be added here -->
-          </tbody>
-        </table>
-      </div>
-      <div class="btn-row no-print">
-        <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
-      </div>
-
-      <!-- Summary -->
-      <div class="summary-section">
-        <div class="summary-box">
-          <div class="summary-row">
-            <span class="label">小计</span>
-            <span class="value" id="subtotal">¥0.00</span>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">报价单生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">💵</span>
+              报价单生成器
+            </h1>
+            <p>创建专业报价单，支持明细项目、税率计算、有效期、条款</p>
           </div>
-          <div class="summary-row">
-            <span class="label">税率</span>
-            <span class="tax-input no-print">
-              <input type="number" id="taxRate" value="0" min="0" max="100" step="0.1" onchange="calculateTotals()">
-              <span>%</span>
-            </span>
-            <span class="value print-only" id="taxRateDisplay" style="display: none"></span>
-          </div>
-          <div class="summary-row">
-            <span class="label">税额</span>
-            <span class="value" id="taxAmount">¥0.00</span>
-          </div>
-          <div class="summary-row total">
-            <span class="label">总计</span>
-            <span class="value" id="total">¥0.00</span>
-          </div>
-        </div>
-      </div>
+        </header>
 
-      <!-- Validity Notice -->
-      <div class="validity-box" id="validityNotice">报价有效期: 请设置有效期</div>
-    </div>
+        <main class="main-content">
+          <!-- Print Header -->
+          <div class="quote-header-print">
+            <div class="print-title">报价单</div>
+            <div class="print-info">
+              <div id="printQuoteNo"></div>
+              <div id="printQuoteDate"></div>
+            </div>
+          </div>
 
-    <!-- Terms -->
-    <div class="tool-section">
-      <div class="section-title">条款与条件</div>
-      <div class="input-group">
-        <textarea id="terms" placeholder="付款条款、交货方式、保修说明等...">1. 付款方式：预付款50%，交货后付清余款
+          <!-- Company Info -->
+          <div class="tool-section">
+            <div class="section-title">公司信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">公司名称</label>
+                <input type="text" id="companyName" placeholder="您的公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">公司地址</label>
+                <input type="text" id="companyAddress" placeholder="公司地址" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="companyPhone" placeholder="联系电话" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">电子邮箱</label>
+                <input type="email" id="companyEmail" placeholder="company@example.com" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Client Info -->
+          <div class="tool-section">
+            <div class="section-title">客户信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">客户名称</label>
+                <input type="text" id="clientName" placeholder="客户/公司名称" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系人</label>
+                <input type="text" id="clientContact" placeholder="联系人姓名" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="clientPhone" placeholder="客户电话" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">电子邮箱</label>
+                <input type="email" id="clientEmail" placeholder="client@example.com" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Quote Details -->
+          <div class="tool-section">
+            <div class="section-title">报价单信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">报价单编号</label>
+                <input type="text" id="quoteNumber" readonly="" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">报价日期</label>
+                <input type="date" id="quoteDate" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">有效期至</label>
+                <input type="date" id="validUntil" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">项目名称</label>
+                <input type="text" id="projectName" placeholder="项目/产品名称" />
+              </div>
+            </div>
+          </div>
+
+          <!-- Line Items -->
+          <div class="tool-section">
+            <div class="section-title">报价明细</div>
+            <div class="line-items-container">
+              <table class="line-items-table">
+                <thead>
+                  <tr>
+                    <th class="desc-col">项目描述</th>
+                    <th class="num-col">数量</th>
+                    <th class="num-col">单价</th>
+                    <th class="amount-col">金额</th>
+                    <th class="action-col no-print"></th>
+                  </tr>
+                </thead>
+                <tbody id="lineItemsBody">
+                  <!-- Line items will be added here -->
+                </tbody>
+              </table>
+            </div>
+            <div class="btn-row no-print">
+              <button class="btn btn-secondary btn-sm" onclick="addLineItem()">+ 添加项目</button>
+            </div>
+
+            <!-- Summary -->
+            <div class="summary-section">
+              <div class="summary-box">
+                <div class="summary-row">
+                  <span class="label">小计</span>
+                  <span class="value" id="subtotal">¥0.00</span>
+                </div>
+                <div class="summary-row">
+                  <span class="label">税率</span>
+                  <span class="tax-input no-print">
+                    <input
+                      type="number"
+                      id="taxRate"
+                      value="0"
+                      min="0"
+                      max="100"
+                      step="0.1"
+                      onchange="calculateTotals()"
+                    />
+                    <span>%</span>
+                  </span>
+                  <span class="value print-only" id="taxRateDisplay" style="display: none"></span>
+                </div>
+                <div class="summary-row">
+                  <span class="label">税额</span>
+                  <span class="value" id="taxAmount">¥0.00</span>
+                </div>
+                <div class="summary-row total">
+                  <span class="label">总计</span>
+                  <span class="value" id="total">¥0.00</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Validity Notice -->
+            <div class="validity-box" id="validityNotice">报价有效期: 请设置有效期</div>
+          </div>
+
+          <!-- Terms -->
+          <div class="tool-section">
+            <div class="section-title">条款与条件</div>
+            <div class="input-group">
+              <textarea id="terms" placeholder="付款条款、交货方式、保修说明等...">
+1. 付款方式：预付款50%，交货后付清余款
 2. 交货周期：收到订单后7-14个工作日
 3. 报价有效期：自报价日起30天内有效
 4. 以上报价不含运费，运费按实际发生计算
-5. 如有任何疑问，请随时联系我们</textarea>
+5. 如有任何疑问，请随时联系我们</textarea
+              >
+            </div>
+          </div>
+
+          <!-- Notes -->
+          <div class="tool-section">
+            <div class="section-title">备注说明</div>
+            <div class="input-group">
+              <textarea id="notes" placeholder="其他补充说明..."></textarea>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printQuote()">🖨️ 打印报价单</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- Notes -->
-    <div class="tool-section">
-      <div class="section-title">备注说明</div>
-      <div class="input-group">
-        <textarea id="notes" placeholder="其他补充说明..."></textarea>
-      </div>
-    </div>
-
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printQuote()">🖨️ 打印报价单</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "报价单生成器",
-              "item": "https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "报价单生成器",
+            "item": "https://tools.realtime-ai.chat/tools/office/quotation-maker.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "quotation_maker_data_v1";
+      var lineItems = [];
+      var itemIdCounter = 0;
 
-  var LS_KEY = "quotation_maker_data_v1";
-        var lineItems = [];
-        var itemIdCounter = 0;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-
-          // Generate quote number if empty
-          var quoteNoEl = document.getElementById("quoteNumber");
-          if (!quoteNoEl.value) {
-            quoteNoEl.value = generateQuoteNumber();
-          }
-
-          // Set default dates if empty
-          var today = new Date().toISOString().split("T")[0];
-          var quoteDateEl = document.getElementById("quoteDate");
-          if (!quoteDateEl.value) {
-            quoteDateEl.value = today;
-          }
-
-          var validUntilEl = document.getElementById("validUntil");
-          if (!validUntilEl.value) {
-            var validDate = new Date();
-            validDate.setDate(validDate.getDate() + 30);
-            validUntilEl.value = validDate.toISOString().split("T")[0];
-          }
-
-          // Add initial line item if none exist
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-          }
-
-          updateValidityNotice();
-
-          // Add input listeners for auto-save
-          var inputs = document.querySelectorAll("input, textarea, select");
-          for (var i = 0; i < inputs.length; i++) {
-            inputs[i].addEventListener("input", debounce(saveToStorage, 500));
-            inputs[i].addEventListener("change", function () {
-              debounce(saveToStorage, 500)();
-              updateValidityNotice();
-            });
-          }
+        // Generate quote number if empty
+        var quoteNoEl = document.getElementById("quoteNumber");
+        if (!quoteNoEl.value) {
+          quoteNoEl.value = generateQuoteNumber();
         }
 
-        // Generate unique quote number
-        function generateQuoteNumber() {
-          var date = new Date();
-          var year = date.getFullYear();
-          var month = String(date.getMonth() + 1).padStart(2, "0");
-          var day = String(date.getDate()).padStart(2, "0");
-          var random = Math.floor(Math.random() * 1000)
-            .toString()
-            .padStart(3, "0");
-          return "QT-" + year + month + day + "-" + random;
+        // Set default dates if empty
+        var today = new Date().toISOString().split("T")[0];
+        var quoteDateEl = document.getElementById("quoteDate");
+        if (!quoteDateEl.value) {
+          quoteDateEl.value = today;
         }
 
-        // Update validity notice
-        function updateValidityNotice() {
-          var quoteDate = document.getElementById("quoteDate").value;
-          var validUntil = document.getElementById("validUntil").value;
-          var notice = document.getElementById("validityNotice");
-
-          if (quoteDate && validUntil) {
-            var start = new Date(quoteDate);
-            var end = new Date(validUntil);
-            var days = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
-            notice.textContent =
-              "报价有效期: " + quoteDate + " 至 " + validUntil + " (" + days + "天)";
-          } else {
-            notice.textContent = "报价有效期: 请设置有效期";
-          }
-        }
-
-        // Add new line item
-        function addLineItem() {
-          var item = {
-            id: ++itemIdCounter,
-            description: "",
-            quantity: 1,
-            unitPrice: 0
-          };
-          lineItems.push(item);
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Remove line item
-        function removeLineItem(id) {
-          lineItems = lineItems.filter(function (item) {
-            return item.id !== id;
-          });
-          if (lineItems.length === 0) {
-            addLineItem();
-          } else {
-            renderLineItems();
-            calculateTotals();
-            saveToStorage();
-          }
-        }
-
-        // Create line item row
-        function createLineItemRow(item) {
-          var row = document.createElement("tr");
-          var amount = item.quantity * item.unitPrice;
-
-          // Description cell
-          var descCell = document.createElement("td");
-          descCell.className = "desc-col";
-          var descTextarea = document.createElement("textarea");
-          descTextarea.value = item.description;
-          descTextarea.placeholder = "项目描述/规格说明";
-          descTextarea.rows = 2;
-          descTextarea.addEventListener("change", function () {
-            updateLineItem(item.id, "description", this.value);
-          });
-          descCell.appendChild(descTextarea);
-          row.appendChild(descCell);
-
-          // Quantity cell
-          var qtyCell = document.createElement("td");
-          qtyCell.className = "num-col";
-          var qtyInput = document.createElement("input");
-          qtyInput.type = "number";
-          qtyInput.value = item.quantity;
-          qtyInput.min = "0";
-          qtyInput.step = "1";
-          qtyInput.addEventListener("change", function () {
-            updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
-          });
-          qtyCell.appendChild(qtyInput);
-          row.appendChild(qtyCell);
-
-          // Unit price cell
-          var priceCell = document.createElement("td");
-          priceCell.className = "num-col";
-          var priceInput = document.createElement("input");
-          priceInput.type = "number";
-          priceInput.value = item.unitPrice;
-          priceInput.min = "0";
-          priceInput.step = "0.01";
-          priceInput.addEventListener("change", function () {
-            updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
-          });
-          priceCell.appendChild(priceInput);
-          row.appendChild(priceCell);
-
-          // Amount cell
-          var amountCell = document.createElement("td");
-          amountCell.className = "amount-col";
-          amountCell.textContent = "¥" + formatNumber(amount);
-          row.appendChild(amountCell);
-
-          // Action cell
-          var actionCell = document.createElement("td");
-          actionCell.className = "action-col no-print";
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove";
-          removeBtn.title = "删除";
-          removeBtn.textContent = "×";
-          removeBtn.addEventListener("click", function () {
-            removeLineItem(item.id);
-          });
-          actionCell.appendChild(removeBtn);
-          row.appendChild(actionCell);
-
-          return row;
-        }
-
-        // Render line items
-        function renderLineItems() {
-          var tbody = document.getElementById("lineItemsBody");
-          tbody.textContent = "";
-
-          for (var i = 0; i < lineItems.length; i++) {
-            var row = createLineItemRow(lineItems[i]);
-            tbody.appendChild(row);
-          }
-
-          calculateTotals();
-        }
-
-        // Update line item
-        function updateLineItem(id, field, value) {
-          for (var i = 0; i < lineItems.length; i++) {
-            if (lineItems[i].id === id) {
-              lineItems[i][field] = value;
-              break;
-            }
-          }
-          renderLineItems();
-          saveToStorage();
-        }
-
-        // Calculate totals
-        function calculateTotals() {
-          var subtotal = 0;
-          for (var i = 0; i < lineItems.length; i++) {
-            subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
-          }
-
-          var taxRate = parseFloat(document.getElementById("taxRate").value) || 0;
-          var taxAmount = subtotal * (taxRate / 100);
-          var total = subtotal + taxAmount;
-
-          document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
-          document.getElementById("taxAmount").textContent = "¥" + formatNumber(taxAmount);
-          document.getElementById("total").textContent = "¥" + formatNumber(total);
-
-          saveToStorage();
-        }
-
-        // Format number
-        function formatNumber(num) {
-          return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-          };
-        }
-
-        // Print quote
-        function printQuote() {
-          document.getElementById("printQuoteNo").textContent =
-            "报价单编号: " + document.getElementById("quoteNumber").value;
-          document.getElementById("printQuoteDate").textContent =
-            "日期: " + document.getElementById("quoteDate").value;
-
-          var taxRateDisplay = document.getElementById("taxRateDisplay");
-          taxRateDisplay.textContent = document.getElementById("taxRate").value + "%";
-          taxRateDisplay.style.display = "inline";
-
-          window.print();
-
-          setTimeout(function () {
-            taxRateDisplay.style.display = "none";
-          }, 100);
-        }
-
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
-
-          document.getElementById("companyName").value = "";
-          document.getElementById("companyAddress").value = "";
-          document.getElementById("companyPhone").value = "";
-          document.getElementById("companyEmail").value = "";
-          document.getElementById("clientName").value = "";
-          document.getElementById("clientContact").value = "";
-          document.getElementById("clientPhone").value = "";
-          document.getElementById("clientEmail").value = "";
-          document.getElementById("quoteNumber").value = generateQuoteNumber();
-          document.getElementById("quoteDate").value = new Date().toISOString().split("T")[0];
+        var validUntilEl = document.getElementById("validUntil");
+        if (!validUntilEl.value) {
           var validDate = new Date();
           validDate.setDate(validDate.getDate() + 30);
-          document.getElementById("validUntil").value = validDate.toISOString().split("T")[0];
-          document.getElementById("projectName").value = "";
-          document.getElementById("taxRate").value = "0";
-          document.getElementById("terms").value =
-            "1. 付款方式：预付款50%，交货后付清余款\n2. 交货周期：收到订单后7-14个工作日\n3. 报价有效期：自报价日起30天内有效\n4. 以上报价不含运费，运费按实际发生计算\n5. 如有任何疑问，请随时联系我们";
-          document.getElementById("notes").value = "";
+          validUntilEl.value = validDate.toISOString().split("T")[0];
+        }
 
-          lineItems = [];
-          itemIdCounter = 0;
+        // Add initial line item if none exist
+        if (lineItems.length === 0) {
           addLineItem();
-          updateValidityNotice();
-
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
+        } else {
+          renderLineItems();
         }
 
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            companyName: document.getElementById("companyName").value,
-            companyAddress: document.getElementById("companyAddress").value,
-            companyPhone: document.getElementById("companyPhone").value,
-            companyEmail: document.getElementById("companyEmail").value,
-            clientName: document.getElementById("clientName").value,
-            clientContact: document.getElementById("clientContact").value,
-            clientPhone: document.getElementById("clientPhone").value,
-            clientEmail: document.getElementById("clientEmail").value,
-            quoteNumber: document.getElementById("quoteNumber").value,
-            quoteDate: document.getElementById("quoteDate").value,
-            validUntil: document.getElementById("validUntil").value,
-            projectName: document.getElementById("projectName").value,
-            taxRate: document.getElementById("taxRate").value,
-            terms: document.getElementById("terms").value,
-            notes: document.getElementById("notes").value,
-            lineItems: lineItems,
-            itemIdCounter: itemIdCounter
+        updateValidityNotice();
+
+        // Add input listeners for auto-save
+        var inputs = document.querySelectorAll("input, textarea, select");
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].addEventListener("input", debounce(saveToStorage, 500));
+          inputs[i].addEventListener("change", function () {
+            debounce(saveToStorage, 500)();
+            updateValidityNotice();
+          });
+        }
+      }
+
+      // Generate unique quote number
+      function generateQuoteNumber() {
+        var date = new Date();
+        var year = date.getFullYear();
+        var month = String(date.getMonth() + 1).padStart(2, "0");
+        var day = String(date.getDate()).padStart(2, "0");
+        var random = Math.floor(Math.random() * 1000)
+          .toString()
+          .padStart(3, "0");
+        return "QT-" + year + month + day + "-" + random;
+      }
+
+      // Update validity notice
+      function updateValidityNotice() {
+        var quoteDate = document.getElementById("quoteDate").value;
+        var validUntil = document.getElementById("validUntil").value;
+        var notice = document.getElementById("validityNotice");
+
+        if (quoteDate && validUntil) {
+          var start = new Date(quoteDate);
+          var end = new Date(validUntil);
+          var days = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
+          notice.textContent =
+            "报价有效期: " + quoteDate + " 至 " + validUntil + " (" + days + "天)";
+        } else {
+          notice.textContent = "报价有效期: 请设置有效期";
+        }
+      }
+
+      // Add new line item
+      function addLineItem() {
+        var item = {
+          id: ++itemIdCounter,
+          description: "",
+          quantity: 1,
+          unitPrice: 0
+        };
+        lineItems.push(item);
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Remove line item
+      function removeLineItem(id) {
+        lineItems = lineItems.filter(function (item) {
+          return item.id !== id;
+        });
+        if (lineItems.length === 0) {
+          addLineItem();
+        } else {
+          renderLineItems();
+          calculateTotals();
+          saveToStorage();
+        }
+      }
+
+      // Create line item row
+      function createLineItemRow(item) {
+        var row = document.createElement("tr");
+        var amount = item.quantity * item.unitPrice;
+
+        // Description cell
+        var descCell = document.createElement("td");
+        descCell.className = "desc-col";
+        var descTextarea = document.createElement("textarea");
+        descTextarea.value = item.description;
+        descTextarea.placeholder = "项目描述/规格说明";
+        descTextarea.rows = 2;
+        descTextarea.addEventListener("change", function () {
+          updateLineItem(item.id, "description", this.value);
+        });
+        descCell.appendChild(descTextarea);
+        row.appendChild(descCell);
+
+        // Quantity cell
+        var qtyCell = document.createElement("td");
+        qtyCell.className = "num-col";
+        var qtyInput = document.createElement("input");
+        qtyInput.type = "number";
+        qtyInput.value = item.quantity;
+        qtyInput.min = "0";
+        qtyInput.step = "1";
+        qtyInput.addEventListener("change", function () {
+          updateLineItem(item.id, "quantity", parseFloat(this.value) || 0);
+        });
+        qtyCell.appendChild(qtyInput);
+        row.appendChild(qtyCell);
+
+        // Unit price cell
+        var priceCell = document.createElement("td");
+        priceCell.className = "num-col";
+        var priceInput = document.createElement("input");
+        priceInput.type = "number";
+        priceInput.value = item.unitPrice;
+        priceInput.min = "0";
+        priceInput.step = "0.01";
+        priceInput.addEventListener("change", function () {
+          updateLineItem(item.id, "unitPrice", parseFloat(this.value) || 0);
+        });
+        priceCell.appendChild(priceInput);
+        row.appendChild(priceCell);
+
+        // Amount cell
+        var amountCell = document.createElement("td");
+        amountCell.className = "amount-col";
+        amountCell.textContent = "¥" + formatNumber(amount);
+        row.appendChild(amountCell);
+
+        // Action cell
+        var actionCell = document.createElement("td");
+        actionCell.className = "action-col no-print";
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove";
+        removeBtn.title = "删除";
+        removeBtn.textContent = "×";
+        removeBtn.addEventListener("click", function () {
+          removeLineItem(item.id);
+        });
+        actionCell.appendChild(removeBtn);
+        row.appendChild(actionCell);
+
+        return row;
+      }
+
+      // Render line items
+      function renderLineItems() {
+        var tbody = document.getElementById("lineItemsBody");
+        tbody.textContent = "";
+
+        for (var i = 0; i < lineItems.length; i++) {
+          var row = createLineItemRow(lineItems[i]);
+          tbody.appendChild(row);
+        }
+
+        calculateTotals();
+      }
+
+      // Update line item
+      function updateLineItem(id, field, value) {
+        for (var i = 0; i < lineItems.length; i++) {
+          if (lineItems[i].id === id) {
+            lineItems[i][field] = value;
+            break;
+          }
+        }
+        renderLineItems();
+        saveToStorage();
+      }
+
+      // Calculate totals
+      function calculateTotals() {
+        var subtotal = 0;
+        for (var i = 0; i < lineItems.length; i++) {
+          subtotal += lineItems[i].quantity * lineItems[i].unitPrice;
+        }
+
+        var taxRate = parseFloat(document.getElementById("taxRate").value) || 0;
+        var taxAmount = subtotal * (taxRate / 100);
+        var total = subtotal + taxAmount;
+
+        document.getElementById("subtotal").textContent = "¥" + formatNumber(subtotal);
+        document.getElementById("taxAmount").textContent = "¥" + formatNumber(taxAmount);
+        document.getElementById("total").textContent = "¥" + formatNumber(total);
+
+        saveToStorage();
+      }
+
+      // Format number
+      function formatNumber(num) {
+        return num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      }
+
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
+            clearTimeout(timeout);
+            func.apply(context, args);
           };
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
 
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
+      // Print quote
+      function printQuote() {
+        document.getElementById("printQuoteNo").textContent =
+          "报价单编号: " + document.getElementById("quoteNumber").value;
+        document.getElementById("printQuoteDate").textContent =
+          "日期: " + document.getElementById("quoteDate").value;
 
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
+        var taxRateDisplay = document.getElementById("taxRateDisplay");
+        taxRateDisplay.textContent = document.getElementById("taxRate").value + "%";
+        taxRateDisplay.style.display = "inline";
 
-          try {
-            var data = JSON.parse(saved);
+        window.print();
 
-            document.getElementById("companyName").value = data.companyName || "";
-            document.getElementById("companyAddress").value = data.companyAddress || "";
-            document.getElementById("companyPhone").value = data.companyPhone || "";
-            document.getElementById("companyEmail").value = data.companyEmail || "";
-            document.getElementById("clientName").value = data.clientName || "";
-            document.getElementById("clientContact").value = data.clientContact || "";
-            document.getElementById("clientPhone").value = data.clientPhone || "";
-            document.getElementById("clientEmail").value = data.clientEmail || "";
-            document.getElementById("quoteNumber").value = data.quoteNumber || "";
-            document.getElementById("quoteDate").value = data.quoteDate || "";
-            document.getElementById("validUntil").value = data.validUntil || "";
-            document.getElementById("projectName").value = data.projectName || "";
-            document.getElementById("taxRate").value = data.taxRate || "0";
-            document.getElementById("terms").value = data.terms || "";
-            document.getElementById("notes").value = data.notes || "";
+        setTimeout(function () {
+          taxRateDisplay.style.display = "none";
+        }, 100);
+      }
 
-            if (data.lineItems && data.lineItems.length > 0) {
-              lineItems = data.lineItems;
-              itemIdCounter = data.itemIdCounter || lineItems.length;
-            }
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
+
+        document.getElementById("companyName").value = "";
+        document.getElementById("companyAddress").value = "";
+        document.getElementById("companyPhone").value = "";
+        document.getElementById("companyEmail").value = "";
+        document.getElementById("clientName").value = "";
+        document.getElementById("clientContact").value = "";
+        document.getElementById("clientPhone").value = "";
+        document.getElementById("clientEmail").value = "";
+        document.getElementById("quoteNumber").value = generateQuoteNumber();
+        document.getElementById("quoteDate").value = new Date().toISOString().split("T")[0];
+        var validDate = new Date();
+        validDate.setDate(validDate.getDate() + 30);
+        document.getElementById("validUntil").value = validDate.toISOString().split("T")[0];
+        document.getElementById("projectName").value = "";
+        document.getElementById("taxRate").value = "0";
+        document.getElementById("terms").value =
+          "1. 付款方式：预付款50%，交货后付清余款\n2. 交货周期：收到订单后7-14个工作日\n3. 报价有效期：自报价日起30天内有效\n4. 以上报价不含运费，运费按实际发生计算\n5. 如有任何疑问，请随时联系我们";
+        document.getElementById("notes").value = "";
+
+        lineItems = [];
+        itemIdCounter = 0;
+        addLineItem();
+        updateValidityNotice();
+
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          companyName: document.getElementById("companyName").value,
+          companyAddress: document.getElementById("companyAddress").value,
+          companyPhone: document.getElementById("companyPhone").value,
+          companyEmail: document.getElementById("companyEmail").value,
+          clientName: document.getElementById("clientName").value,
+          clientContact: document.getElementById("clientContact").value,
+          clientPhone: document.getElementById("clientPhone").value,
+          clientEmail: document.getElementById("clientEmail").value,
+          quoteNumber: document.getElementById("quoteNumber").value,
+          quoteDate: document.getElementById("quoteDate").value,
+          validUntil: document.getElementById("validUntil").value,
+          projectName: document.getElementById("projectName").value,
+          taxRate: document.getElementById("taxRate").value,
+          terms: document.getElementById("terms").value,
+          notes: document.getElementById("notes").value,
+          lineItems: lineItems,
+          itemIdCounter: itemIdCounter
+        };
+
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          document.getElementById("companyName").value = data.companyName || "";
+          document.getElementById("companyAddress").value = data.companyAddress || "";
+          document.getElementById("companyPhone").value = data.companyPhone || "";
+          document.getElementById("companyEmail").value = data.companyEmail || "";
+          document.getElementById("clientName").value = data.clientName || "";
+          document.getElementById("clientContact").value = data.clientContact || "";
+          document.getElementById("clientPhone").value = data.clientPhone || "";
+          document.getElementById("clientEmail").value = data.clientEmail || "";
+          document.getElementById("quoteNumber").value = data.quoteNumber || "";
+          document.getElementById("quoteDate").value = data.quoteDate || "";
+          document.getElementById("validUntil").value = data.validUntil || "";
+          document.getElementById("projectName").value = data.projectName || "";
+          document.getElementById("taxRate").value = data.taxRate || "0";
+          document.getElementById("terms").value = data.terms || "";
+          document.getElementById("notes").value = data.notes || "";
+
+          if (data.lineItems && data.lineItems.length > 0) {
+            lineItems = data.lineItems;
+            itemIdCounter = data.itemIdCounter || lineItems.length;
           }
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
         }
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      }
 
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        }
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
 
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+      // Initialize on load
+      init();
+    </script>
 
-        // Initialize on load
-        init();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/resume-maker.html
+++ b/tools/office/resume-maker.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Resume Maker - WebUtils" />
-    <meta property="og:description" content="Resume Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Resume Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/resume-maker.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/resume-maker.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Resume Maker - WebUtils" />
-    <meta name="twitter:description" content="Resume Maker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Resume Maker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Resume Maker",
-      "item": "https://tools.realtime-ai.chat/tools/office/resume-maker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Resume Maker",
+            "item": "https://tools.realtime-ai.chat/tools/office/resume-maker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Resume Maker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Resume Maker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1139 +97,1154 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 16px;
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  input[type="email"],
-  input[type="tel"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="date"],
+      input[type="email"],
+      input[type="tel"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  textarea {
-    min-height: 80px;
-    resize: vertical;
-  }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      textarea {
+        min-height: 80px;
+        resize: vertical;
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
 
-  /* Entry Card */
-  .entry-card {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    margin-bottom: 12px;
-    position: relative;
-  }
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
 
-  .entry-card .form-grid {
-    margin-bottom: 8px;
-  }
+      /* Entry Card */
+      .entry-card {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        margin-bottom: 12px;
+        position: relative;
+      }
 
-  .btn-remove-entry {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    background: transparent;
-    border: none;
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 1.2rem;
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    transition: background 0.2s;
-  }
+      .entry-card .form-grid {
+        margin-bottom: 8px;
+      }
 
-  .btn-remove-entry:hover {
-    background: rgba(244, 63, 94, 0.1);
-  }
+      .btn-remove-entry {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background: transparent;
+        border: none;
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 1.2rem;
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        transition: background 0.2s;
+      }
 
-  /* Skills Tags */
-  .skills-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 12px;
-  }
+      .btn-remove-entry:hover {
+        background: rgba(244, 63, 94, 0.1);
+      }
 
-  .skill-tag {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    padding: 6px 12px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
+      /* Skills Tags */
+      .skills-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
 
-  .skill-tag .remove {
-    cursor: pointer;
-    color: var(--accent-red);
-    font-size: 1rem;
-  }
+      .skill-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        padding: 6px 12px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
 
-  .skill-tag .remove:hover {
-    opacity: 0.8;
-  }
+      .skill-tag .remove {
+        cursor: pointer;
+        color: var(--accent-red);
+        font-size: 1rem;
+      }
 
-  .skill-input-row {
-    display: flex;
-    gap: 8px;
-  }
+      .skill-tag .remove:hover {
+        opacity: 0.8;
+      }
 
-  .skill-input-row input {
-    flex: 1;
-  }
+      .skill-input-row {
+        display: flex;
+        gap: 8px;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .skill-input-row input {
+        flex: 1;
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .btn-remove-entry,
-    .skill-input-row,
-    .no-print {
-      display: none !important;
-    }
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
 
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .btn-remove-entry,
+        .skill-input-row,
+        .no-print {
+          display: none !important;
+        }
 
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
 
-    .tool-section {
-      page-break-inside: avoid;
-    }
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
 
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
+        .tool-section {
+          page-break-inside: avoid;
+        }
 
-    input,
-    textarea,
-    select {
-      border: none !important;
-      background: transparent !important;
-      padding: 4px 0 !important;
-      color: #000 !important;
-    }
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
 
-    .entry-card {
-      background: transparent;
-      border: none;
-      border-bottom: 1px solid #eee;
-      padding: 12px 0;
-      margin-bottom: 8px;
-    }
+        input,
+        textarea,
+        select {
+          border: none !important;
+          background: transparent !important;
+          padding: 4px 0 !important;
+          color: #000 !important;
+        }
 
-    .skill-tag {
-      background: #f0f0f0;
-      border-color: #ddd;
-      color: #333;
-    }
+        .entry-card {
+          background: transparent;
+          border: none;
+          border-bottom: 1px solid #eee;
+          padding: 12px 0;
+          margin-bottom: 8px;
+        }
 
-    .skill-tag .remove {
-      display: none;
-    }
+        .skill-tag {
+          background: #f0f0f0;
+          border-color: #ddd;
+          color: #333;
+        }
 
-    .input-label {
-      display: none;
-    }
+        .skill-tag .remove {
+          display: none;
+        }
 
-    .form-grid {
-      display: block;
-    }
+        .input-label {
+          display: none;
+        }
 
-    .input-group {
-      display: inline-block;
-      margin-right: 16px;
-    }
+        .form-grid {
+          display: block;
+        }
 
-    .resume-header-print {
-      display: block !important;
-      text-align: center;
-      margin-bottom: 24px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
+        .input-group {
+          display: inline-block;
+          margin-right: 16px;
+        }
 
-    .print-name {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #000;
-      margin-bottom: 8px;
-    }
+        .resume-header-print {
+          display: block !important;
+          text-align: center;
+          margin-bottom: 24px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
 
-    .print-contact {
-      font-size: 0.9rem;
-      color: #666;
-    }
-  }
+        .print-name {
+          font-size: 2rem;
+          font-weight: 700;
+          color: #000;
+          margin-bottom: 8px;
+        }
 
-  .resume-header-print {
-    display: none;
-  }
+        .print-contact {
+          font-size: 0.9rem;
+          color: #666;
+        }
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .resume-header-print {
+        display: none;
+      }
 
-    .btn-row {
-      flex-direction: column;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">简历生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📄</span>
-        简历生成器
-      </h1>
-      <p>创建专业简历，支持个人信息、教育背景、工作经验、技能展示</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">简历生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📄</span>
+              简历生成器
+            </h1>
+            <p>创建专业简历，支持个人信息、教育背景、工作经验、技能展示</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Print Header -->
-    <div class="resume-header-print">
-      <div class="print-name" id="printName"></div>
-      <div class="print-contact" id="printContact"></div>
+        <main class="main-content">
+          <!-- Print Header -->
+          <div class="resume-header-print">
+            <div class="print-name" id="printName"></div>
+            <div class="print-contact" id="printContact"></div>
+          </div>
+
+          <!-- Personal Info -->
+          <div class="tool-section">
+            <div class="section-title">个人信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">姓名</label>
+                <input type="text" id="fullName" placeholder="您的姓名" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">求职意向</label>
+                <input type="text" id="jobTitle" placeholder="目标职位" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">电子邮箱</label>
+                <input type="email" id="email" placeholder="your@email.com" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">联系电话</label>
+                <input type="tel" id="phone" placeholder="手机号码" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">所在城市</label>
+                <input type="text" id="location" placeholder="城市" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">个人网站/作品集</label>
+                <input type="text" id="website" placeholder="https://..." />
+              </div>
+            </div>
+          </div>
+
+          <!-- Summary -->
+          <div class="tool-section">
+            <div class="section-title">个人简介</div>
+            <div class="input-group">
+              <textarea
+                id="summary"
+                placeholder="简要介绍自己的专业背景、核心优势和职业目标..."
+              ></textarea>
+            </div>
+          </div>
+
+          <!-- Education -->
+          <div class="tool-section">
+            <div class="section-title">教育经历</div>
+            <div id="educationList">
+              <!-- Education entries will be added here -->
+            </div>
+            <div class="btn-row no-print">
+              <button class="btn btn-secondary btn-sm" onclick="addEducation()">
+                + 添加教育经历
+              </button>
+            </div>
+          </div>
+
+          <!-- Work Experience -->
+          <div class="tool-section">
+            <div class="section-title">工作经验</div>
+            <div id="experienceList">
+              <!-- Experience entries will be added here -->
+            </div>
+            <div class="btn-row no-print">
+              <button class="btn btn-secondary btn-sm" onclick="addExperience()">
+                + 添加工作经验
+              </button>
+            </div>
+          </div>
+
+          <!-- Skills -->
+          <div class="tool-section">
+            <div class="section-title">专业技能</div>
+            <div class="skills-container" id="skillsContainer">
+              <!-- Skill tags will be added here -->
+            </div>
+            <div class="skill-input-row no-print">
+              <input
+                type="text"
+                id="skillInput"
+                placeholder="输入技能名称"
+                onkeypress="handleSkillKeypress(event)"
+              />
+              <button class="btn btn-secondary btn-sm" onclick="addSkill()">添加</button>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printResume()">🖨️ 打印简历</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
 
-    <!-- Personal Info -->
-    <div class="tool-section">
-      <div class="section-title">个人信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">姓名</label>
-          <input type="text" id="fullName" placeholder="您的姓名">
-        </div>
-        <div class="input-group">
-          <label class="input-label">求职意向</label>
-          <input type="text" id="jobTitle" placeholder="目标职位">
-        </div>
-        <div class="input-group">
-          <label class="input-label">电子邮箱</label>
-          <input type="email" id="email" placeholder="your@email.com">
-        </div>
-        <div class="input-group">
-          <label class="input-label">联系电话</label>
-          <input type="tel" id="phone" placeholder="手机号码">
-        </div>
-        <div class="input-group">
-          <label class="input-label">所在城市</label>
-          <input type="text" id="location" placeholder="城市">
-        </div>
-        <div class="input-group">
-          <label class="input-label">个人网站/作品集</label>
-          <input type="text" id="website" placeholder="https://...">
-        </div>
-      </div>
-    </div>
-
-    <!-- Summary -->
-    <div class="tool-section">
-      <div class="section-title">个人简介</div>
-      <div class="input-group">
-        <textarea id="summary" placeholder="简要介绍自己的专业背景、核心优势和职业目标..."></textarea>
-      </div>
-    </div>
-
-    <!-- Education -->
-    <div class="tool-section">
-      <div class="section-title">教育经历</div>
-      <div id="educationList">
-        <!-- Education entries will be added here -->
-      </div>
-      <div class="btn-row no-print">
-        <button class="btn btn-secondary btn-sm" onclick="addEducation()">+ 添加教育经历</button>
-      </div>
-    </div>
-
-    <!-- Work Experience -->
-    <div class="tool-section">
-      <div class="section-title">工作经验</div>
-      <div id="experienceList">
-        <!-- Experience entries will be added here -->
-      </div>
-      <div class="btn-row no-print">
-        <button class="btn btn-secondary btn-sm" onclick="addExperience()">+ 添加工作经验</button>
-      </div>
-    </div>
-
-    <!-- Skills -->
-    <div class="tool-section">
-      <div class="section-title">专业技能</div>
-      <div class="skills-container" id="skillsContainer">
-        <!-- Skill tags will be added here -->
-      </div>
-      <div class="skill-input-row no-print">
-        <input type="text" id="skillInput" placeholder="输入技能名称" onkeypress="handleSkillKeypress(event)">
-        <button class="btn btn-secondary btn-sm" onclick="addSkill()">添加</button>
-      </div>
-    </div>
-
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printResume()">🖨️ 打印简历</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "简历生成器",
-              "item": "https://tools.realtime-ai.chat/tools/office/resume-maker.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "简历生成器",
+            "item": "https://tools.realtime-ai.chat/tools/office/resume-maker.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "resume_maker_data_v1";
+      var educationList = [];
+      var experienceList = [];
+      var skillsList = [];
+      var idCounter = 0;
 
-  var LS_KEY = "resume_maker_data_v1";
-        var educationList = [];
-        var experienceList = [];
-        var skillsList = [];
-        var idCounter = 0;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-
-          // Add initial entries if none exist
-          if (educationList.length === 0) {
-            addEducation();
-          } else {
-            renderEducation();
-          }
-
-          if (experienceList.length === 0) {
-            addExperience();
-          } else {
-            renderExperience();
-          }
-
-          renderSkills();
-
-          // Add input listeners for auto-save
-          var inputs = document.querySelectorAll("input, textarea, select");
-          for (var i = 0; i < inputs.length; i++) {
-            inputs[i].addEventListener("input", debounce(saveToStorage, 500));
-            inputs[i].addEventListener("change", debounce(saveToStorage, 500));
-          }
+        // Add initial entries if none exist
+        if (educationList.length === 0) {
+          addEducation();
+        } else {
+          renderEducation();
         }
 
-        // Add education entry
-        function addEducation() {
-          var entry = {
-            id: ++idCounter,
-            school: "",
-            degree: "",
-            field: "",
-            startDate: "",
-            endDate: "",
-            description: ""
-          };
-          educationList.push(entry);
+        if (experienceList.length === 0) {
+          addExperience();
+        } else {
+          renderExperience();
+        }
+
+        renderSkills();
+
+        // Add input listeners for auto-save
+        var inputs = document.querySelectorAll("input, textarea, select");
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].addEventListener("input", debounce(saveToStorage, 500));
+          inputs[i].addEventListener("change", debounce(saveToStorage, 500));
+        }
+      }
+
+      // Add education entry
+      function addEducation() {
+        var entry = {
+          id: ++idCounter,
+          school: "",
+          degree: "",
+          field: "",
+          startDate: "",
+          endDate: "",
+          description: ""
+        };
+        educationList.push(entry);
+        renderEducation();
+        saveToStorage();
+      }
+
+      // Remove education entry
+      function removeEducation(id) {
+        educationList = educationList.filter(function (e) {
+          return e.id !== id;
+        });
+        if (educationList.length === 0) {
+          addEducation();
+        } else {
           renderEducation();
           saveToStorage();
         }
+      }
 
-        // Remove education entry
-        function removeEducation(id) {
-          educationList = educationList.filter(function (e) {
-            return e.id !== id;
-          });
-          if (educationList.length === 0) {
-            addEducation();
-          } else {
-            renderEducation();
-            saveToStorage();
+      // Render education entries
+      function renderEducation() {
+        var container = document.getElementById("educationList");
+        container.textContent = "";
+
+        for (var i = 0; i < educationList.length; i++) {
+          var entry = educationList[i];
+          var card = createEducationCard(entry);
+          container.appendChild(card);
+        }
+      }
+
+      // Create education card
+      function createEducationCard(entry) {
+        var card = document.createElement("div");
+        card.className = "entry-card";
+
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove-entry no-print";
+        removeBtn.textContent = "×";
+        removeBtn.title = "删除";
+        removeBtn.addEventListener("click", function () {
+          removeEducation(entry.id);
+        });
+        card.appendChild(removeBtn);
+
+        var grid = document.createElement("div");
+        grid.className = "form-grid";
+
+        // School
+        var schoolGroup = createInputGroup(
+          "学校名称",
+          "text",
+          entry.school,
+          "学校名称",
+          function (val) {
+            updateEducation(entry.id, "school", val);
+          }
+        );
+        grid.appendChild(schoolGroup);
+
+        // Degree
+        var degreeGroup = createInputGroup(
+          "学历",
+          "text",
+          entry.degree,
+          "本科/硕士/博士",
+          function (val) {
+            updateEducation(entry.id, "degree", val);
+          }
+        );
+        grid.appendChild(degreeGroup);
+
+        // Field
+        var fieldGroup = createInputGroup("专业", "text", entry.field, "专业名称", function (val) {
+          updateEducation(entry.id, "field", val);
+        });
+        grid.appendChild(fieldGroup);
+
+        // Start date
+        var startGroup = createInputGroup("开始日期", "date", entry.startDate, "", function (val) {
+          updateEducation(entry.id, "startDate", val);
+        });
+        grid.appendChild(startGroup);
+
+        // End date
+        var endGroup = createInputGroup("结束日期", "date", entry.endDate, "", function (val) {
+          updateEducation(entry.id, "endDate", val);
+        });
+        grid.appendChild(endGroup);
+
+        card.appendChild(grid);
+
+        return card;
+      }
+
+      // Update education entry
+      function updateEducation(id, field, value) {
+        for (var i = 0; i < educationList.length; i++) {
+          if (educationList[i].id === id) {
+            educationList[i][field] = value;
+            break;
           }
         }
+        saveToStorage();
+      }
 
-        // Render education entries
-        function renderEducation() {
-          var container = document.getElementById("educationList");
-          container.textContent = "";
+      // Add experience entry
+      function addExperience() {
+        var entry = {
+          id: ++idCounter,
+          company: "",
+          position: "",
+          startDate: "",
+          endDate: "",
+          description: ""
+        };
+        experienceList.push(entry);
+        renderExperience();
+        saveToStorage();
+      }
 
-          for (var i = 0; i < educationList.length; i++) {
-            var entry = educationList[i];
-            var card = createEducationCard(entry);
-            container.appendChild(card);
-          }
-        }
-
-        // Create education card
-        function createEducationCard(entry) {
-          var card = document.createElement("div");
-          card.className = "entry-card";
-
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove-entry no-print";
-          removeBtn.textContent = "×";
-          removeBtn.title = "删除";
-          removeBtn.addEventListener("click", function () {
-            removeEducation(entry.id);
-          });
-          card.appendChild(removeBtn);
-
-          var grid = document.createElement("div");
-          grid.className = "form-grid";
-
-          // School
-          var schoolGroup = createInputGroup(
-            "学校名称",
-            "text",
-            entry.school,
-            "学校名称",
-            function (val) {
-              updateEducation(entry.id, "school", val);
-            }
-          );
-          grid.appendChild(schoolGroup);
-
-          // Degree
-          var degreeGroup = createInputGroup(
-            "学历",
-            "text",
-            entry.degree,
-            "本科/硕士/博士",
-            function (val) {
-              updateEducation(entry.id, "degree", val);
-            }
-          );
-          grid.appendChild(degreeGroup);
-
-          // Field
-          var fieldGroup = createInputGroup("专业", "text", entry.field, "专业名称", function (val) {
-            updateEducation(entry.id, "field", val);
-          });
-          grid.appendChild(fieldGroup);
-
-          // Start date
-          var startGroup = createInputGroup("开始日期", "date", entry.startDate, "", function (val) {
-            updateEducation(entry.id, "startDate", val);
-          });
-          grid.appendChild(startGroup);
-
-          // End date
-          var endGroup = createInputGroup("结束日期", "date", entry.endDate, "", function (val) {
-            updateEducation(entry.id, "endDate", val);
-          });
-          grid.appendChild(endGroup);
-
-          card.appendChild(grid);
-
-          return card;
-        }
-
-        // Update education entry
-        function updateEducation(id, field, value) {
-          for (var i = 0; i < educationList.length; i++) {
-            if (educationList[i].id === id) {
-              educationList[i][field] = value;
-              break;
-            }
-          }
-          saveToStorage();
-        }
-
-        // Add experience entry
-        function addExperience() {
-          var entry = {
-            id: ++idCounter,
-            company: "",
-            position: "",
-            startDate: "",
-            endDate: "",
-            description: ""
-          };
-          experienceList.push(entry);
+      // Remove experience entry
+      function removeExperience(id) {
+        experienceList = experienceList.filter(function (e) {
+          return e.id !== id;
+        });
+        if (experienceList.length === 0) {
+          addExperience();
+        } else {
           renderExperience();
           saveToStorage();
         }
+      }
 
-        // Remove experience entry
-        function removeExperience(id) {
-          experienceList = experienceList.filter(function (e) {
-            return e.id !== id;
-          });
-          if (experienceList.length === 0) {
-            addExperience();
-          } else {
-            renderExperience();
-            saveToStorage();
+      // Render experience entries
+      function renderExperience() {
+        var container = document.getElementById("experienceList");
+        container.textContent = "";
+
+        for (var i = 0; i < experienceList.length; i++) {
+          var entry = experienceList[i];
+          var card = createExperienceCard(entry);
+          container.appendChild(card);
+        }
+      }
+
+      // Create experience card
+      function createExperienceCard(entry) {
+        var card = document.createElement("div");
+        card.className = "entry-card";
+
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove-entry no-print";
+        removeBtn.textContent = "×";
+        removeBtn.title = "删除";
+        removeBtn.addEventListener("click", function () {
+          removeExperience(entry.id);
+        });
+        card.appendChild(removeBtn);
+
+        var grid = document.createElement("div");
+        grid.className = "form-grid";
+
+        // Company
+        var companyGroup = createInputGroup(
+          "公司名称",
+          "text",
+          entry.company,
+          "公司名称",
+          function (val) {
+            updateExperience(entry.id, "company", val);
+          }
+        );
+        grid.appendChild(companyGroup);
+
+        // Position
+        var positionGroup = createInputGroup(
+          "职位",
+          "text",
+          entry.position,
+          "职位名称",
+          function (val) {
+            updateExperience(entry.id, "position", val);
+          }
+        );
+        grid.appendChild(positionGroup);
+
+        // Start date
+        var startGroup = createInputGroup("开始日期", "date", entry.startDate, "", function (val) {
+          updateExperience(entry.id, "startDate", val);
+        });
+        grid.appendChild(startGroup);
+
+        // End date
+        var endGroup = createInputGroup("结束日期", "date", entry.endDate, "", function (val) {
+          updateExperience(entry.id, "endDate", val);
+        });
+        grid.appendChild(endGroup);
+
+        card.appendChild(grid);
+
+        // Description
+        var descGroup = document.createElement("div");
+        descGroup.className = "input-group";
+        var descLabel = document.createElement("label");
+        descLabel.className = "input-label";
+        descLabel.textContent = "工作描述";
+        descGroup.appendChild(descLabel);
+        var descTextarea = document.createElement("textarea");
+        descTextarea.value = entry.description;
+        descTextarea.placeholder = "描述您的主要职责和成就...";
+        descTextarea.addEventListener("change", function () {
+          updateExperience(entry.id, "description", this.value);
+        });
+        descGroup.appendChild(descTextarea);
+        card.appendChild(descGroup);
+
+        return card;
+      }
+
+      // Update experience entry
+      function updateExperience(id, field, value) {
+        for (var i = 0; i < experienceList.length; i++) {
+          if (experienceList[i].id === id) {
+            experienceList[i][field] = value;
+            break;
           }
         }
+        saveToStorage();
+      }
 
-        // Render experience entries
-        function renderExperience() {
-          var container = document.getElementById("experienceList");
-          container.textContent = "";
+      // Create input group helper
+      function createInputGroup(label, type, value, placeholder, onChange) {
+        var group = document.createElement("div");
+        group.className = "input-group";
 
-          for (var i = 0; i < experienceList.length; i++) {
-            var entry = experienceList[i];
-            var card = createExperienceCard(entry);
-            container.appendChild(card);
-          }
+        var labelEl = document.createElement("label");
+        labelEl.className = "input-label";
+        labelEl.textContent = label;
+        group.appendChild(labelEl);
+
+        var input = document.createElement("input");
+        input.type = type;
+        input.value = value;
+        input.placeholder = placeholder;
+        input.addEventListener("change", function () {
+          onChange(this.value);
+        });
+        group.appendChild(input);
+
+        return group;
+      }
+
+      // Add skill
+      function addSkill() {
+        var input = document.getElementById("skillInput");
+        var skill = input.value.trim();
+
+        if (!skill) {
+          showToast("请输入技能名称");
+          return;
         }
 
-        // Create experience card
-        function createExperienceCard(entry) {
-          var card = document.createElement("div");
-          card.className = "entry-card";
+        if (skillsList.indexOf(skill) !== -1) {
+          showToast("该技能已存在");
+          return;
+        }
 
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove-entry no-print";
+        skillsList.push(skill);
+        input.value = "";
+        renderSkills();
+        saveToStorage();
+      }
+
+      // Handle skill input keypress
+      function handleSkillKeypress(event) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          addSkill();
+        }
+      }
+
+      // Remove skill
+      function removeSkill(skill) {
+        skillsList = skillsList.filter(function (s) {
+          return s !== skill;
+        });
+        renderSkills();
+        saveToStorage();
+      }
+
+      // Render skills
+      function renderSkills() {
+        var container = document.getElementById("skillsContainer");
+        container.textContent = "";
+
+        for (var i = 0; i < skillsList.length; i++) {
+          var skill = skillsList[i];
+          var tag = document.createElement("span");
+          tag.className = "skill-tag";
+          tag.textContent = skill;
+
+          var removeBtn = document.createElement("span");
+          removeBtn.className = "remove";
           removeBtn.textContent = "×";
-          removeBtn.title = "删除";
-          removeBtn.addEventListener("click", function () {
-            removeExperience(entry.id);
-          });
-          card.appendChild(removeBtn);
-
-          var grid = document.createElement("div");
-          grid.className = "form-grid";
-
-          // Company
-          var companyGroup = createInputGroup(
-            "公司名称",
-            "text",
-            entry.company,
-            "公司名称",
-            function (val) {
-              updateExperience(entry.id, "company", val);
-            }
+          removeBtn.addEventListener(
+            "click",
+            (function (s) {
+              return function () {
+                removeSkill(s);
+              };
+            })(skill)
           );
-          grid.appendChild(companyGroup);
+          tag.appendChild(removeBtn);
 
-          // Position
-          var positionGroup = createInputGroup(
-            "职位",
-            "text",
-            entry.position,
-            "职位名称",
-            function (val) {
-              updateExperience(entry.id, "position", val);
-            }
-          );
-          grid.appendChild(positionGroup);
-
-          // Start date
-          var startGroup = createInputGroup("开始日期", "date", entry.startDate, "", function (val) {
-            updateExperience(entry.id, "startDate", val);
-          });
-          grid.appendChild(startGroup);
-
-          // End date
-          var endGroup = createInputGroup("结束日期", "date", entry.endDate, "", function (val) {
-            updateExperience(entry.id, "endDate", val);
-          });
-          grid.appendChild(endGroup);
-
-          card.appendChild(grid);
-
-          // Description
-          var descGroup = document.createElement("div");
-          descGroup.className = "input-group";
-          var descLabel = document.createElement("label");
-          descLabel.className = "input-label";
-          descLabel.textContent = "工作描述";
-          descGroup.appendChild(descLabel);
-          var descTextarea = document.createElement("textarea");
-          descTextarea.value = entry.description;
-          descTextarea.placeholder = "描述您的主要职责和成就...";
-          descTextarea.addEventListener("change", function () {
-            updateExperience(entry.id, "description", this.value);
-          });
-          descGroup.appendChild(descTextarea);
-          card.appendChild(descGroup);
-
-          return card;
+          container.appendChild(tag);
         }
+      }
 
-        // Update experience entry
-        function updateExperience(id, field, value) {
-          for (var i = 0; i < experienceList.length; i++) {
-            if (experienceList[i].id === id) {
-              experienceList[i][field] = value;
-              break;
-            }
-          }
-          saveToStorage();
-        }
-
-        // Create input group helper
-        function createInputGroup(label, type, value, placeholder, onChange) {
-          var group = document.createElement("div");
-          group.className = "input-group";
-
-          var labelEl = document.createElement("label");
-          labelEl.className = "input-label";
-          labelEl.textContent = label;
-          group.appendChild(labelEl);
-
-          var input = document.createElement("input");
-          input.type = type;
-          input.value = value;
-          input.placeholder = placeholder;
-          input.addEventListener("change", function () {
-            onChange(this.value);
-          });
-          group.appendChild(input);
-
-          return group;
-        }
-
-        // Add skill
-        function addSkill() {
-          var input = document.getElementById("skillInput");
-          var skill = input.value.trim();
-
-          if (!skill) {
-            showToast("请输入技能名称");
-            return;
-          }
-
-          if (skillsList.indexOf(skill) !== -1) {
-            showToast("该技能已存在");
-            return;
-          }
-
-          skillsList.push(skill);
-          input.value = "";
-          renderSkills();
-          saveToStorage();
-        }
-
-        // Handle skill input keypress
-        function handleSkillKeypress(event) {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            addSkill();
-          }
-        }
-
-        // Remove skill
-        function removeSkill(skill) {
-          skillsList = skillsList.filter(function (s) {
-            return s !== skill;
-          });
-          renderSkills();
-          saveToStorage();
-        }
-
-        // Render skills
-        function renderSkills() {
-          var container = document.getElementById("skillsContainer");
-          container.textContent = "";
-
-          for (var i = 0; i < skillsList.length; i++) {
-            var skill = skillsList[i];
-            var tag = document.createElement("span");
-            tag.className = "skill-tag";
-            tag.textContent = skill;
-
-            var removeBtn = document.createElement("span");
-            removeBtn.className = "remove";
-            removeBtn.textContent = "×";
-            removeBtn.addEventListener(
-              "click",
-              (function (s) {
-                return function () {
-                  removeSkill(s);
-                };
-              })(skill)
-            );
-            tag.appendChild(removeBtn);
-
-            container.appendChild(tag);
-          }
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
             clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
+            func.apply(context, args);
           };
-        }
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
 
-        // Print resume
-        function printResume() {
-          var name = document.getElementById("fullName").value || "姓名";
-          var contact = [];
-          var email = document.getElementById("email").value;
-          var phone = document.getElementById("phone").value;
-          var location = document.getElementById("location").value;
+      // Print resume
+      function printResume() {
+        var name = document.getElementById("fullName").value || "姓名";
+        var contact = [];
+        var email = document.getElementById("email").value;
+        var phone = document.getElementById("phone").value;
+        var location = document.getElementById("location").value;
 
-          if (email) contact.push(email);
-          if (phone) contact.push(phone);
-          if (location) contact.push(location);
+        if (email) contact.push(email);
+        if (phone) contact.push(phone);
+        if (location) contact.push(location);
 
-          document.getElementById("printName").textContent = name;
-          document.getElementById("printContact").textContent = contact.join(" | ");
+        document.getElementById("printName").textContent = name;
+        document.getElementById("printContact").textContent = contact.join(" | ");
 
-          window.print();
-        }
+        window.print();
+      }
 
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
 
-          document.getElementById("fullName").value = "";
-          document.getElementById("jobTitle").value = "";
-          document.getElementById("email").value = "";
-          document.getElementById("phone").value = "";
-          document.getElementById("location").value = "";
-          document.getElementById("website").value = "";
-          document.getElementById("summary").value = "";
+        document.getElementById("fullName").value = "";
+        document.getElementById("jobTitle").value = "";
+        document.getElementById("email").value = "";
+        document.getElementById("phone").value = "";
+        document.getElementById("location").value = "";
+        document.getElementById("website").value = "";
+        document.getElementById("summary").value = "";
 
-          educationList = [];
-          experienceList = [];
-          skillsList = [];
-          idCounter = 0;
+        educationList = [];
+        experienceList = [];
+        skillsList = [];
+        idCounter = 0;
 
-          addEducation();
-          addExperience();
-          renderSkills();
+        addEducation();
+        addExperience();
+        renderSkills();
 
-          localStorage.removeItem(LS_KEY);
+        localStorage.removeItem(LS_KEY);
 
-          showToast("已清空");
-        }
+        showToast("已清空");
+      }
 
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            fullName: document.getElementById("fullName").value,
-            jobTitle: document.getElementById("jobTitle").value,
-            email: document.getElementById("email").value,
-            phone: document.getElementById("phone").value,
-            location: document.getElementById("location").value,
-            website: document.getElementById("website").value,
-            summary: document.getElementById("summary").value,
-            educationList: educationList,
-            experienceList: experienceList,
-            skillsList: skillsList,
-            idCounter: idCounter
-          };
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          fullName: document.getElementById("fullName").value,
+          jobTitle: document.getElementById("jobTitle").value,
+          email: document.getElementById("email").value,
+          phone: document.getElementById("phone").value,
+          location: document.getElementById("location").value,
+          website: document.getElementById("website").value,
+          summary: document.getElementById("summary").value,
+          educationList: educationList,
+          experienceList: experienceList,
+          skillsList: skillsList,
+          idCounter: idCounter
+        };
 
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
 
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
 
-          try {
-            var data = JSON.parse(saved);
+        try {
+          var data = JSON.parse(saved);
 
-            document.getElementById("fullName").value = data.fullName || "";
-            document.getElementById("jobTitle").value = data.jobTitle || "";
-            document.getElementById("email").value = data.email || "";
-            document.getElementById("phone").value = data.phone || "";
-            document.getElementById("location").value = data.location || "";
-            document.getElementById("website").value = data.website || "";
-            document.getElementById("summary").value = data.summary || "";
+          document.getElementById("fullName").value = data.fullName || "";
+          document.getElementById("jobTitle").value = data.jobTitle || "";
+          document.getElementById("email").value = data.email || "";
+          document.getElementById("phone").value = data.phone || "";
+          document.getElementById("location").value = data.location || "";
+          document.getElementById("website").value = data.website || "";
+          document.getElementById("summary").value = data.summary || "";
 
-            if (data.educationList && data.educationList.length > 0) {
-              educationList = data.educationList;
-            }
-
-            if (data.experienceList && data.experienceList.length > 0) {
-              experienceList = data.experienceList;
-            }
-
-            if (data.skillsList) {
-              skillsList = data.skillsList;
-            }
-
-            idCounter = data.idCounter || 0;
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
+          if (data.educationList && data.educationList.length > 0) {
+            educationList = data.educationList;
           }
-        }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
+          if (data.experienceList && data.experienceList.length > 0) {
+            experienceList = data.experienceList;
           }
-        }
 
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+          if (data.skillsList) {
+            skillsList = data.skillsList;
+          }
 
-        // Initialize on load
-        init();
-</script>
-    
+          idCounter = data.idCounter || 0;
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
+        }
+      }
+
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      }
+
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Initialize on load
+      init();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/seating-chart.html
+++ b/tools/office/seating-chart.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Seating Chart - WebUtils" />
-    <meta property="og:description" content="Seating Chart，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Seating Chart，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/seating-chart.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/seating-chart.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Seating Chart - WebUtils" />
-    <meta name="twitter:description" content="Seating Chart，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Seating Chart，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Seating Chart",
-      "item": "https://tools.realtime-ai.chat/tools/office/seating-chart.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Seating Chart",
+            "item": "https://tools.realtime-ai.chat/tools/office/seating-chart.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Seating Chart - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Seating Chart - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1114 +97,1125 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  select {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
-
-  /* Seating Grid */
-  .seating-canvas {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 24px;
-    min-height: 400px;
-    overflow: auto;
-  }
-
-  .tables-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 32px;
-    justify-content: center;
-  }
-
-  .table-group {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .table-label {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    margin-bottom: 12px;
-    padding: 4px 12px;
-    background: rgba(0, 245, 212, 0.1);
-    border-radius: var(--radius-sm);
-  }
-
-  .table-shape {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-  }
-
-  /* Round table */
-  .table-round {
-    width: 200px;
-    height: 200px;
-    border-radius: 50%;
-    background: var(--border-strong);
-    position: relative;
-  }
-
-  .table-round .seat {
-    position: absolute;
-    width: 50px;
-    height: 50px;
-    transform: translate(-50%, -50%);
-  }
-
-  /* Rectangle table */
-  .table-rect {
-    display: grid;
-    gap: 8px;
-    padding: 16px;
-  }
-
-  .table-rect-body {
-    background: var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 16px;
-    min-width: 120px;
-    min-height: 60px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .table-seats-row {
-    display: flex;
-    gap: 8px;
-    justify-content: center;
-  }
-
-  /* Seat styles */
-  .seat {
-    width: 60px;
-    height: 60px;
-    background: var(--color-bg-card);
-    border: 2px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.2s;
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    text-align: center;
-    padding: 4px;
-  }
-
-  .seat:hover {
-    border-color: var(--color-accent-cyan);
-    transform: scale(1.05);
-  }
-
-  .seat.occupied {
-    background: rgba(0, 245, 212, 0.1);
-    border-color: var(--color-accent-cyan);
-  }
-
-  .seat-number {
-    font-size: 0.65rem;
-    color: var(--color-text-muted);
-  }
-
-  .seat-name {
-    font-size: 0.75rem;
-    color: var(--color-text-primary);
-    word-break: break-all;
-    line-height: 1.2;
-  }
-
-  .btn-remove-table {
-    margin-top: 8px;
-    background: transparent;
-    border: 1px solid var(--accent-red);
-    color: var(--accent-red);
-    cursor: pointer;
-    font-size: 0.75rem;
-    padding: 4px 8px;
-    border-radius: var(--radius-sm);
-    transition: all 0.2s;
-    font-family: var(--font-mono);
-  }
-
-  .btn-remove-table:hover {
-    background: rgba(244, 63, 94, 0.1);
-  }
-
-  /* Stats */
-  .stats-row {
-    display: flex;
-    gap: 24px;
-    flex-wrap: wrap;
-    margin-bottom: 16px;
-  }
-
-  .stat-item {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  .stat-item span {
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  /* Modal */
-  .modal-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.7);
-    z-index: 200;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .modal-overlay.show {
-    display: flex;
-  }
-
-  .modal {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    max-width: 400px;
-    width: 90%;
-  }
-
-  .modal-title {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 16px;
-  }
-
-  .modal .btn-row {
-    margin-top: 16px;
-  }
-
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
-
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .btn-remove-table,
-    .no-print,
-    .modal-overlay {
-      display: none !important;
-    }
-
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
-
-    .tool-section {
-      page-break-inside: avoid;
-    }
-
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
-
-    .seating-canvas {
-      background: #fff;
-      border: 1px solid #ddd;
-    }
-
-    .table-label {
-      background: #f0f0f0;
-      color: #333;
-    }
-
-    .table-round,
-    .table-rect-body {
-      background: #e0e0e0;
-    }
-
-    .seat {
-      background: #fff;
-      border-color: #ccc;
-    }
-
-    .seat.occupied {
-      background: #e8f5e9;
-      border-color: #4caf50;
-    }
-
-    .seat-number,
-    .seat-name {
-      color: #333;
-    }
-
-    .chart-header-print {
-      display: block !important;
-      text-align: center;
-      margin-bottom: 24px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
-
-    .print-title {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: #000;
-    }
-
-    .print-event {
-      font-size: 1rem;
-      color: #666;
-      margin-top: 8px;
-    }
-  }
-
-  .chart-header-print {
-    display: none;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
+
+      /* Seating Grid */
+      .seating-canvas {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 24px;
+        min-height: 400px;
+        overflow: auto;
+      }
+
+      .tables-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 32px;
+        justify-content: center;
+      }
+
+      .table-group {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .table-label {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        margin-bottom: 12px;
+        padding: 4px 12px;
+        background: rgba(0, 245, 212, 0.1);
+        border-radius: var(--radius-sm);
+      }
+
+      .table-shape {
+        position: relative;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+      }
+
+      /* Round table */
+      .table-round {
+        width: 200px;
+        height: 200px;
+        border-radius: 50%;
+        background: var(--border-strong);
+        position: relative;
+      }
+
+      .table-round .seat {
+        position: absolute;
+        width: 50px;
+        height: 50px;
+        transform: translate(-50%, -50%);
+      }
+
+      /* Rectangle table */
+      .table-rect {
+        display: grid;
+        gap: 8px;
+        padding: 16px;
+      }
+
+      .table-rect-body {
+        background: var(--border-strong);
+        border-radius: var(--radius-sm);
+        padding: 16px;
+        min-width: 120px;
+        min-height: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .table-seats-row {
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+      }
+
+      /* Seat styles */
+      .seat {
+        width: 60px;
+        height: 60px;
+        background: var(--color-bg-card);
+        border: 2px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: all 0.2s;
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        text-align: center;
+        padding: 4px;
+      }
+
+      .seat:hover {
+        border-color: var(--color-accent-cyan);
+        transform: scale(1.05);
+      }
+
+      .seat.occupied {
+        background: rgba(0, 245, 212, 0.1);
+        border-color: var(--color-accent-cyan);
+      }
+
+      .seat-number {
+        font-size: 0.65rem;
+        color: var(--color-text-muted);
+      }
+
+      .seat-name {
+        font-size: 0.75rem;
+        color: var(--color-text-primary);
+        word-break: break-all;
+        line-height: 1.2;
+      }
+
+      .btn-remove-table {
+        margin-top: 8px;
+        background: transparent;
+        border: 1px solid var(--accent-red);
+        color: var(--accent-red);
+        cursor: pointer;
+        font-size: 0.75rem;
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        transition: all 0.2s;
+        font-family: var(--font-mono);
+      }
+
+      .btn-remove-table:hover {
+        background: rgba(244, 63, 94, 0.1);
+      }
+
+      /* Stats */
+      .stats-row {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        margin-bottom: 16px;
+      }
+
+      .stat-item {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .stat-item span {
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      /* Modal */
+      .modal-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+        z-index: 200;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .modal-overlay.show {
+        display: flex;
+      }
+
+      .modal {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        max-width: 400px;
+        width: 90%;
+      }
+
+      .modal-title {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        font-weight: 600;
+        margin-bottom: 16px;
+      }
+
+      .modal .btn-row {
+        margin-top: 16px;
+      }
+
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
+
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .btn-remove-table,
+        .no-print,
+        .modal-overlay {
+          display: none !important;
+        }
+
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
+
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
+
+        .tool-section {
+          page-break-inside: avoid;
+        }
+
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
+
+        .seating-canvas {
+          background: #fff;
+          border: 1px solid #ddd;
+        }
+
+        .table-label {
+          background: #f0f0f0;
+          color: #333;
+        }
+
+        .table-round,
+        .table-rect-body {
+          background: #e0e0e0;
+        }
+
+        .seat {
+          background: #fff;
+          border-color: #ccc;
+        }
+
+        .seat.occupied {
+          background: #e8f5e9;
+          border-color: #4caf50;
+        }
+
+        .seat-number,
+        .seat-name {
+          color: #333;
+        }
+
+        .chart-header-print {
+          display: block !important;
+          text-align: center;
+          margin-bottom: 24px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
+
+        .print-title {
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: #000;
+        }
+
+        .print-event {
+          font-size: 1rem;
+          color: #666;
+          margin-top: 8px;
+        }
+      }
+
+      .chart-header-print {
+        display: none;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">座位图生成器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">💺</span>
-        座位图生成器
-      </h1>
-      <p>创建座位安排图，支持多种桌型、分配座位、可视化布局</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">座位图生成器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">💺</span>
+              座位图生成器
+            </h1>
+            <p>创建座位安排图，支持多种桌型、分配座位、可视化布局</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Print Header -->
-    <div class="chart-header-print">
-      <div class="print-title">座位安排图</div>
-      <div class="print-event" id="printEventName"></div>
-    </div>
+        <main class="main-content">
+          <!-- Print Header -->
+          <div class="chart-header-print">
+            <div class="print-title">座位安排图</div>
+            <div class="print-event" id="printEventName"></div>
+          </div>
 
-    <!-- Event Info -->
-    <div class="tool-section no-print">
-      <div class="section-title">活动信息</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">活动名称</label>
-          <input type="text" id="eventName" placeholder="会议/活动名称">
-        </div>
-      </div>
-    </div>
+          <!-- Event Info -->
+          <div class="tool-section no-print">
+            <div class="section-title">活动信息</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">活动名称</label>
+                <input type="text" id="eventName" placeholder="会议/活动名称" />
+              </div>
+            </div>
+          </div>
 
-    <!-- Add Table -->
-    <div class="tool-section no-print">
-      <div class="section-title">添加桌子</div>
-      <div class="form-grid">
-        <div class="input-group">
-          <label class="input-label">桌子名称</label>
-          <input type="text" id="tableName" placeholder="如: A桌, 主桌">
-        </div>
-        <div class="input-group">
-          <label class="input-label">桌型</label>
-          <select id="tableType">
-            <option value="round">圆桌</option>
-            <option value="rect">长桌</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">座位数</label>
-          <input type="number" id="seatCount" value="8" min="2" max="20">
-        </div>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-secondary btn-sm" onclick="addTable()">+ 添加桌子</button>
-      </div>
-    </div>
+          <!-- Add Table -->
+          <div class="tool-section no-print">
+            <div class="section-title">添加桌子</div>
+            <div class="form-grid">
+              <div class="input-group">
+                <label class="input-label">桌子名称</label>
+                <input type="text" id="tableName" placeholder="如: A桌, 主桌" />
+              </div>
+              <div class="input-group">
+                <label class="input-label">桌型</label>
+                <select id="tableType">
+                  <option value="round">圆桌</option>
+                  <option value="rect">长桌</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">座位数</label>
+                <input type="number" id="seatCount" value="8" min="2" max="20" />
+              </div>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-secondary btn-sm" onclick="addTable()">+ 添加桌子</button>
+            </div>
+          </div>
 
-    <!-- Stats -->
-    <div class="tool-section">
-      <div class="stats-row">
-        <div class="stat-item">
-          桌子数:
-          <span id="tableCount">0</span>
-        </div>
-        <div class="stat-item">
-          总座位:
-          <span id="totalSeats">0</span>
-        </div>
-        <div class="stat-item">
-          已分配:
-          <span id="assignedSeats">0</span>
-        </div>
-      </div>
-    </div>
+          <!-- Stats -->
+          <div class="tool-section">
+            <div class="stats-row">
+              <div class="stat-item">
+                桌子数:
+                <span id="tableCount">0</span>
+              </div>
+              <div class="stat-item">
+                总座位:
+                <span id="totalSeats">0</span>
+              </div>
+              <div class="stat-item">
+                已分配:
+                <span id="assignedSeats">0</span>
+              </div>
+            </div>
+          </div>
 
-    <!-- Seating Canvas -->
-    <div class="tool-section">
-      <div class="section-title">座位布局</div>
-      <div class="seating-canvas">
-        <div class="tables-container" id="tablesContainer">
-          <!-- Tables will be rendered here -->
-          <div style="text-align: center; color: var(--color-text-muted); padding: 60px 0">
-            点击"添加桌子"开始创建座位图
+          <!-- Seating Canvas -->
+          <div class="tool-section">
+            <div class="section-title">座位布局</div>
+            <div class="seating-canvas">
+              <div class="tables-container" id="tablesContainer">
+                <!-- Tables will be rendered here -->
+                <div style="text-align: center; color: var(--color-text-muted); padding: 60px 0">
+                  点击"添加桌子"开始创建座位图
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printChart()">🖨️ 打印座位图</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
+
+        <div
+          class="modal"
+          id="seatModal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="seatModalTitle"
+        >
+          <div class="modal-content">
+            <div class="modal-title" id="seatModalTitle">分配座位</div>
+            <div class="input-group">
+              <label class="input-label" for="seatPersonName">姓名</label>
+              <input type="text" id="seatPersonName" placeholder="输入姓名" />
+            </div>
+            <div class="btn-row">
+              <button type="button" class="btn btn-secondary" onclick="closeModal()">取消</button>
+              <button type="button" class="btn btn-secondary" onclick="clearSeat()">
+                清空座位
+              </button>
+              <button type="button" class="btn btn-primary" onclick="assignSeat()">保存</button>
+            </div>
           </div>
         </div>
+
+        <div class="toast" id="toast" role="status" aria-live="polite"></div>
       </div>
     </div>
 
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printChart()">🖨️ 打印座位图</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-
-  <div class="modal" id="seatModal" role="dialog" aria-modal="true" aria-labelledby="seatModalTitle">
-    <div class="modal-content">
-      <div class="modal-title" id="seatModalTitle">分配座位</div>
-      <div class="input-group">
-        <label class="input-label" for="seatPersonName">姓名</label>
-        <input type="text" id="seatPersonName" placeholder="输入姓名">
-      </div>
-      <div class="btn-row">
-        <button type="button" class="btn btn-secondary" onclick="closeModal()">取消</button>
-        <button type="button" class="btn btn-secondary" onclick="clearSeat()">清空座位</button>
-        <button type="button" class="btn btn-primary" onclick="assignSeat()">保存</button>
-      </div>
-    </div>
-  </div>
-
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "座位图生成器",
-              "item": "https://tools.realtime-ai.chat/tools/office/seating-chart.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "座位图生成器",
+            "item": "https://tools.realtime-ai.chat/tools/office/seating-chart.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "seating_chart_data_v1";
+      var tables = [];
+      var tableIdCounter = 0;
+      var currentSeat = null;
 
-  var LS_KEY = "seating_chart_data_v1";
-        var tables = [];
-        var tableIdCounter = 0;
-        var currentSeat = null;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
+        renderTables();
+        updateStats();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-          renderTables();
-          updateStats();
+        // Add input listeners for auto-save
+        document
+          .getElementById("eventName")
+          .addEventListener("input", debounce(saveToStorage, 500));
+      }
 
-          // Add input listeners for auto-save
-          document
-            .getElementById("eventName")
-            .addEventListener("input", debounce(saveToStorage, 500));
+      // Add table
+      function addTable() {
+        var name = document.getElementById("tableName").value.trim();
+        var type = document.getElementById("tableType").value;
+        var seatCount = parseInt(document.getElementById("seatCount").value) || 8;
+
+        if (!name) {
+          name = "桌 " + (tables.length + 1);
         }
 
-        // Add table
-        function addTable() {
-          var name = document.getElementById("tableName").value.trim();
-          var type = document.getElementById("tableType").value;
-          var seatCount = parseInt(document.getElementById("seatCount").value) || 8;
+        if (seatCount < 2) seatCount = 2;
+        if (seatCount > 20) seatCount = 20;
 
-          if (!name) {
-            name = "桌 " + (tables.length + 1);
-          }
-
-          if (seatCount < 2) seatCount = 2;
-          if (seatCount > 20) seatCount = 20;
-
-          var seats = [];
-          for (var i = 0; i < seatCount; i++) {
-            seats.push({
-              number: i + 1,
-              name: ""
-            });
-          }
-
-          tables.push({
-            id: ++tableIdCounter,
-            name: name,
-            type: type,
-            seats: seats
+        var seats = [];
+        for (var i = 0; i < seatCount; i++) {
+          seats.push({
+            number: i + 1,
+            name: ""
           });
-
-          // Reset inputs
-          document.getElementById("tableName").value = "";
-          document.getElementById("seatCount").value = "8";
-
-          renderTables();
-          updateStats();
-          saveToStorage();
-          showToast("已添加 " + name);
         }
 
-        // Remove table
-        function removeTable(id) {
-          if (!confirm("确定要删除这张桌子吗？")) return;
-
-          tables = tables.filter(function (t) {
-            return t.id !== id;
-          });
-          renderTables();
-          updateStats();
-          saveToStorage();
-          showToast("已删除");
-        }
-
-        // Render tables
-        function renderTables() {
-          var container = document.getElementById("tablesContainer");
-          container.textContent = "";
-
-          if (tables.length === 0) {
-            var placeholder = document.createElement("div");
-            placeholder.style.textAlign = "center";
-            placeholder.style.color = "var(--color-text-muted)";
-            placeholder.style.padding = "60px 0";
-            placeholder.textContent = '点击"添加桌子"开始创建座位图';
-            container.appendChild(placeholder);
-            return;
-          }
-
-          for (var i = 0; i < tables.length; i++) {
-            var tableEl = createTableElement(tables[i]);
-            container.appendChild(tableEl);
-          }
-        }
-
-        // Create table element
-        function createTableElement(table) {
-          var group = document.createElement("div");
-          group.className = "table-group";
-
-          var label = document.createElement("div");
-          label.className = "table-label";
-          label.textContent = table.name;
-          group.appendChild(label);
-
-          var shape = document.createElement("div");
-          shape.className = "table-shape";
-
-          if (table.type === "round") {
-            shape.appendChild(createRoundTable(table));
-          } else {
-            shape.appendChild(createRectTable(table));
-          }
-
-          group.appendChild(shape);
-
-          // Remove button
-          var removeBtn = document.createElement("button");
-          removeBtn.className = "btn-remove-table no-print";
-          removeBtn.textContent = "删除桌子";
-          removeBtn.addEventListener("click", function () {
-            removeTable(table.id);
-          });
-          group.appendChild(removeBtn);
-
-          return group;
-        }
-
-        // Create round table
-        function createRoundTable(table) {
-          var tableEl = document.createElement("div");
-          tableEl.className = "table-round";
-
-          var seatCount = table.seats.length;
-          var radius = 100; // px from center
-          var angleStep = (2 * Math.PI) / seatCount;
-
-          for (var i = 0; i < seatCount; i++) {
-            var angle = angleStep * i - Math.PI / 2; // Start from top
-            var x = 100 + radius * Math.cos(angle);
-            var y = 100 + radius * Math.sin(angle);
-
-            var seat = createSeatElement(table, i);
-            seat.style.left = x + "px";
-            seat.style.top = y + "px";
-            tableEl.appendChild(seat);
-          }
-
-          return tableEl;
-        }
-
-        // Create rectangle table
-        function createRectTable(table) {
-          var wrapper = document.createElement("div");
-          wrapper.className = "table-rect";
-
-          var seatCount = table.seats.length;
-          var seatsPerSide = Math.ceil(seatCount / 2);
-
-          // Top row
-          var topRow = document.createElement("div");
-          topRow.className = "table-seats-row";
-          for (var i = 0; i < seatsPerSide && i < seatCount; i++) {
-            topRow.appendChild(createSeatElement(table, i));
-          }
-          wrapper.appendChild(topRow);
-
-          // Table body
-          var body = document.createElement("div");
-          body.className = "table-rect-body";
-          wrapper.appendChild(body);
-
-          // Bottom row
-          var bottomRow = document.createElement("div");
-          bottomRow.className = "table-seats-row";
-          for (var i = seatsPerSide; i < seatCount; i++) {
-            bottomRow.appendChild(createSeatElement(table, i));
-          }
-          wrapper.appendChild(bottomRow);
-
-          return wrapper;
-        }
-
-        // Create seat element
-        function createSeatElement(table, seatIndex) {
-          var seatData = table.seats[seatIndex];
-          var seat = document.createElement("div");
-          seat.className = "seat" + (seatData.name ? " occupied" : "");
-
-          var number = document.createElement("div");
-          number.className = "seat-number";
-          number.textContent = seatData.number;
-          seat.appendChild(number);
-
-          var name = document.createElement("div");
-          name.className = "seat-name";
-          name.textContent = seatData.name || "空";
-          seat.appendChild(name);
-
-          seat.addEventListener("click", function () {
-            openSeatModal(table.id, seatIndex);
-          });
-
-          return seat;
-        }
-
-        // Open seat modal
-        function openSeatModal(tableId, seatIndex) {
-          currentSeat = { tableId: tableId, seatIndex: seatIndex };
-
-          // Find current name
-          var table = tables.find(function (t) {
-            return t.id === tableId;
-          });
-          var currentName = table.seats[seatIndex].name;
-
-          document.getElementById("seatPersonName").value = currentName;
-          document.getElementById("seatModal").classList.add("show");
-          document.getElementById("seatPersonName").focus();
-        }
-
-        // Close modal
-        function closeModal() {
-          document.getElementById("seatModal").classList.remove("show");
-          currentSeat = null;
-        }
-
-        // Assign seat
-        function assignSeat() {
-          if (!currentSeat) return;
-
-          var name = document.getElementById("seatPersonName").value.trim();
-          var table = tables.find(function (t) {
-            return t.id === currentSeat.tableId;
-          });
-
-          if (table) {
-            table.seats[currentSeat.seatIndex].name = name;
-            renderTables();
-            updateStats();
-            saveToStorage();
-          }
-
-          closeModal();
-        }
-
-        // Clear seat
-        function clearSeat() {
-          document.getElementById("seatPersonName").value = "";
-          assignSeat();
-        }
-
-        // Update stats
-        function updateStats() {
-          var totalSeats = 0;
-          var assignedSeats = 0;
-
-          for (var i = 0; i < tables.length; i++) {
-            var seats = tables[i].seats;
-            totalSeats += seats.length;
-            for (var j = 0; j < seats.length; j++) {
-              if (seats[j].name) assignedSeats++;
-            }
-          }
-
-          document.getElementById("tableCount").textContent = tables.length;
-          document.getElementById("totalSeats").textContent = totalSeats;
-          document.getElementById("assignedSeats").textContent = assignedSeats;
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-          };
-        }
-
-        // Print chart
-        function printChart() {
-          var eventName = document.getElementById("eventName").value || "座位安排";
-          document.getElementById("printEventName").textContent = eventName;
-          window.print();
-        }
-
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
-
-          document.getElementById("eventName").value = "";
-          tables = [];
-          tableIdCounter = 0;
-
-          renderTables();
-          updateStats();
-
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
-        }
-
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            eventName: document.getElementById("eventName").value,
-            tables: tables,
-            tableIdCounter: tableIdCounter
-          };
-
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
-
-          try {
-            var data = JSON.parse(saved);
-
-            document.getElementById("eventName").value = data.eventName || "";
-            tables = data.tables || [];
-            tableIdCounter = data.tableIdCounter || 0;
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
-          }
-        }
-
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        }
-
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // Handle Enter key in modal
-        document.getElementById("seatPersonName").addEventListener("keypress", function (e) {
-          if (e.key === "Enter") {
-            assignSeat();
-          }
+        tables.push({
+          id: ++tableIdCounter,
+          name: name,
+          type: type,
+          seats: seats
         });
 
-        // Initialize on load
-        init();
-</script>
-    
+        // Reset inputs
+        document.getElementById("tableName").value = "";
+        document.getElementById("seatCount").value = "8";
+
+        renderTables();
+        updateStats();
+        saveToStorage();
+        showToast("已添加 " + name);
+      }
+
+      // Remove table
+      function removeTable(id) {
+        if (!confirm("确定要删除这张桌子吗？")) return;
+
+        tables = tables.filter(function (t) {
+          return t.id !== id;
+        });
+        renderTables();
+        updateStats();
+        saveToStorage();
+        showToast("已删除");
+      }
+
+      // Render tables
+      function renderTables() {
+        var container = document.getElementById("tablesContainer");
+        container.textContent = "";
+
+        if (tables.length === 0) {
+          var placeholder = document.createElement("div");
+          placeholder.style.textAlign = "center";
+          placeholder.style.color = "var(--color-text-muted)";
+          placeholder.style.padding = "60px 0";
+          placeholder.textContent = '点击"添加桌子"开始创建座位图';
+          container.appendChild(placeholder);
+          return;
+        }
+
+        for (var i = 0; i < tables.length; i++) {
+          var tableEl = createTableElement(tables[i]);
+          container.appendChild(tableEl);
+        }
+      }
+
+      // Create table element
+      function createTableElement(table) {
+        var group = document.createElement("div");
+        group.className = "table-group";
+
+        var label = document.createElement("div");
+        label.className = "table-label";
+        label.textContent = table.name;
+        group.appendChild(label);
+
+        var shape = document.createElement("div");
+        shape.className = "table-shape";
+
+        if (table.type === "round") {
+          shape.appendChild(createRoundTable(table));
+        } else {
+          shape.appendChild(createRectTable(table));
+        }
+
+        group.appendChild(shape);
+
+        // Remove button
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "btn-remove-table no-print";
+        removeBtn.textContent = "删除桌子";
+        removeBtn.addEventListener("click", function () {
+          removeTable(table.id);
+        });
+        group.appendChild(removeBtn);
+
+        return group;
+      }
+
+      // Create round table
+      function createRoundTable(table) {
+        var tableEl = document.createElement("div");
+        tableEl.className = "table-round";
+
+        var seatCount = table.seats.length;
+        var radius = 100; // px from center
+        var angleStep = (2 * Math.PI) / seatCount;
+
+        for (var i = 0; i < seatCount; i++) {
+          var angle = angleStep * i - Math.PI / 2; // Start from top
+          var x = 100 + radius * Math.cos(angle);
+          var y = 100 + radius * Math.sin(angle);
+
+          var seat = createSeatElement(table, i);
+          seat.style.left = x + "px";
+          seat.style.top = y + "px";
+          tableEl.appendChild(seat);
+        }
+
+        return tableEl;
+      }
+
+      // Create rectangle table
+      function createRectTable(table) {
+        var wrapper = document.createElement("div");
+        wrapper.className = "table-rect";
+
+        var seatCount = table.seats.length;
+        var seatsPerSide = Math.ceil(seatCount / 2);
+
+        // Top row
+        var topRow = document.createElement("div");
+        topRow.className = "table-seats-row";
+        for (var i = 0; i < seatsPerSide && i < seatCount; i++) {
+          topRow.appendChild(createSeatElement(table, i));
+        }
+        wrapper.appendChild(topRow);
+
+        // Table body
+        var body = document.createElement("div");
+        body.className = "table-rect-body";
+        wrapper.appendChild(body);
+
+        // Bottom row
+        var bottomRow = document.createElement("div");
+        bottomRow.className = "table-seats-row";
+        for (var i = seatsPerSide; i < seatCount; i++) {
+          bottomRow.appendChild(createSeatElement(table, i));
+        }
+        wrapper.appendChild(bottomRow);
+
+        return wrapper;
+      }
+
+      // Create seat element
+      function createSeatElement(table, seatIndex) {
+        var seatData = table.seats[seatIndex];
+        var seat = document.createElement("div");
+        seat.className = "seat" + (seatData.name ? " occupied" : "");
+
+        var number = document.createElement("div");
+        number.className = "seat-number";
+        number.textContent = seatData.number;
+        seat.appendChild(number);
+
+        var name = document.createElement("div");
+        name.className = "seat-name";
+        name.textContent = seatData.name || "空";
+        seat.appendChild(name);
+
+        seat.addEventListener("click", function () {
+          openSeatModal(table.id, seatIndex);
+        });
+
+        return seat;
+      }
+
+      // Open seat modal
+      function openSeatModal(tableId, seatIndex) {
+        currentSeat = { tableId: tableId, seatIndex: seatIndex };
+
+        // Find current name
+        var table = tables.find(function (t) {
+          return t.id === tableId;
+        });
+        var currentName = table.seats[seatIndex].name;
+
+        document.getElementById("seatPersonName").value = currentName;
+        document.getElementById("seatModal").classList.add("show");
+        document.getElementById("seatPersonName").focus();
+      }
+
+      // Close modal
+      function closeModal() {
+        document.getElementById("seatModal").classList.remove("show");
+        currentSeat = null;
+      }
+
+      // Assign seat
+      function assignSeat() {
+        if (!currentSeat) return;
+
+        var name = document.getElementById("seatPersonName").value.trim();
+        var table = tables.find(function (t) {
+          return t.id === currentSeat.tableId;
+        });
+
+        if (table) {
+          table.seats[currentSeat.seatIndex].name = name;
+          renderTables();
+          updateStats();
+          saveToStorage();
+        }
+
+        closeModal();
+      }
+
+      // Clear seat
+      function clearSeat() {
+        document.getElementById("seatPersonName").value = "";
+        assignSeat();
+      }
+
+      // Update stats
+      function updateStats() {
+        var totalSeats = 0;
+        var assignedSeats = 0;
+
+        for (var i = 0; i < tables.length; i++) {
+          var seats = tables[i].seats;
+          totalSeats += seats.length;
+          for (var j = 0; j < seats.length; j++) {
+            if (seats[j].name) assignedSeats++;
+          }
+        }
+
+        document.getElementById("tableCount").textContent = tables.length;
+        document.getElementById("totalSeats").textContent = totalSeats;
+        document.getElementById("assignedSeats").textContent = assignedSeats;
+      }
+
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
+            clearTimeout(timeout);
+            func.apply(context, args);
+          };
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
+
+      // Print chart
+      function printChart() {
+        var eventName = document.getElementById("eventName").value || "座位安排";
+        document.getElementById("printEventName").textContent = eventName;
+        window.print();
+      }
+
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
+
+        document.getElementById("eventName").value = "";
+        tables = [];
+        tableIdCounter = 0;
+
+        renderTables();
+        updateStats();
+
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          eventName: document.getElementById("eventName").value,
+          tables: tables,
+          tableIdCounter: tableIdCounter
+        };
+
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          document.getElementById("eventName").value = data.eventName || "";
+          tables = data.tables || [];
+          tableIdCounter = data.tableIdCounter || 0;
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
+        }
+      }
+
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      }
+
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Handle Enter key in modal
+      document.getElementById("seatPersonName").addEventListener("keypress", function (e) {
+        if (e.key === "Enter") {
+          assignSeat();
+        }
+      });
+
+      // Initialize on load
+      init();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/slide-notes.html
+++ b/tools/office/slide-notes.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Slide Notes - WebUtils" />
-    <meta property="og:description" content="Slide Notes，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Slide Notes，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/slide-notes.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/slide-notes.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Slide Notes - WebUtils" />
-    <meta name="twitter:description" content="Slide Notes，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Slide Notes，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Slide Notes",
-      "item": "https://tools.realtime-ai.chat/tools/office/slide-notes.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Slide Notes",
+            "item": "https://tools.realtime-ai.chat/tools/office/slide-notes.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Slide Notes - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Slide Notes - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1143 +97,1148 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  select,
-  textarea {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus,
-  textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  textarea {
-    min-height: 150px;
-    resize: vertical;
-    line-height: 1.8;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 100px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-sm {
-    min-width: auto;
-    padding: 8px 12px;
-    font-size: 0.8rem;
-    flex: none;
-  }
-
-  /* Timer Section */
-  .timer-section {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: 24px;
-  }
-
-  .timer-display {
-    font-family: var(--font-mono);
-    font-size: 2.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    min-width: 180px;
-    text-align: center;
-  }
-
-  .timer-controls {
-    display: flex;
-    gap: 8px;
-  }
-
-  .timer-btn {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
-  }
-
-  .timer-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .timer-btn.active {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-    border-color: var(--color-accent-cyan);
-  }
-
-  /* Slide Navigation */
-  .slide-nav {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: 16px;
-  }
-
-  .nav-btn {
-    width: 48px;
-    height: 48px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    font-size: 1.2rem;
-    transition: all 0.2s;
-  }
-
-  .nav-btn:hover:not(:disabled) {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .nav-btn:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
-  }
-
-  .slide-indicator {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    color: var(--color-text-secondary);
-    min-width: 100px;
-    text-align: center;
-  }
-
-  .slide-indicator span {
-    color: var(--color-accent-cyan);
-    font-weight: 600;
-  }
-
-  /* Current Slide Display */
-  .current-slide {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 24px;
-    margin-bottom: 16px;
-  }
-
-  .slide-title-display {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .slide-notes-display {
-    font-size: 1.1rem;
-    line-height: 2;
-    white-space: pre-wrap;
-    color: var(--color-text-primary);
-  }
-
-  /* Slide List */
-  .slide-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .slide-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .slide-item:hover {
-    border-color: var(--color-accent-cyan);
-  }
-
-  .slide-item.active {
-    border-color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.05);
-  }
-
-  .slide-number {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.1);
-    padding: 4px 10px;
-    border-radius: var(--radius-sm);
-    min-width: 40px;
-    text-align: center;
-  }
-
-  .slide-content {
-    flex: 1;
-  }
-
-  .slide-item-title {
-    font-family: var(--font-mono);
-    font-weight: 500;
-    margin-bottom: 4px;
-  }
-
-  .slide-item-preview {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 500px;
-  }
-
-  .slide-item-actions {
-    display: flex;
-    gap: 8px;
-  }
-
-  .btn-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle);
-    background: transparent;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    font-size: 0.9rem;
-    transition: all 0.2s;
-  }
-
-  .btn-icon:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-icon.delete:hover {
-    border-color: var(--accent-red);
-    color: var(--accent-red);
-  }
-
-  /* Edit Mode */
-  .edit-section {
-    display: none;
-    background: var(--bg-input);
-    border: 1px solid var(--color-accent-cyan);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    margin-bottom: 16px;
-  }
-
-  .edit-section.show {
-    display: block;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  /* Print Styles */
-  @media print {
-    body {
-      background: #fff !important;
-      color: #000 !important;
-    }
-
-    .bg-grid,
-    .theme-toggle,
-    .breadcrumb,
-    .btn-row,
-    .btn,
-    .timer-section,
-    .slide-nav,
-    .edit-section,
-    .slide-item-actions,
-    .no-print {
-      display: none !important;
-    }
-
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-
-    .main-content {
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      background: #fff;
-    }
-
-    .tool-section {
-      page-break-inside: avoid;
-    }
-
-    .section-title {
-      color: #333;
-      border-bottom-color: #ddd;
-    }
-
-    .slide-item {
-      background: #fff;
-      border: 1px solid #ddd;
-      page-break-inside: avoid;
-    }
-
-    .slide-number {
-      background: #f0f0f0;
-      color: #333;
-    }
-
-    .slide-item-title,
-    .slide-item-preview {
-      color: #333;
-    }
-
-    .notes-header-print {
-      display: block !important;
-      text-align: center;
-      margin-bottom: 24px;
-      padding-bottom: 16px;
-      border-bottom: 2px solid #333;
-    }
-
-    .print-title {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: #000;
-    }
-
-    .print-subtitle {
-      font-size: 1rem;
-      color: #666;
-      margin-top: 8px;
-    }
-
-    .current-slide {
-      display: none;
-    }
-  }
-
-  .notes-header-print {
-    display: none;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .timer-display {
-      font-size: 1.8rem;
-      min-width: 120px;
-    }
-
-    .slide-item-preview {
-      max-width: 200px;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+        line-height: 1.8;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 100px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-sm {
+        min-width: auto;
+        padding: 8px 12px;
+        font-size: 0.8rem;
+        flex: none;
+      }
+
+      /* Timer Section */
+      .timer-section {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: 24px;
+      }
+
+      .timer-display {
+        font-family: var(--font-mono);
+        font-size: 2.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        min-width: 180px;
+        text-align: center;
+      }
+
+      .timer-controls {
+        display: flex;
+        gap: 8px;
+      }
+
+      .timer-btn {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        font-size: 1rem;
+        transition: all 0.2s;
+      }
+
+      .timer-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .timer-btn.active {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+        border-color: var(--color-accent-cyan);
+      }
+
+      /* Slide Navigation */
+      .slide-nav {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: 16px;
+      }
+
+      .nav-btn {
+        width: 48px;
+        height: 48px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        font-size: 1.2rem;
+        transition: all 0.2s;
+      }
+
+      .nav-btn:hover:not(:disabled) {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .nav-btn:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+      }
+
+      .slide-indicator {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        color: var(--color-text-secondary);
+        min-width: 100px;
+        text-align: center;
+      }
+
+      .slide-indicator span {
+        color: var(--color-accent-cyan);
+        font-weight: 600;
+      }
+
+      /* Current Slide Display */
+      .current-slide {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 24px;
+        margin-bottom: 16px;
+      }
+
+      .slide-title-display {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        margin-bottom: 16px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .slide-notes-display {
+        font-size: 1.1rem;
+        line-height: 2;
+        white-space: pre-wrap;
+        color: var(--color-text-primary);
+      }
+
+      /* Slide List */
+      .slide-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .slide-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .slide-item:hover {
+        border-color: var(--color-accent-cyan);
+      }
+
+      .slide-item.active {
+        border-color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.05);
+      }
+
+      .slide-number {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.1);
+        padding: 4px 10px;
+        border-radius: var(--radius-sm);
+        min-width: 40px;
+        text-align: center;
+      }
+
+      .slide-content {
+        flex: 1;
+      }
+
+      .slide-item-title {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        margin-bottom: 4px;
+      }
+
+      .slide-item-preview {
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 500px;
+      }
+
+      .slide-item-actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      .btn-icon {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-subtle);
+        background: transparent;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        font-size: 0.9rem;
+        transition: all 0.2s;
+      }
+
+      .btn-icon:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-icon.delete:hover {
+        border-color: var(--accent-red);
+        color: var(--accent-red);
+      }
+
+      /* Edit Mode */
+      .edit-section {
+        display: none;
+        background: var(--bg-input);
+        border: 1px solid var(--color-accent-cyan);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+
+      .edit-section.show {
+        display: block;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      /* Print Styles */
+      @media print {
+        body {
+          background: #fff !important;
+          color: #000 !important;
+        }
+
+        .bg-grid,
+        .theme-toggle,
+        .breadcrumb,
+        .btn-row,
+        .btn,
+        .timer-section,
+        .slide-nav,
+        .edit-section,
+        .slide-item-actions,
+        .no-print {
+          display: none !important;
+        }
+
+        .container {
+          max-width: 100%;
+          padding: 0;
+        }
+
+        .main-content {
+          border: none;
+          box-shadow: none;
+          padding: 0;
+          background: #fff;
+        }
+
+        .tool-section {
+          page-break-inside: avoid;
+        }
+
+        .section-title {
+          color: #333;
+          border-bottom-color: #ddd;
+        }
+
+        .slide-item {
+          background: #fff;
+          border: 1px solid #ddd;
+          page-break-inside: avoid;
+        }
+
+        .slide-number {
+          background: #f0f0f0;
+          color: #333;
+        }
+
+        .slide-item-title,
+        .slide-item-preview {
+          color: #333;
+        }
+
+        .notes-header-print {
+          display: block !important;
+          text-align: center;
+          margin-bottom: 24px;
+          padding-bottom: 16px;
+          border-bottom: 2px solid #333;
+        }
+
+        .print-title {
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: #000;
+        }
+
+        .print-subtitle {
+          font-size: 1rem;
+          color: #666;
+          margin-top: 8px;
+        }
+
+        .current-slide {
+          display: none;
+        }
+      }
+
+      .notes-header-print {
+        display: none;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .timer-display {
+          font-size: 1.8rem;
+          min-width: 120px;
+        }
+
+        .slide-item-preview {
+          max-width: 200px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">演讲笔记</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">📝</span>
-        演讲笔记
-      </h1>
-      <p>管理演讲幻灯片备注，支持导航、计时、打印</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">演讲笔记</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">📝</span>
+              演讲笔记
+            </h1>
+            <p>管理演讲幻灯片备注，支持导航、计时、打印</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Print Header -->
-    <div class="notes-header-print">
-      <div class="print-title">演讲笔记</div>
-      <div class="print-subtitle" id="printPresentationTitle"></div>
+        <main class="main-content">
+          <!-- Print Header -->
+          <div class="notes-header-print">
+            <div class="print-title">演讲笔记</div>
+            <div class="print-subtitle" id="printPresentationTitle"></div>
+          </div>
+
+          <!-- Presentation Title -->
+          <div class="tool-section no-print">
+            <div class="input-group">
+              <label class="input-label">演讲标题</label>
+              <input type="text" id="presentationTitle" placeholder="您的演讲标题" />
+            </div>
+          </div>
+
+          <!-- Timer -->
+          <div class="timer-section no-print">
+            <div class="timer-display" id="timerDisplay">00:00:00</div>
+            <div class="timer-controls">
+              <button class="timer-btn" id="timerPlayBtn" onclick="toggleTimer()" title="开始/暂停">
+                ▶
+              </button>
+              <button class="timer-btn" onclick="resetTimer()" title="重置">↺</button>
+            </div>
+          </div>
+
+          <!-- Slide Navigation -->
+          <div class="slide-nav no-print">
+            <button class="nav-btn" id="prevBtn" onclick="prevSlide()" title="上一页">◀</button>
+            <div class="slide-indicator">
+              <span id="currentSlideNum">0</span>
+              /
+              <span id="totalSlides">0</span>
+            </div>
+            <button class="nav-btn" id="nextBtn" onclick="nextSlide()" title="下一页">▶</button>
+          </div>
+
+          <!-- Current Slide Display -->
+          <div class="current-slide no-print" id="currentSlideDisplay">
+            <div class="slide-title-display" id="slideTitle">请添加幻灯片</div>
+            <div class="slide-notes-display" id="slideNotes">
+              点击下方"添加幻灯片"开始创建演讲笔记
+            </div>
+          </div>
+
+          <!-- Edit Section -->
+          <div class="edit-section" id="editSection">
+            <div class="input-group">
+              <label class="input-label">幻灯片标题</label>
+              <input type="text" id="editTitle" placeholder="幻灯片标题" />
+            </div>
+            <div class="input-group">
+              <label class="input-label">演讲备注</label>
+              <textarea id="editNotes" placeholder="在此输入演讲备注、要点、提示..."></textarea>
+            </div>
+            <div class="btn-row">
+              <button class="btn btn-primary btn-sm" onclick="saveSlide()">保存</button>
+              <button class="btn btn-secondary btn-sm" onclick="cancelEdit()">取消</button>
+            </div>
+          </div>
+
+          <!-- Slide List -->
+          <div class="tool-section">
+            <div class="section-title">幻灯片列表</div>
+            <div class="slide-list" id="slideList">
+              <!-- Slides will be rendered here -->
+            </div>
+            <div class="btn-row no-print" style="margin-top: 16px">
+              <button class="btn btn-secondary btn-sm" onclick="addSlide()">+ 添加幻灯片</button>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="tool-section no-print">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="printNotes()">🖨️ 打印笔记</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
 
-    <!-- Presentation Title -->
-    <div class="tool-section no-print">
-      <div class="input-group">
-        <label class="input-label">演讲标题</label>
-        <input type="text" id="presentationTitle" placeholder="您的演讲标题">
-      </div>
-    </div>
-
-    <!-- Timer -->
-    <div class="timer-section no-print">
-      <div class="timer-display" id="timerDisplay">00:00:00</div>
-      <div class="timer-controls">
-        <button class="timer-btn" id="timerPlayBtn" onclick="toggleTimer()" title="开始/暂停">
-          ▶
-        </button>
-        <button class="timer-btn" onclick="resetTimer()" title="重置">↺</button>
-      </div>
-    </div>
-
-    <!-- Slide Navigation -->
-    <div class="slide-nav no-print">
-      <button class="nav-btn" id="prevBtn" onclick="prevSlide()" title="上一页">◀</button>
-      <div class="slide-indicator">
-        <span id="currentSlideNum">0</span>
-        /
-        <span id="totalSlides">0</span>
-      </div>
-      <button class="nav-btn" id="nextBtn" onclick="nextSlide()" title="下一页">▶</button>
-    </div>
-
-    <!-- Current Slide Display -->
-    <div class="current-slide no-print" id="currentSlideDisplay">
-      <div class="slide-title-display" id="slideTitle">请添加幻灯片</div>
-      <div class="slide-notes-display" id="slideNotes">点击下方"添加幻灯片"开始创建演讲笔记</div>
-    </div>
-
-    <!-- Edit Section -->
-    <div class="edit-section" id="editSection">
-      <div class="input-group">
-        <label class="input-label">幻灯片标题</label>
-        <input type="text" id="editTitle" placeholder="幻灯片标题">
-      </div>
-      <div class="input-group">
-        <label class="input-label">演讲备注</label>
-        <textarea id="editNotes" placeholder="在此输入演讲备注、要点、提示..."></textarea>
-      </div>
-      <div class="btn-row">
-        <button class="btn btn-primary btn-sm" onclick="saveSlide()">保存</button>
-        <button class="btn btn-secondary btn-sm" onclick="cancelEdit()">取消</button>
-      </div>
-    </div>
-
-    <!-- Slide List -->
-    <div class="tool-section">
-      <div class="section-title">幻灯片列表</div>
-      <div class="slide-list" id="slideList">
-        <!-- Slides will be rendered here -->
-      </div>
-      <div class="btn-row no-print" style="margin-top: 16px">
-        <button class="btn btn-secondary btn-sm" onclick="addSlide()">+ 添加幻灯片</button>
-      </div>
-    </div>
-
-    <!-- Actions -->
-    <div class="tool-section no-print">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="printNotes()">🖨️ 打印笔记</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空重置</button>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "演讲笔记",
-              "item": "https://tools.realtime-ai.chat/tools/office/slide-notes.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "演讲笔记",
+            "item": "https://tools.realtime-ai.chat/tools/office/slide-notes.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "slide_notes_data_v1";
+      var slides = [];
+      var currentIndex = 0;
+      var editingIndex = -1;
+      var timerInterval = null;
+      var timerSeconds = 0;
+      var timerRunning = false;
 
-  var LS_KEY = "slide_notes_data_v1";
-        var slides = [];
-        var currentIndex = 0;
-        var editingIndex = -1;
-        var timerInterval = null;
-        var timerSeconds = 0;
-        var timerRunning = false;
+      // Initialize
+      function init() {
+        loadTheme();
+        loadFromStorage();
+        renderSlideList();
+        updateDisplay();
+        updateNavigation();
 
-        // Initialize
-        function init() {
-          loadTheme();
-          loadFromStorage();
-          renderSlideList();
-          updateDisplay();
-          updateNavigation();
+        // Add input listeners for auto-save
+        document
+          .getElementById("presentationTitle")
+          .addEventListener("input", debounce(saveToStorage, 500));
 
-          // Add input listeners for auto-save
-          document
-            .getElementById("presentationTitle")
-            .addEventListener("input", debounce(saveToStorage, 500));
+        // Keyboard navigation
+        document.addEventListener("keydown", function (e) {
+          if (editingIndex >= 0) return; // Don't navigate while editing
 
-          // Keyboard navigation
-          document.addEventListener("keydown", function (e) {
-            if (editingIndex >= 0) return; // Don't navigate while editing
-
-            if (e.key === "ArrowLeft" || e.key === "PageUp") {
-              prevSlide();
-            } else if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") {
-              e.preventDefault();
-              nextSlide();
-            }
-          });
-        }
-
-        // Timer functions
-        function toggleTimer() {
-          if (timerRunning) {
-            pauseTimer();
-          } else {
-            startTimer();
+          if (e.key === "ArrowLeft" || e.key === "PageUp") {
+            prevSlide();
+          } else if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") {
+            e.preventDefault();
+            nextSlide();
           }
-        }
+        });
+      }
 
-        function startTimer() {
-          timerRunning = true;
-          document.getElementById("timerPlayBtn").textContent = "⏸";
-          document.getElementById("timerPlayBtn").classList.add("active");
-
-          timerInterval = setInterval(function () {
-            timerSeconds++;
-            updateTimerDisplay();
-          }, 1000);
-        }
-
-        function pauseTimer() {
-          timerRunning = false;
-          document.getElementById("timerPlayBtn").textContent = "▶";
-          document.getElementById("timerPlayBtn").classList.remove("active");
-
-          if (timerInterval) {
-            clearInterval(timerInterval);
-            timerInterval = null;
-          }
-        }
-
-        function resetTimer() {
+      // Timer functions
+      function toggleTimer() {
+        if (timerRunning) {
           pauseTimer();
-          timerSeconds = 0;
+        } else {
+          startTimer();
+        }
+      }
+
+      function startTimer() {
+        timerRunning = true;
+        document.getElementById("timerPlayBtn").textContent = "⏸";
+        document.getElementById("timerPlayBtn").classList.add("active");
+
+        timerInterval = setInterval(function () {
+          timerSeconds++;
           updateTimerDisplay();
+        }, 1000);
+      }
+
+      function pauseTimer() {
+        timerRunning = false;
+        document.getElementById("timerPlayBtn").textContent = "▶";
+        document.getElementById("timerPlayBtn").classList.remove("active");
+
+        if (timerInterval) {
+          clearInterval(timerInterval);
+          timerInterval = null;
         }
+      }
 
-        function updateTimerDisplay() {
-          var hours = Math.floor(timerSeconds / 3600);
-          var minutes = Math.floor((timerSeconds % 3600) / 60);
-          var seconds = timerSeconds % 60;
+      function resetTimer() {
+        pauseTimer();
+        timerSeconds = 0;
+        updateTimerDisplay();
+      }
 
-          var display =
-            String(hours).padStart(2, "0") +
-            ":" +
-            String(minutes).padStart(2, "0") +
-            ":" +
-            String(seconds).padStart(2, "0");
+      function updateTimerDisplay() {
+        var hours = Math.floor(timerSeconds / 3600);
+        var minutes = Math.floor((timerSeconds % 3600) / 60);
+        var seconds = timerSeconds % 60;
 
-          document.getElementById("timerDisplay").textContent = display;
-        }
+        var display =
+          String(hours).padStart(2, "0") +
+          ":" +
+          String(minutes).padStart(2, "0") +
+          ":" +
+          String(seconds).padStart(2, "0");
 
-        // Slide navigation
-        function prevSlide() {
-          if (currentIndex > 0) {
-            currentIndex--;
-            updateDisplay();
-            updateNavigation();
-          }
-        }
+        document.getElementById("timerDisplay").textContent = display;
+      }
 
-        function nextSlide() {
-          if (currentIndex < slides.length - 1) {
-            currentIndex++;
-            updateDisplay();
-            updateNavigation();
-          }
-        }
-
-        function goToSlide(index) {
-          if (index >= 0 && index < slides.length) {
-            currentIndex = index;
-            updateDisplay();
-            updateNavigation();
-            renderSlideList();
-          }
-        }
-
-        function updateNavigation() {
-          document.getElementById("prevBtn").disabled = currentIndex === 0;
-          document.getElementById("nextBtn").disabled = currentIndex >= slides.length - 1;
-          document.getElementById("currentSlideNum").textContent =
-            slides.length > 0 ? currentIndex + 1 : 0;
-          document.getElementById("totalSlides").textContent = slides.length;
-        }
-
-        function updateDisplay() {
-          if (slides.length === 0) {
-            document.getElementById("slideTitle").textContent = "请添加幻灯片";
-            document.getElementById("slideNotes").textContent =
-              '点击下方"添加幻灯片"开始创建演讲笔记';
-            return;
-          }
-
-          var slide = slides[currentIndex];
-          document.getElementById("slideTitle").textContent = slide.title || "(无标题)";
-          document.getElementById("slideNotes").textContent = slide.notes || "(无备注)";
-        }
-
-        // Slide CRUD
-        function addSlide() {
-          editingIndex = -1;
-          document.getElementById("editTitle").value = "";
-          document.getElementById("editNotes").value = "";
-          document.getElementById("editSection").classList.add("show");
-          document.getElementById("editTitle").focus();
-        }
-
-        function editSlide(index) {
-          editingIndex = index;
-          var slide = slides[index];
-          document.getElementById("editTitle").value = slide.title;
-          document.getElementById("editNotes").value = slide.notes;
-          document.getElementById("editSection").classList.add("show");
-          document.getElementById("editTitle").focus();
-        }
-
-        function saveSlide() {
-          var title = document.getElementById("editTitle").value.trim();
-          var notes = document.getElementById("editNotes").value.trim();
-
-          if (!title) {
-            title = "幻灯片 " + (editingIndex >= 0 ? editingIndex + 1 : slides.length + 1);
-          }
-
-          if (editingIndex >= 0) {
-            // Update existing
-            slides[editingIndex].title = title;
-            slides[editingIndex].notes = notes;
-            showToast("已更新");
-          } else {
-            // Add new
-            slides.push({ title: title, notes: notes });
-            currentIndex = slides.length - 1;
-            showToast("已添加");
-          }
-
-          cancelEdit();
-          renderSlideList();
+      // Slide navigation
+      function prevSlide() {
+        if (currentIndex > 0) {
+          currentIndex--;
           updateDisplay();
           updateNavigation();
-          saveToStorage();
+        }
+      }
+
+      function nextSlide() {
+        if (currentIndex < slides.length - 1) {
+          currentIndex++;
+          updateDisplay();
+          updateNavigation();
+        }
+      }
+
+      function goToSlide(index) {
+        if (index >= 0 && index < slides.length) {
+          currentIndex = index;
+          updateDisplay();
+          updateNavigation();
+          renderSlideList();
+        }
+      }
+
+      function updateNavigation() {
+        document.getElementById("prevBtn").disabled = currentIndex === 0;
+        document.getElementById("nextBtn").disabled = currentIndex >= slides.length - 1;
+        document.getElementById("currentSlideNum").textContent =
+          slides.length > 0 ? currentIndex + 1 : 0;
+        document.getElementById("totalSlides").textContent = slides.length;
+      }
+
+      function updateDisplay() {
+        if (slides.length === 0) {
+          document.getElementById("slideTitle").textContent = "请添加幻灯片";
+          document.getElementById("slideNotes").textContent =
+            '点击下方"添加幻灯片"开始创建演讲笔记';
+          return;
         }
 
-        function cancelEdit() {
-          editingIndex = -1;
-          document.getElementById("editSection").classList.remove("show");
+        var slide = slides[currentIndex];
+        document.getElementById("slideTitle").textContent = slide.title || "(无标题)";
+        document.getElementById("slideNotes").textContent = slide.notes || "(无备注)";
+      }
+
+      // Slide CRUD
+      function addSlide() {
+        editingIndex = -1;
+        document.getElementById("editTitle").value = "";
+        document.getElementById("editNotes").value = "";
+        document.getElementById("editSection").classList.add("show");
+        document.getElementById("editTitle").focus();
+      }
+
+      function editSlide(index) {
+        editingIndex = index;
+        var slide = slides[index];
+        document.getElementById("editTitle").value = slide.title;
+        document.getElementById("editNotes").value = slide.notes;
+        document.getElementById("editSection").classList.add("show");
+        document.getElementById("editTitle").focus();
+      }
+
+      function saveSlide() {
+        var title = document.getElementById("editTitle").value.trim();
+        var notes = document.getElementById("editNotes").value.trim();
+
+        if (!title) {
+          title = "幻灯片 " + (editingIndex >= 0 ? editingIndex + 1 : slides.length + 1);
         }
 
-        function deleteSlide(index) {
-          if (!confirm("确定要删除这张幻灯片吗？")) return;
+        if (editingIndex >= 0) {
+          // Update existing
+          slides[editingIndex].title = title;
+          slides[editingIndex].notes = notes;
+          showToast("已更新");
+        } else {
+          // Add new
+          slides.push({ title: title, notes: notes });
+          currentIndex = slides.length - 1;
+          showToast("已添加");
+        }
 
-          slides.splice(index, 1);
+        cancelEdit();
+        renderSlideList();
+        updateDisplay();
+        updateNavigation();
+        saveToStorage();
+      }
+
+      function cancelEdit() {
+        editingIndex = -1;
+        document.getElementById("editSection").classList.remove("show");
+      }
+
+      function deleteSlide(index) {
+        if (!confirm("确定要删除这张幻灯片吗？")) return;
+
+        slides.splice(index, 1);
+
+        if (currentIndex >= slides.length) {
+          currentIndex = Math.max(0, slides.length - 1);
+        }
+
+        renderSlideList();
+        updateDisplay();
+        updateNavigation();
+        saveToStorage();
+        showToast("已删除");
+      }
+
+      // Render slide list
+      function renderSlideList() {
+        var container = document.getElementById("slideList");
+        container.textContent = "";
+
+        if (slides.length === 0) {
+          var placeholder = document.createElement("div");
+          placeholder.style.textAlign = "center";
+          placeholder.style.color = "var(--color-text-muted)";
+          placeholder.style.padding = "40px 0";
+          placeholder.textContent = "暂无幻灯片";
+          container.appendChild(placeholder);
+          return;
+        }
+
+        for (var i = 0; i < slides.length; i++) {
+          var item = createSlideItem(slides[i], i);
+          container.appendChild(item);
+        }
+      }
+
+      function createSlideItem(slide, index) {
+        var item = document.createElement("div");
+        item.className = "slide-item" + (index === currentIndex ? " active" : "");
+
+        item.addEventListener("click", function (e) {
+          if (e.target.closest(".slide-item-actions")) return;
+          goToSlide(index);
+        });
+
+        var number = document.createElement("div");
+        number.className = "slide-number";
+        number.textContent = index + 1;
+        item.appendChild(number);
+
+        var content = document.createElement("div");
+        content.className = "slide-content";
+
+        var title = document.createElement("div");
+        title.className = "slide-item-title";
+        title.textContent = slide.title || "(无标题)";
+        content.appendChild(title);
+
+        var preview = document.createElement("div");
+        preview.className = "slide-item-preview";
+        preview.textContent = slide.notes || "(无备注)";
+        content.appendChild(preview);
+
+        item.appendChild(content);
+
+        var actions = document.createElement("div");
+        actions.className = "slide-item-actions no-print";
+
+        var editBtn = document.createElement("button");
+        editBtn.className = "btn-icon";
+        editBtn.title = "编辑";
+        editBtn.textContent = "✎";
+        editBtn.addEventListener("click", function () {
+          editSlide(index);
+        });
+        actions.appendChild(editBtn);
+
+        var deleteBtn = document.createElement("button");
+        deleteBtn.className = "btn-icon delete";
+        deleteBtn.title = "删除";
+        deleteBtn.textContent = "×";
+        deleteBtn.addEventListener("click", function () {
+          deleteSlide(index);
+        });
+        actions.appendChild(deleteBtn);
+
+        item.appendChild(actions);
+
+        return item;
+      }
+
+      // Debounce function
+      function debounce(func, wait) {
+        var timeout;
+        return function () {
+          var context = this;
+          var args = arguments;
+          var later = function () {
+            clearTimeout(timeout);
+            func.apply(context, args);
+          };
+          clearTimeout(timeout);
+          timeout = setTimeout(later, wait);
+        };
+      }
+
+      // Print notes
+      function printNotes() {
+        var title = document.getElementById("presentationTitle").value || "演讲笔记";
+        document.getElementById("printPresentationTitle").textContent = title;
+        window.print();
+      }
+
+      // Clear all
+      function clearAll() {
+        if (!confirm("确定要清空所有内容吗？")) return;
+
+        document.getElementById("presentationTitle").value = "";
+        slides = [];
+        currentIndex = 0;
+        resetTimer();
+        cancelEdit();
+
+        renderSlideList();
+        updateDisplay();
+        updateNavigation();
+
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          presentationTitle: document.getElementById("presentationTitle").value,
+          slides: slides,
+          currentIndex: currentIndex
+        };
+
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          var data = JSON.parse(saved);
+
+          document.getElementById("presentationTitle").value = data.presentationTitle || "";
+          slides = data.slides || [];
+          currentIndex = data.currentIndex || 0;
 
           if (currentIndex >= slides.length) {
             currentIndex = Math.max(0, slides.length - 1);
           }
-
-          renderSlideList();
-          updateDisplay();
-          updateNavigation();
-          saveToStorage();
-          showToast("已删除");
+        } catch (e) {
+          console.error("Failed to load saved data:", e);
         }
+      }
 
-        // Render slide list
-        function renderSlideList() {
-          var container = document.getElementById("slideList");
-          container.textContent = "";
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-          if (slides.length === 0) {
-            var placeholder = document.createElement("div");
-            placeholder.style.textAlign = "center";
-            placeholder.style.color = "var(--color-text-muted)";
-            placeholder.style.padding = "40px 0";
-            placeholder.textContent = "暂无幻灯片";
-            container.appendChild(placeholder);
-            return;
-          }
-
-          for (var i = 0; i < slides.length; i++) {
-            var item = createSlideItem(slides[i], i);
-            container.appendChild(item);
-          }
+      // Load theme
+      function loadTheme() {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      }
 
-        function createSlideItem(slide, index) {
-          var item = document.createElement("div");
-          item.className = "slide-item" + (index === currentIndex ? " active" : "");
+      // Show toast
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
 
-          item.addEventListener("click", function (e) {
-            if (e.target.closest(".slide-item-actions")) return;
-            goToSlide(index);
-          });
+      // Initialize on load
+      init();
+    </script>
 
-          var number = document.createElement("div");
-          number.className = "slide-number";
-          number.textContent = index + 1;
-          item.appendChild(number);
-
-          var content = document.createElement("div");
-          content.className = "slide-content";
-
-          var title = document.createElement("div");
-          title.className = "slide-item-title";
-          title.textContent = slide.title || "(无标题)";
-          content.appendChild(title);
-
-          var preview = document.createElement("div");
-          preview.className = "slide-item-preview";
-          preview.textContent = slide.notes || "(无备注)";
-          content.appendChild(preview);
-
-          item.appendChild(content);
-
-          var actions = document.createElement("div");
-          actions.className = "slide-item-actions no-print";
-
-          var editBtn = document.createElement("button");
-          editBtn.className = "btn-icon";
-          editBtn.title = "编辑";
-          editBtn.textContent = "✎";
-          editBtn.addEventListener("click", function () {
-            editSlide(index);
-          });
-          actions.appendChild(editBtn);
-
-          var deleteBtn = document.createElement("button");
-          deleteBtn.className = "btn-icon delete";
-          deleteBtn.title = "删除";
-          deleteBtn.textContent = "×";
-          deleteBtn.addEventListener("click", function () {
-            deleteSlide(index);
-          });
-          actions.appendChild(deleteBtn);
-
-          item.appendChild(actions);
-
-          return item;
-        }
-
-        // Debounce function
-        function debounce(func, wait) {
-          var timeout;
-          return function () {
-            var context = this;
-            var args = arguments;
-            var later = function () {
-              clearTimeout(timeout);
-              func.apply(context, args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-          };
-        }
-
-        // Print notes
-        function printNotes() {
-          var title = document.getElementById("presentationTitle").value || "演讲笔记";
-          document.getElementById("printPresentationTitle").textContent = title;
-          window.print();
-        }
-
-        // Clear all
-        function clearAll() {
-          if (!confirm("确定要清空所有内容吗？")) return;
-
-          document.getElementById("presentationTitle").value = "";
-          slides = [];
-          currentIndex = 0;
-          resetTimer();
-          cancelEdit();
-
-          renderSlideList();
-          updateDisplay();
-          updateNavigation();
-
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
-        }
-
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            presentationTitle: document.getElementById("presentationTitle").value,
-            slides: slides,
-            currentIndex: currentIndex
-          };
-
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // Load from localStorage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
-
-          try {
-            var data = JSON.parse(saved);
-
-            document.getElementById("presentationTitle").value = data.presentationTitle || "";
-            slides = data.slides || [];
-            currentIndex = data.currentIndex || 0;
-
-            if (currentIndex >= slides.length) {
-              currentIndex = Math.max(0, slides.length - 1);
-            }
-          } catch (e) {
-            console.error("Failed to load saved data:", e);
-          }
-        }
-
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-
-        // Load theme
-        function loadTheme() {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        }
-
-        // Show toast
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // Initialize on load
-        init();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/office/task-tracker.html
+++ b/tools/office/task-tracker.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Task Tracker - WebUtils" />
-    <meta property="og:description" content="Task Tracker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Task Tracker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/office/task-tracker.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/office/task-tracker.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Task Tracker - WebUtils" />
-    <meta name="twitter:description" content="Task Tracker，在线使用，办公效率，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Task Tracker，在线使用，办公效率，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "办公效率",
-      "item": "https://tools.realtime-ai.chat/tools/office/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Task Tracker",
-      "item": "https://tools.realtime-ai.chat/tools/office/task-tracker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公效率",
+            "item": "https://tools.realtime-ai.chat/tools/office/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Task Tracker",
+            "item": "https://tools.realtime-ai.chat/tools/office/task-tracker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Task Tracker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Task Tracker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1018 +97,1027 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --bg-hover: #252535;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-orange: #f97316;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0 245 212 / 15%);
-    --glow-green: rgb(16 185 129 / 15%);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --priority-high: #f43f5e;
-    --priority-medium: #fbbf24;
-    --priority-low: #10b981;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f0f0f0;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  /* Add Task Form */
-  .add-task-form {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .task-input {
-    flex: 1;
-    min-width: 200px;
-    padding: 12px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  .task-input:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  .task-input::placeholder {
-    color: var(--color-text-muted);
-  }
-
-  .priority-select {
-    padding: 12px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    min-width: 120px;
-  }
-
-  .priority-select:focus {
-    outline: none;
-    border-color: var(--color-accent-cyan);
-  }
-
-  .btn {
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    white-space: nowrap;
-  }
-
-  .btn-primary {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-cyan);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-  }
-
-  .btn-danger {
-    background: transparent;
-    color: var(--accent-red);
-    border: 1px solid var(--accent-red);
-  }
-
-  .btn-danger:hover {
-    background: var(--accent-red);
-    color: white;
-  }
-
-  /* Filters */
-  .filters {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .filter-group {
-    display: flex;
-    gap: 4px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 4px;
-  }
-
-  .filter-btn {
-    padding: 8px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .filter-btn:hover {
-    color: var(--color-text-primary);
-    background: var(--bg-hover);
-  }
-
-  .filter-btn.active {
-    background: var(--color-accent-cyan);
-    color: var(--color-bg-deep);
-  }
-
-  .filter-label {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-right: 8px;
-  }
-
-  /* Task Stats */
-  .task-stats {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 20px;
-    padding: 16px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    flex-wrap: wrap;
-  }
-
-  .stat-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-  }
-
-  .stat-value {
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
-
-  .stat-label {
-    color: var(--color-text-secondary);
-  }
-
-  /* Task List */
-  .task-list {
-    list-style: none;
-  }
-
-  .task-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-bottom: 8px;
-    transition: all 0.2s;
-  }
-
-  .task-item:hover {
-    border-color: var(--border-strong);
-    background: var(--bg-hover);
-  }
-
-  .task-item.completed {
-    opacity: 0.6;
-  }
-
-  .task-item.completed .task-title {
-    text-decoration: line-through;
-    color: var(--color-text-muted);
-  }
-
-  .task-checkbox {
-    width: 22px;
-    height: 22px;
-    border: 2px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    transition: all 0.2s;
-    background: transparent;
-  }
-
-  .task-checkbox:hover {
-    border-color: var(--color-accent-cyan);
-  }
-
-  .task-checkbox.checked {
-    background: var(--accent-green);
-    border-color: var(--accent-green);
-  }
-
-  .task-checkbox.checked::after {
-    content: "✓";
-    color: white;
-    font-size: 0.8rem;
-    font-weight: bold;
-  }
-
-  .priority-indicator {
-    width: 4px;
-    height: 32px;
-    border-radius: 2px;
-    flex-shrink: 0;
-  }
-
-  .priority-indicator.high {
-    background: var(--priority-high);
-  }
-
-  .priority-indicator.medium {
-    background: var(--priority-medium);
-  }
-
-  .priority-indicator.low {
-    background: var(--priority-low);
-  }
-
-  .task-content {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .task-title {
-    font-family: var(--font-sans);
-    font-size: 0.95rem;
-    color: var(--color-text-primary);
-    overflow-wrap: anywhere;
-  }
-
-  .task-meta {
-    display: flex;
-    gap: 12px;
-    margin-top: 4px;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-  }
-
-  .priority-badge {
-    padding: 2px 8px;
-    border-radius: var(--radius-sm);
-    font-size: 0.7rem;
-    font-weight: 500;
-    text-transform: uppercase;
-  }
-
-  .priority-badge.high {
-    background: rgb(244 63 94 / 20%);
-    color: var(--priority-high);
-  }
-
-  .priority-badge.medium {
-    background: rgb(251 191 36 / 20%);
-    color: var(--priority-medium);
-  }
-
-  .priority-badge.low {
-    background: rgb(16 185 129 / 20%);
-    color: var(--priority-low);
-  }
-
-  .delete-btn {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s;
-    flex-shrink: 0;
-  }
-
-  .delete-btn:hover {
-    background: rgb(244 63 94 / 15%);
-    color: var(--accent-red);
-  }
-
-  /* Empty State */
-  .empty-state {
-    text-align: center;
-    padding: 48px 24px;
-    color: var(--color-text-muted);
-  }
-
-  .empty-state .icon {
-    font-size: 3rem;
-    margin-bottom: 16px;
-    opacity: 0.5;
-  }
-
-  .empty-state p {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-  }
-
-  /* Actions */
-  .actions {
-    display: flex;
-    gap: 12px;
-    margin-top: 24px;
-    padding-top: 24px;
-    border-top: 1px solid var(--border-subtle);
-    flex-wrap: wrap;
-  }
-
-  /* Toast */
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: white;
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .add-task-form {
-      flex-direction: column;
-    }
-
-    .priority-select {
-      width: 100%;
-    }
-
-    .filters {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .filter-group {
-      justify-content: center;
-    }
-
-    .task-stats {
-      justify-content: space-between;
-    }
-
-    .task-meta {
-      flex-wrap: wrap;
-    }
-
-    .actions {
-      flex-direction: column;
-    }
-
-    .actions .btn {
-      width: 100%;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --bg-hover: #252535;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-orange: #f97316;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0 245 212 / 15%);
+        --glow-green: rgb(16 185 129 / 15%);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --priority-high: #f43f5e;
+        --priority-medium: #fbbf24;
+        --priority-low: #10b981;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f0f0f0;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(0 245 212 / 2%) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(0 245 212 / 2%) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      /* Add Task Form */
+      .add-task-form {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .task-input {
+        flex: 1;
+        min-width: 200px;
+        padding: 12px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      .task-input:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      .task-input::placeholder {
+        color: var(--color-text-muted);
+      }
+
+      .priority-select {
+        padding: 12px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        min-width: 120px;
+      }
+
+      .priority-select:focus {
+        outline: none;
+        border-color: var(--color-accent-cyan);
+      }
+
+      .btn {
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        white-space: nowrap;
+      }
+
+      .btn-primary {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-cyan);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+      }
+
+      .btn-danger {
+        background: transparent;
+        color: var(--accent-red);
+        border: 1px solid var(--accent-red);
+      }
+
+      .btn-danger:hover {
+        background: var(--accent-red);
+        color: white;
+      }
+
+      /* Filters */
+      .filters {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .filter-group {
+        display: flex;
+        gap: 4px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 4px;
+      }
+
+      .filter-btn {
+        padding: 8px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .filter-btn:hover {
+        color: var(--color-text-primary);
+        background: var(--bg-hover);
+      }
+
+      .filter-btn.active {
+        background: var(--color-accent-cyan);
+        color: var(--color-bg-deep);
+      }
+
+      .filter-label {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-right: 8px;
+      }
+
+      /* Task Stats */
+      .task-stats {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 20px;
+        padding: 16px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        flex-wrap: wrap;
+      }
+
+      .stat-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+      }
+
+      .stat-value {
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
+
+      .stat-label {
+        color: var(--color-text-secondary);
+      }
+
+      /* Task List */
+      .task-list {
+        list-style: none;
+      }
+
+      .task-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 16px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-bottom: 8px;
+        transition: all 0.2s;
+      }
+
+      .task-item:hover {
+        border-color: var(--border-strong);
+        background: var(--bg-hover);
+      }
+
+      .task-item.completed {
+        opacity: 0.6;
+      }
+
+      .task-item.completed .task-title {
+        text-decoration: line-through;
+        color: var(--color-text-muted);
+      }
+
+      .task-checkbox {
+        width: 22px;
+        height: 22px;
+        border: 2px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        transition: all 0.2s;
+        background: transparent;
+      }
+
+      .task-checkbox:hover {
+        border-color: var(--color-accent-cyan);
+      }
+
+      .task-checkbox.checked {
+        background: var(--accent-green);
+        border-color: var(--accent-green);
+      }
+
+      .task-checkbox.checked::after {
+        content: "✓";
+        color: white;
+        font-size: 0.8rem;
+        font-weight: bold;
+      }
+
+      .priority-indicator {
+        width: 4px;
+        height: 32px;
+        border-radius: 2px;
+        flex-shrink: 0;
+      }
+
+      .priority-indicator.high {
+        background: var(--priority-high);
+      }
+
+      .priority-indicator.medium {
+        background: var(--priority-medium);
+      }
+
+      .priority-indicator.low {
+        background: var(--priority-low);
+      }
+
+      .task-content {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .task-title {
+        font-family: var(--font-sans);
+        font-size: 0.95rem;
+        color: var(--color-text-primary);
+        overflow-wrap: anywhere;
+      }
+
+      .task-meta {
+        display: flex;
+        gap: 12px;
+        margin-top: 4px;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      .priority-badge {
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        font-size: 0.7rem;
+        font-weight: 500;
+        text-transform: uppercase;
+      }
+
+      .priority-badge.high {
+        background: rgb(244 63 94 / 20%);
+        color: var(--priority-high);
+      }
+
+      .priority-badge.medium {
+        background: rgb(251 191 36 / 20%);
+        color: var(--priority-medium);
+      }
+
+      .priority-badge.low {
+        background: rgb(16 185 129 / 20%);
+        color: var(--priority-low);
+      }
+
+      .delete-btn {
+        width: 32px;
+        height: 32px;
+        border: none;
+        background: transparent;
+        color: var(--color-text-muted);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s;
+        flex-shrink: 0;
+      }
+
+      .delete-btn:hover {
+        background: rgb(244 63 94 / 15%);
+        color: var(--accent-red);
+      }
+
+      /* Empty State */
+      .empty-state {
+        text-align: center;
+        padding: 48px 24px;
+        color: var(--color-text-muted);
+      }
+
+      .empty-state .icon {
+        font-size: 3rem;
+        margin-bottom: 16px;
+        opacity: 0.5;
+      }
+
+      .empty-state p {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      /* Actions */
+      .actions {
+        display: flex;
+        gap: 12px;
+        margin-top: 24px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border-subtle);
+        flex-wrap: wrap;
+      }
+
+      /* Toast */
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: white;
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .add-task-form {
+          flex-direction: column;
+        }
+
+        .priority-select {
+          width: 100%;
+        }
+
+        .filters {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .filter-group {
+          justify-content: center;
+        }
+
+        .task-stats {
+          justify-content: space-between;
+        }
+
+        .task-meta {
+          flex-wrap: wrap;
+        }
+
+        .actions {
+          flex-direction: column;
+        }
+
+        .actions .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">任务跟踪器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">✅</span>
-        任务跟踪器
-      </h1>
-      <p>管理待办事项，支持优先级和筛选</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">任务跟踪器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">✅</span>
+              任务跟踪器
+            </h1>
+            <p>管理待办事项，支持优先级和筛选</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Add Task Form -->
-    <form class="add-task-form" id="addTaskForm">
-      <input type="text" id="taskInput" class="task-input" placeholder="添加新任务..." autocomplete="off">
-      <select id="prioritySelect" class="priority-select">
-        <option value="medium">中优先级</option>
-        <option value="high">高优先级</option>
-        <option value="low">低优先级</option>
-      </select>
-      <button type="submit" class="btn btn-primary">➕ 添加</button>
-    </form>
+        <main class="main-content">
+          <!-- Add Task Form -->
+          <form class="add-task-form" id="addTaskForm">
+            <input
+              type="text"
+              id="taskInput"
+              class="task-input"
+              placeholder="添加新任务..."
+              autocomplete="off"
+            />
+            <select id="prioritySelect" class="priority-select">
+              <option value="medium">中优先级</option>
+              <option value="high">高优先级</option>
+              <option value="low">低优先级</option>
+            </select>
+            <button type="submit" class="btn btn-primary">➕ 添加</button>
+          </form>
 
-    <!-- Filters -->
-    <div class="filters">
-      <div>
-        <span class="filter-label">状态:</span>
-        <div class="filter-group" id="statusFilter">
-          <button class="filter-btn active" data-filter="all">全部</button>
-          <button class="filter-btn" data-filter="active">进行中</button>
-          <button class="filter-btn" data-filter="completed">已完成</button>
-        </div>
-      </div>
-      <div>
-        <span class="filter-label">优先级:</span>
-        <div class="filter-group" id="priorityFilter">
-          <button class="filter-btn active" data-filter="all">全部</button>
-          <button class="filter-btn" data-filter="high">高</button>
-          <button class="filter-btn" data-filter="medium">中</button>
-          <button class="filter-btn" data-filter="low">低</button>
-        </div>
+          <!-- Filters -->
+          <div class="filters">
+            <div>
+              <span class="filter-label">状态:</span>
+              <div class="filter-group" id="statusFilter">
+                <button class="filter-btn active" data-filter="all">全部</button>
+                <button class="filter-btn" data-filter="active">进行中</button>
+                <button class="filter-btn" data-filter="completed">已完成</button>
+              </div>
+            </div>
+            <div>
+              <span class="filter-label">优先级:</span>
+              <div class="filter-group" id="priorityFilter">
+                <button class="filter-btn active" data-filter="all">全部</button>
+                <button class="filter-btn" data-filter="high">高</button>
+                <button class="filter-btn" data-filter="medium">中</button>
+                <button class="filter-btn" data-filter="low">低</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Task Stats -->
+          <div class="task-stats">
+            <div class="stat-item">
+              <span class="stat-value" id="totalCount">0</span>
+              <span class="stat-label">总任务</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-value" id="activeCount">0</span>
+              <span class="stat-label">进行中</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-value" id="completedCount">0</span>
+              <span class="stat-label">已完成</span>
+            </div>
+          </div>
+
+          <!-- Task List -->
+          <ul class="task-list" id="taskList"></ul>
+
+          <!-- Actions -->
+          <div class="actions">
+            <button class="btn btn-danger" id="clearCompletedBtn">🗑️ 清除已完成</button>
+            <button class="btn btn-secondary" id="clearAllBtn">🔄 清空全部</button>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- Task Stats -->
-    <div class="task-stats">
-      <div class="stat-item">
-        <span class="stat-value" id="totalCount">0</span>
-        <span class="stat-label">总任务</span>
-      </div>
-      <div class="stat-item">
-        <span class="stat-value" id="activeCount">0</span>
-        <span class="stat-label">进行中</span>
-      </div>
-      <div class="stat-item">
-        <span class="stat-value" id="completedCount">0</span>
-        <span class="stat-label">已完成</span>
-      </div>
-    </div>
-
-    <!-- Task List -->
-    <ul class="task-list" id="taskList"></ul>
-
-    <!-- Actions -->
-    <div class="actions">
-      <button class="btn btn-danger" id="clearCompletedBtn">🗑️ 清除已完成</button>
-      <button class="btn btn-secondary" id="clearAllBtn">🔄 清空全部</button>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "办公工具",
-              "item": "https://tools.realtime-ai.chat/#office"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "任务跟踪器",
-              "item": "https://tools.realtime-ai.chat/tools/office/task-tracker.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "办公工具",
+            "item": "https://tools.realtime-ai.chat/#office"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "任务跟踪器",
+            "item": "https://tools.realtime-ai.chat/tools/office/task-tracker.html"
+          }
+        ]
+      }
     </script>
     <script>
+      (function () {
+        "use strict";
 
-  (function () {
-          "use strict";
+        var LS_KEY = "task_tracker_v1";
+        var tasks = [];
+        var currentStatusFilter = "all";
+        var currentPriorityFilter = "all";
 
-          var LS_KEY = "task_tracker_v1";
-          var tasks = [];
-          var currentStatusFilter = "all";
-          var currentPriorityFilter = "all";
+        var priorityLabels = {
+          high: "高",
+          medium: "中",
+          low: "低"
+        };
 
-          var priorityLabels = {
-            high: "高",
-            medium: "中",
-            low: "低"
+        // DOM elements
+        var taskList = document.getElementById("taskList");
+        var taskInput = document.getElementById("taskInput");
+        var prioritySelect = document.getElementById("prioritySelect");
+        var addTaskForm = document.getElementById("addTaskForm");
+        var statusFilter = document.getElementById("statusFilter");
+        var priorityFilterEl = document.getElementById("priorityFilter");
+        var toastEl = document.getElementById("toast");
+
+        // Theme toggle
+        window.toggleTheme = function () {
+          var html = document.documentElement;
+          var isDark = html.getAttribute("data-theme") !== "light";
+          html.setAttribute("data-theme", isDark ? "light" : "dark");
+          localStorage.setItem("theme", isDark ? "light" : "dark");
+        };
+
+        // Load theme
+        (function () {
+          var saved = localStorage.getItem("theme");
+          if (saved === "light") {
+            document.documentElement.setAttribute("data-theme", "light");
+          }
+        })();
+
+        // Load tasks from localStorage
+        function loadTasks() {
+          try {
+            var saved = localStorage.getItem(LS_KEY);
+            if (saved) {
+              tasks = JSON.parse(saved);
+            }
+          } catch (e) {
+            tasks = [];
+          }
+          renderTasks();
+        }
+
+        // Save tasks to localStorage
+        function saveTasks() {
+          localStorage.setItem(LS_KEY, JSON.stringify(tasks));
+        }
+
+        // Generate unique ID
+        function generateId() {
+          return Date.now().toString(36) + Math.random().toString(36).substr(2);
+        }
+
+        // Format date
+        function formatDate(timestamp) {
+          var date = new Date(timestamp);
+          var now = new Date();
+          var diff = now - date;
+
+          if (diff < 60000) return "刚刚";
+          if (diff < 3600000) return Math.floor(diff / 60000) + " 分钟前";
+          if (diff < 86400000) return Math.floor(diff / 3600000) + " 小时前";
+          if (diff < 604800000) return Math.floor(diff / 86400000) + " 天前";
+
+          var y = date.getFullYear();
+          var m = String(date.getMonth() + 1).padStart(2, "0");
+          var d = String(date.getDate()).padStart(2, "0");
+          return y + "/" + m + "/" + d;
+        }
+
+        // Show toast
+        function showToast(msg) {
+          toastEl.textContent = msg;
+          toastEl.classList.add("show");
+          setTimeout(function () {
+            toastEl.classList.remove("show");
+          }, 2000);
+        }
+
+        // Add new task
+        function addTask(e) {
+          e.preventDefault();
+          var title = taskInput.value.trim();
+          var priority = prioritySelect.value;
+
+          if (!title) {
+            showToast("请输入任务内容");
+            return;
+          }
+
+          var task = {
+            id: generateId(),
+            title: title,
+            priority: priority,
+            completed: false,
+            createdAt: Date.now()
           };
 
-          // DOM elements
-          var taskList = document.getElementById("taskList");
-          var taskInput = document.getElementById("taskInput");
-          var prioritySelect = document.getElementById("prioritySelect");
-          var addTaskForm = document.getElementById("addTaskForm");
-          var statusFilter = document.getElementById("statusFilter");
-          var priorityFilterEl = document.getElementById("priorityFilter");
-          var toastEl = document.getElementById("toast");
+          tasks.unshift(task);
+          saveTasks();
+          renderTasks();
+          taskInput.value = "";
+          showToast("任务已添加");
+        }
 
-          // Theme toggle
-          window.toggleTheme = function () {
-            var html = document.documentElement;
-            var isDark = html.getAttribute("data-theme") !== "light";
-            html.setAttribute("data-theme", isDark ? "light" : "dark");
-            localStorage.setItem("theme", isDark ? "light" : "dark");
-          };
-
-          // Load theme
-          (function () {
-            var saved = localStorage.getItem("theme");
-            if (saved === "light") {
-              document.documentElement.setAttribute("data-theme", "light");
+        // Toggle task completion
+        function toggleTask(id) {
+          for (var i = 0; i < tasks.length; i++) {
+            if (tasks[i].id === id) {
+              tasks[i].completed = !tasks[i].completed;
+              break;
             }
-          })();
+          }
+          saveTasks();
+          renderTasks();
+        }
 
-          // Load tasks from localStorage
-          function loadTasks() {
-            try {
-              var saved = localStorage.getItem(LS_KEY);
-              if (saved) {
-                tasks = JSON.parse(saved);
+        // Delete task
+        function deleteTask(id) {
+          tasks = tasks.filter(function (t) {
+            return t.id !== id;
+          });
+          saveTasks();
+          renderTasks();
+          showToast("任务已删除");
+        }
+
+        // Clear completed tasks
+        function clearCompleted() {
+          var completedCount = tasks.filter(function (t) {
+            return t.completed;
+          }).length;
+          if (completedCount === 0) {
+            showToast("没有已完成的任务");
+            return;
+          }
+          tasks = tasks.filter(function (t) {
+            return !t.completed;
+          });
+          saveTasks();
+          renderTasks();
+          showToast("已清除 " + completedCount + " 个已完成任务");
+        }
+
+        // Clear all tasks
+        function clearAll() {
+          if (tasks.length === 0) {
+            showToast("任务列表为空");
+            return;
+          }
+          if (confirm("确定要清空所有任务吗？")) {
+            tasks = [];
+            saveTasks();
+            renderTasks();
+            showToast("已清空所有任务");
+          }
+        }
+
+        // Filter tasks
+        function getFilteredTasks() {
+          return tasks.filter(function (task) {
+            var statusMatch =
+              currentStatusFilter === "all" ||
+              (currentStatusFilter === "active" && !task.completed) ||
+              (currentStatusFilter === "completed" && task.completed);
+
+            var priorityMatch =
+              currentPriorityFilter === "all" || task.priority === currentPriorityFilter;
+
+            return statusMatch && priorityMatch;
+          });
+        }
+
+        // Create task element
+        function createTaskElement(task) {
+          var li = document.createElement("li");
+          li.className = "task-item" + (task.completed ? " completed" : "");
+
+          // Checkbox
+          var checkbox = document.createElement("div");
+          checkbox.className = "task-checkbox" + (task.completed ? " checked" : "");
+          checkbox.addEventListener("click", function () {
+            toggleTask(task.id);
+          });
+
+          // Priority indicator
+          var indicator = document.createElement("div");
+          indicator.className = "priority-indicator " + task.priority;
+
+          // Content container
+          var content = document.createElement("div");
+          content.className = "task-content";
+
+          // Title
+          var title = document.createElement("div");
+          title.className = "task-title";
+          title.textContent = task.title;
+
+          // Meta
+          var meta = document.createElement("div");
+          meta.className = "task-meta";
+
+          var badge = document.createElement("span");
+          badge.className = "priority-badge " + task.priority;
+          badge.textContent = priorityLabels[task.priority];
+
+          var dateSpan = document.createElement("span");
+          dateSpan.textContent = formatDate(task.createdAt);
+
+          meta.appendChild(badge);
+          meta.appendChild(dateSpan);
+
+          content.appendChild(title);
+          content.appendChild(meta);
+
+          // Delete button
+          var deleteBtn = document.createElement("button");
+          deleteBtn.className = "delete-btn";
+          deleteBtn.title = "删除";
+          deleteBtn.textContent = "✕";
+          deleteBtn.addEventListener("click", function () {
+            deleteTask(task.id);
+          });
+
+          li.appendChild(checkbox);
+          li.appendChild(indicator);
+          li.appendChild(content);
+          li.appendChild(deleteBtn);
+
+          return li;
+        }
+
+        // Render tasks
+        function renderTasks() {
+          var filteredTasks = getFilteredTasks();
+
+          // Update stats
+          var totalCount = tasks.length;
+          var completedCount = tasks.filter(function (t) {
+            return t.completed;
+          }).length;
+          var activeCount = totalCount - completedCount;
+
+          document.getElementById("totalCount").textContent = totalCount;
+          document.getElementById("activeCount").textContent = activeCount;
+          document.getElementById("completedCount").textContent = completedCount;
+
+          // Clear list
+          taskList.textContent = "";
+
+          // Render list
+          if (filteredTasks.length === 0) {
+            var emptyState = document.createElement("li");
+            emptyState.className = "empty-state";
+
+            var icon = document.createElement("div");
+            icon.className = "icon";
+            icon.textContent = "📋";
+
+            var message = document.createElement("p");
+            message.textContent =
+              tasks.length === 0 ? "还没有任务，添加一个吧！" : "没有符合筛选条件的任务";
+
+            emptyState.appendChild(icon);
+            emptyState.appendChild(message);
+            taskList.appendChild(emptyState);
+            return;
+          }
+
+          for (var i = 0; i < filteredTasks.length; i++) {
+            taskList.appendChild(createTaskElement(filteredTasks[i]));
+          }
+        }
+
+        // Setup filters
+        function setupFilters() {
+          statusFilter.addEventListener("click", function (e) {
+            if (e.target.classList.contains("filter-btn")) {
+              var btns = statusFilter.querySelectorAll(".filter-btn");
+              for (var i = 0; i < btns.length; i++) {
+                btns[i].classList.remove("active");
               }
-            } catch (e) {
-              tasks = [];
-            }
-            renderTasks();
-          }
-
-          // Save tasks to localStorage
-          function saveTasks() {
-            localStorage.setItem(LS_KEY, JSON.stringify(tasks));
-          }
-
-          // Generate unique ID
-          function generateId() {
-            return Date.now().toString(36) + Math.random().toString(36).substr(2);
-          }
-
-          // Format date
-          function formatDate(timestamp) {
-            var date = new Date(timestamp);
-            var now = new Date();
-            var diff = now - date;
-
-            if (diff < 60000) return "刚刚";
-            if (diff < 3600000) return Math.floor(diff / 60000) + " 分钟前";
-            if (diff < 86400000) return Math.floor(diff / 3600000) + " 小时前";
-            if (diff < 604800000) return Math.floor(diff / 86400000) + " 天前";
-
-            var y = date.getFullYear();
-            var m = String(date.getMonth() + 1).padStart(2, "0");
-            var d = String(date.getDate()).padStart(2, "0");
-            return y + "/" + m + "/" + d;
-          }
-
-          // Show toast
-          function showToast(msg) {
-            toastEl.textContent = msg;
-            toastEl.classList.add("show");
-            setTimeout(function () {
-              toastEl.classList.remove("show");
-            }, 2000);
-          }
-
-          // Add new task
-          function addTask(e) {
-            e.preventDefault();
-            var title = taskInput.value.trim();
-            var priority = prioritySelect.value;
-
-            if (!title) {
-              showToast("请输入任务内容");
-              return;
-            }
-
-            var task = {
-              id: generateId(),
-              title: title,
-              priority: priority,
-              completed: false,
-              createdAt: Date.now()
-            };
-
-            tasks.unshift(task);
-            saveTasks();
-            renderTasks();
-            taskInput.value = "";
-            showToast("任务已添加");
-          }
-
-          // Toggle task completion
-          function toggleTask(id) {
-            for (var i = 0; i < tasks.length; i++) {
-              if (tasks[i].id === id) {
-                tasks[i].completed = !tasks[i].completed;
-                break;
-              }
-            }
-            saveTasks();
-            renderTasks();
-          }
-
-          // Delete task
-          function deleteTask(id) {
-            tasks = tasks.filter(function (t) {
-              return t.id !== id;
-            });
-            saveTasks();
-            renderTasks();
-            showToast("任务已删除");
-          }
-
-          // Clear completed tasks
-          function clearCompleted() {
-            var completedCount = tasks.filter(function (t) {
-              return t.completed;
-            }).length;
-            if (completedCount === 0) {
-              showToast("没有已完成的任务");
-              return;
-            }
-            tasks = tasks.filter(function (t) {
-              return !t.completed;
-            });
-            saveTasks();
-            renderTasks();
-            showToast("已清除 " + completedCount + " 个已完成任务");
-          }
-
-          // Clear all tasks
-          function clearAll() {
-            if (tasks.length === 0) {
-              showToast("任务列表为空");
-              return;
-            }
-            if (confirm("确定要清空所有任务吗？")) {
-              tasks = [];
-              saveTasks();
+              e.target.classList.add("active");
+              currentStatusFilter = e.target.dataset.filter;
               renderTasks();
-              showToast("已清空所有任务");
-            }
-          }
-
-          // Filter tasks
-          function getFilteredTasks() {
-            return tasks.filter(function (task) {
-              var statusMatch =
-                currentStatusFilter === "all" ||
-                (currentStatusFilter === "active" && !task.completed) ||
-                (currentStatusFilter === "completed" && task.completed);
-
-              var priorityMatch =
-                currentPriorityFilter === "all" || task.priority === currentPriorityFilter;
-
-              return statusMatch && priorityMatch;
-            });
-          }
-
-          // Create task element
-          function createTaskElement(task) {
-            var li = document.createElement("li");
-            li.className = "task-item" + (task.completed ? " completed" : "");
-
-            // Checkbox
-            var checkbox = document.createElement("div");
-            checkbox.className = "task-checkbox" + (task.completed ? " checked" : "");
-            checkbox.addEventListener("click", function () {
-              toggleTask(task.id);
-            });
-
-            // Priority indicator
-            var indicator = document.createElement("div");
-            indicator.className = "priority-indicator " + task.priority;
-
-            // Content container
-            var content = document.createElement("div");
-            content.className = "task-content";
-
-            // Title
-            var title = document.createElement("div");
-            title.className = "task-title";
-            title.textContent = task.title;
-
-            // Meta
-            var meta = document.createElement("div");
-            meta.className = "task-meta";
-
-            var badge = document.createElement("span");
-            badge.className = "priority-badge " + task.priority;
-            badge.textContent = priorityLabels[task.priority];
-
-            var dateSpan = document.createElement("span");
-            dateSpan.textContent = formatDate(task.createdAt);
-
-            meta.appendChild(badge);
-            meta.appendChild(dateSpan);
-
-            content.appendChild(title);
-            content.appendChild(meta);
-
-            // Delete button
-            var deleteBtn = document.createElement("button");
-            deleteBtn.className = "delete-btn";
-            deleteBtn.title = "删除";
-            deleteBtn.textContent = "✕";
-            deleteBtn.addEventListener("click", function () {
-              deleteTask(task.id);
-            });
-
-            li.appendChild(checkbox);
-            li.appendChild(indicator);
-            li.appendChild(content);
-            li.appendChild(deleteBtn);
-
-            return li;
-          }
-
-          // Render tasks
-          function renderTasks() {
-            var filteredTasks = getFilteredTasks();
-
-            // Update stats
-            var totalCount = tasks.length;
-            var completedCount = tasks.filter(function (t) {
-              return t.completed;
-            }).length;
-            var activeCount = totalCount - completedCount;
-
-            document.getElementById("totalCount").textContent = totalCount;
-            document.getElementById("activeCount").textContent = activeCount;
-            document.getElementById("completedCount").textContent = completedCount;
-
-            // Clear list
-            taskList.textContent = "";
-
-            // Render list
-            if (filteredTasks.length === 0) {
-              var emptyState = document.createElement("li");
-              emptyState.className = "empty-state";
-
-              var icon = document.createElement("div");
-              icon.className = "icon";
-              icon.textContent = "📋";
-
-              var message = document.createElement("p");
-              message.textContent =
-                tasks.length === 0 ? "还没有任务，添加一个吧！" : "没有符合筛选条件的任务";
-
-              emptyState.appendChild(icon);
-              emptyState.appendChild(message);
-              taskList.appendChild(emptyState);
-              return;
-            }
-
-            for (var i = 0; i < filteredTasks.length; i++) {
-              taskList.appendChild(createTaskElement(filteredTasks[i]));
-            }
-          }
-
-          // Setup filters
-          function setupFilters() {
-            statusFilter.addEventListener("click", function (e) {
-              if (e.target.classList.contains("filter-btn")) {
-                var btns = statusFilter.querySelectorAll(".filter-btn");
-                for (var i = 0; i < btns.length; i++) {
-                  btns[i].classList.remove("active");
-                }
-                e.target.classList.add("active");
-                currentStatusFilter = e.target.dataset.filter;
-                renderTasks();
-              }
-            });
-
-            priorityFilterEl.addEventListener("click", function (e) {
-              if (e.target.classList.contains("filter-btn")) {
-                var btns = priorityFilterEl.querySelectorAll(".filter-btn");
-                for (var i = 0; i < btns.length; i++) {
-                  btns[i].classList.remove("active");
-                }
-                e.target.classList.add("active");
-                currentPriorityFilter = e.target.dataset.filter;
-                renderTasks();
-              }
-            });
-          }
-
-          // Event listeners
-          addTaskForm.addEventListener("submit", addTask);
-          document.getElementById("clearCompletedBtn").addEventListener("click", clearCompleted);
-          document.getElementById("clearAllBtn").addEventListener("click", clearAll);
-
-          // Keyboard shortcut
-          document.addEventListener("keydown", function (e) {
-            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-              if (document.activeElement === taskInput && taskInput.value.trim()) {
-                addTask(e);
-              }
             }
           });
 
-          // Initialize
-          loadTasks();
-          setupFilters();
-        })();
-</script>
-    
+          priorityFilterEl.addEventListener("click", function (e) {
+            if (e.target.classList.contains("filter-btn")) {
+              var btns = priorityFilterEl.querySelectorAll(".filter-btn");
+              for (var i = 0; i < btns.length; i++) {
+                btns[i].classList.remove("active");
+              }
+              e.target.classList.add("active");
+              currentPriorityFilter = e.target.dataset.filter;
+              renderTasks();
+            }
+          });
+        }
+
+        // Event listeners
+        addTaskForm.addEventListener("submit", addTask);
+        document.getElementById("clearCompletedBtn").addEventListener("click", clearCompleted);
+        document.getElementById("clearAllBtn").addEventListener("click", clearAll);
+
+        // Keyboard shortcut
+        document.addEventListener("keydown", function (e) {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            if (document.activeElement === taskInput && taskInput.value.trim()) {
+              addTask(e);
+            }
+          }
+        });
+
+        // Initialize
+        loadTasks();
+        setupFilters();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/realestate/loan-compare.html
+++ b/tools/realestate/loan-compare.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="贷款对比 商贷 公积金 利率" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/realestate/loan-compare.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/realestate/loan-compare.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="贷款方案对比 - WebUtils" />
     <meta property="og:description" content="对比不同贷款方案的成本" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/realestate/loan-compare.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/realestate/loan-compare.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "房产工具",
-      "item": "https://tools.realtime-ai.chat/tools/realestate/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "贷款方案对比",
-      "item": "https://tools.realtime-ai.chat/tools/realestate/loan-compare.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "房产工具",
+            "item": "https://tools.realtime-ai.chat/tools/realestate/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "贷款方案对比",
+            "item": "https://tools.realtime-ai.chat/tools/realestate/loan-compare.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "贷款方案对比 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "贷款方案对比 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1170 +94,1174 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg: #0a0a0f;
-    --card: #12121a;
-    --border: #2a2a3a;
-    --text: #fff;
-    --text2: #888;
-    --accent: #6366f1;
-    --accent2: #f59e0b;
-    --success: #10b981;
-    --danger: #ef4444;
-  }
-  body {
-    font-family:
-      system-ui,
-      -apple-system,
-      sans-serif;
-    font-size: 16px;
-    line-height: 1.6;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .container {
-    max-width: 1000px;
-    margin: 0 auto;
-  }
-  .back-link {
-    display: inline-block;
-    margin-bottom: 16px;
-    color: var(--accent-cyan);
-    text-decoration: none;
-    font-size: 0.9rem;
-  }
-  .back-link:hover {
-    text-decoration: underline;
-  }
-  h1 {
-    text-align: center;
-    margin-bottom: 8px;
-    font-size: 1.8rem;
-  }
-  .subtitle {
-    text-align: center;
-    color: var(--text-secondary);
-    margin-bottom: 24px;
-  }
-  .card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 20px;
-  }
-  .card-title {
-    font-size: 1rem;
-    color: var(--text-secondary);
-    margin-bottom: 16px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .form-group {
-    margin-bottom: 16px;
-  }
-  .form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-  }
-  input,
-  select {
-    width: 100%;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    font-size: 1rem;
-  }
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-  }
-  .input-group {
-    display: flex;
-    gap: 8px;
-  }
-  .input-group input {
-    flex: 1;
-  }
-  .input-group .unit {
-    padding: 12px 16px;
-    background: var(--border-subtle);
-    border-radius: 8px;
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    display: flex;
-    align-items: center;
-    min-width: 50px;
-    justify-content: center;
-  }
-  .plans-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
-    margin-bottom: 20px;
-  }
-  .plan-card {
-    background: var(--bg-card);
-    border: 2px solid var(--border-subtle);
-    border-radius: 12px;
-    padding: 20px;
-    position: relative;
-    transition: all 0.2s;
-  }
-  .plan-card.best {
-    border-color: var(--accent-green);
-  }
-  .plan-card.best::before {
-    content: "推荐";
-    position: absolute;
-    top: -10px;
-    right: 16px;
-    background: var(--accent-green);
-    color: white;
-    padding: 2px 12px;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    font-weight: 600;
-  }
-  .plan-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .plan-name {
-    font-weight: 600;
-    font-size: 1.1rem;
-  }
-  .plan-type {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    background: var(--bg-deep);
-    padding: 4px 8px;
-    border-radius: 4px;
-  }
-  .plan-row {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px 0;
-    font-size: 0.9rem;
-  }
-  .plan-row .label {
-    color: var(--text-secondary);
-  }
-  .plan-row .value {
-    font-weight: 500;
-  }
-  .plan-row.highlight {
-    background: rgba(99, 102, 241, 0.1);
-    margin: 0 -12px;
-    padding: 8px 12px;
-    border-radius: 6px;
-  }
-  .plan-row.highlight .value {
-    color: var(--accent-cyan);
-    font-weight: 600;
-  }
-  .remove-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    padding: 4px 8px;
-    font-size: 1.2rem;
-    line-height: 1;
-    border-radius: 4px;
-    transition: all 0.2s;
-  }
-  .remove-btn:hover {
-    background: var(--accent-red);
-    color: white;
-  }
-  .add-plan-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    width: 100%;
-    padding: 40px 20px;
-    background: var(--bg-deep);
-    border: 2px dashed var(--border-subtle);
-    border-radius: 12px;
-    color: var(--text-secondary);
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
-  }
-  .add-plan-btn:hover {
-    border-color: var(--accent-cyan);
-    color: var(--accent-cyan);
-  }
-  .chart-container {
-    margin-top: 24px;
-  }
-  .chart-title {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-    margin-bottom: 12px;
-  }
-  .bar-chart {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-  .bar-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .bar-label {
-    width: 80px;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    text-align: right;
-    flex-shrink: 0;
-  }
-  .bar-track {
-    flex: 1;
-    height: 28px;
-    background: var(--bg-deep);
-    border-radius: 6px;
-    overflow: hidden;
-    position: relative;
-  }
-  .bar-fill {
-    height: 100%;
-    border-radius: 6px;
-    transition: width 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding-right: 8px;
-  }
-  .bar-value {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: white;
-    white-space: nowrap;
-  }
-  .legend {
-    display: flex;
-    gap: 20px;
-    margin-top: 16px;
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-  }
-  .legend-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
-  }
-  .summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-    margin-top: 20px;
-  }
-  .summary-card {
-    background: var(--bg-deep);
-    border-radius: 8px;
-    padding: 16px;
-    text-align: center;
-  }
-  .summary-card .title {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    margin-bottom: 8px;
-  }
-  .summary-card .value {
-    font-size: 1.3rem;
-    font-weight: 700;
-  }
-  .summary-card.best .value {
-    color: var(--accent-green);
-  }
-  .quick-btns {
-    display: flex;
-    gap: 8px;
-    margin-top: 8px;
-    flex-wrap: wrap;
-  }
-  .quick-btn {
-    padding: 6px 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 4px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: 0.8rem;
-    transition: all 0.2s;
-  }
-  .quick-btn:hover {
-    border-color: var(--accent-cyan);
-    background: var(--accent-cyan);
-    color: white;
-  }
-  .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-    opacity: 0;
-    visibility: hidden;
-    transition: all 0.2s;
-  }
-  .modal-overlay.show {
-    opacity: 1;
-    visibility: visible;
-  }
-  .modal {
-    background: var(--bg-card);
-    border-radius: 12px;
-    padding: 24px;
-    width: 90%;
-    max-width: 400px;
-    transform: scale(0.9);
-    transition: transform 0.2s;
-  }
-  .modal-overlay.show .modal {
-    transform: scale(1);
-  }
-  .modal-title {
-    font-size: 1.2rem;
-    margin-bottom: 20px;
-  }
-  .modal-btns {
-    display: flex;
-    gap: 12px;
-    margin-top: 20px;
-  }
-  .modal-btn {
-    flex: 1;
-    padding: 12px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 8px;
-    background: var(--bg-deep);
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
-  }
-  .modal-btn.primary {
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-    color: white;
-  }
-  .modal-btn:hover {
-    opacity: 0.9;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0a0f;
+        --card: #12121a;
+        --border: #2a2a3a;
+        --text: #fff;
+        --text2: #888;
+        --accent: #6366f1;
+        --accent2: #f59e0b;
+        --success: #10b981;
+        --danger: #ef4444;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        min-height: 100vh;
+        padding: 20px;
+      }
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+      .back-link {
+        display: inline-block;
+        margin-bottom: 16px;
+        color: var(--accent-cyan);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        text-decoration: underline;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 8px;
+        font-size: 1.8rem;
+      }
+      .subtitle {
+        text-align: center;
+        color: var(--text-secondary);
+        margin-bottom: 24px;
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 24px;
+        margin-bottom: 20px;
+      }
+      .card-title {
+        font-size: 1rem;
+        color: var(--text-secondary);
+        margin-bottom: 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .form-group {
+        margin-bottom: 16px;
+      }
+      .form-group label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+      }
+      input,
+      select {
+        width: 100%;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+      }
+      .input-group {
+        display: flex;
+        gap: 8px;
+      }
+      .input-group input {
+        flex: 1;
+      }
+      .input-group .unit {
+        padding: 12px 16px;
+        background: var(--border-subtle);
+        border-radius: 8px;
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        display: flex;
+        align-items: center;
+        min-width: 50px;
+        justify-content: center;
+      }
+      .plans-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 16px;
+        margin-bottom: 20px;
+      }
+      .plan-card {
+        background: var(--bg-card);
+        border: 2px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 20px;
+        position: relative;
+        transition: all 0.2s;
+      }
+      .plan-card.best {
+        border-color: var(--accent-green);
+      }
+      .plan-card.best::before {
+        content: "推荐";
+        position: absolute;
+        top: -10px;
+        right: 16px;
+        background: var(--accent-green);
+        color: white;
+        padding: 2px 12px;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .plan-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .plan-name {
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+      .plan-type {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        background: var(--bg-deep);
+        padding: 4px 8px;
+        border-radius: 4px;
+      }
+      .plan-row {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        font-size: 0.9rem;
+      }
+      .plan-row .label {
+        color: var(--text-secondary);
+      }
+      .plan-row .value {
+        font-weight: 500;
+      }
+      .plan-row.highlight {
+        background: rgba(99, 102, 241, 0.1);
+        margin: 0 -12px;
+        padding: 8px 12px;
+        border-radius: 6px;
+      }
+      .plan-row.highlight .value {
+        color: var(--accent-cyan);
+        font-weight: 600;
+      }
+      .remove-btn {
+        background: transparent;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        padding: 4px 8px;
+        font-size: 1.2rem;
+        line-height: 1;
+        border-radius: 4px;
+        transition: all 0.2s;
+      }
+      .remove-btn:hover {
+        background: var(--accent-red);
+        color: white;
+      }
+      .add-plan-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        width: 100%;
+        padding: 40px 20px;
+        background: var(--bg-deep);
+        border: 2px dashed var(--border-subtle);
+        border-radius: 12px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        font-size: 1rem;
+        transition: all 0.2s;
+      }
+      .add-plan-btn:hover {
+        border-color: var(--accent-cyan);
+        color: var(--accent-cyan);
+      }
+      .chart-container {
+        margin-top: 24px;
+      }
+      .chart-title {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        margin-bottom: 12px;
+      }
+      .bar-chart {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .bar-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .bar-label {
+        width: 80px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+        text-align: right;
+        flex-shrink: 0;
+      }
+      .bar-track {
+        flex: 1;
+        height: 28px;
+        background: var(--bg-deep);
+        border-radius: 6px;
+        overflow: hidden;
+        position: relative;
+      }
+      .bar-fill {
+        height: 100%;
+        border-radius: 6px;
+        transition: width 0.3s ease;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding-right: 8px;
+      }
+      .bar-value {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: white;
+        white-space: nowrap;
+      }
+      .legend {
+        display: flex;
+        gap: 20px;
+        margin-top: 16px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+      .legend-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+      }
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin-top: 20px;
+      }
+      .summary-card {
+        background: var(--bg-deep);
+        border-radius: 8px;
+        padding: 16px;
+        text-align: center;
+      }
+      .summary-card .title {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        margin-bottom: 8px;
+      }
+      .summary-card .value {
+        font-size: 1.3rem;
+        font-weight: 700;
+      }
+      .summary-card.best .value {
+        color: var(--accent-green);
+      }
+      .quick-btns {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+        flex-wrap: wrap;
+      }
+      .quick-btn {
+        padding: 6px 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 4px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 0.8rem;
+        transition: all 0.2s;
+      }
+      .quick-btn:hover {
+        border-color: var(--accent-cyan);
+        background: var(--accent-cyan);
+        color: white;
+      }
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.7);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: all 0.2s;
+      }
+      .modal-overlay.show {
+        opacity: 1;
+        visibility: visible;
+      }
+      .modal {
+        background: var(--bg-card);
+        border-radius: 12px;
+        padding: 24px;
+        width: 90%;
+        max-width: 400px;
+        transform: scale(0.9);
+        transition: transform 0.2s;
+      }
+      .modal-overlay.show .modal {
+        transform: scale(1);
+      }
+      .modal-title {
+        font-size: 1.2rem;
+        margin-bottom: 20px;
+      }
+      .modal-btns {
+        display: flex;
+        gap: 12px;
+        margin-top: 20px;
+      }
+      .modal-btn {
+        flex: 1;
+        padding: 12px;
+        border: 1px solid var(--border-subtle);
+        border-radius: 8px;
+        background: var(--bg-deep);
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 1rem;
+        transition: all 0.2s;
+      }
+      .modal-btn.primary {
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+        color: white;
+      }
+      .modal-btn:hover {
+        opacity: 0.9;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <h1>📊 贷款方案对比</h1>
-  <p class="subtitle">对比不同贷款方案，找到最优选择</p>
+        <h1>📊 贷款方案对比</h1>
+        <p class="subtitle">对比不同贷款方案，找到最优选择</p>
 
-  <div class="plans-grid" id="plansGrid"></div>
+        <div class="plans-grid" id="plansGrid"></div>
 
-  <div class="card">
-    <div class="card-title">对比分析</div>
+        <div class="card">
+          <div class="card-title">对比分析</div>
 
-    <div class="chart-container">
-      <div class="chart-title">月供对比</div>
-      <div class="bar-chart" id="monthlyChart"></div>
-    </div>
+          <div class="chart-container">
+            <div class="chart-title">月供对比</div>
+            <div class="bar-chart" id="monthlyChart"></div>
+          </div>
 
-    <div class="chart-container">
-      <div class="chart-title">总利息对比</div>
-      <div class="bar-chart" id="interestChart"></div>
-    </div>
+          <div class="chart-container">
+            <div class="chart-title">总利息对比</div>
+            <div class="bar-chart" id="interestChart"></div>
+          </div>
 
-    <div class="legend">
-      <div class="legend-item">
-        <div class="legend-dot" style="background: #6366f1"></div>
-        方案一
-      </div>
-      <div class="legend-item">
-        <div class="legend-dot" style="background: #f59e0b"></div>
-        方案二
-      </div>
-      <div class="legend-item">
-        <div class="legend-dot" style="background: #10b981"></div>
-        方案三
-      </div>
-      <div class="legend-item">
-        <div class="legend-dot" style="background: #ec4899"></div>
-        方案四
-      </div>
-    </div>
+          <div class="legend">
+            <div class="legend-item">
+              <div class="legend-dot" style="background: #6366f1"></div>
+              方案一
+            </div>
+            <div class="legend-item">
+              <div class="legend-dot" style="background: #f59e0b"></div>
+              方案二
+            </div>
+            <div class="legend-item">
+              <div class="legend-dot" style="background: #10b981"></div>
+              方案三
+            </div>
+            <div class="legend-item">
+              <div class="legend-dot" style="background: #ec4899"></div>
+              方案四
+            </div>
+          </div>
 
-    <div class="summary-grid" id="summaryGrid"></div>
-  </div>
+          <div class="summary-grid" id="summaryGrid"></div>
+        </div>
 
-  <div class="modal-overlay" id="modalOverlay">
-    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
-      <div class="modal-title" id="modalTitle">贷款方案</div>
-      <div class="input-group">
-        <label for="modalName">方案名称</label>
-        <input id="modalName" type="text" />
-      </div>
-      <div class="input-group">
-        <label for="modalAmount">贷款金额（万元）</label>
-        <input id="modalAmount" type="number" min="1" step="1" />
-      </div>
-      <div class="input-group">
-        <label for="modalYears">贷款年限（年）</label>
-        <input id="modalYears" type="number" min="1" max="40" step="1" />
-      </div>
-      <div class="input-group">
-        <label for="modalRate">年利率（%）</label>
-        <input id="modalRate" type="number" min="0" step="0.01" />
-        <div class="quick-btns">
-          <button type="button" class="quick-btn" data-rate="2.85">首套 2.85%</button>
-          <button type="button" class="quick-btn" data-rate="3.1">基准 3.1%</button>
-          <button type="button" class="quick-btn" data-rate="3.55">二套 3.55%</button>
+        <div class="modal-overlay" id="modalOverlay">
+          <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+            <div class="modal-title" id="modalTitle">贷款方案</div>
+            <div class="input-group">
+              <label for="modalName">方案名称</label>
+              <input id="modalName" type="text" />
+            </div>
+            <div class="input-group">
+              <label for="modalAmount">贷款金额（万元）</label>
+              <input id="modalAmount" type="number" min="1" step="1" />
+            </div>
+            <div class="input-group">
+              <label for="modalYears">贷款年限（年）</label>
+              <input id="modalYears" type="number" min="1" max="40" step="1" />
+            </div>
+            <div class="input-group">
+              <label for="modalRate">年利率（%）</label>
+              <input id="modalRate" type="number" min="0" step="0.01" />
+              <div class="quick-btns">
+                <button type="button" class="quick-btn" data-rate="2.85">首套 2.85%</button>
+                <button type="button" class="quick-btn" data-rate="3.1">基准 3.1%</button>
+                <button type="button" class="quick-btn" data-rate="3.55">二套 3.55%</button>
+              </div>
+            </div>
+            <div class="input-group">
+              <label for="modalType">还款方式</label>
+              <select id="modalType">
+                <option value="equal-payment">等额本息</option>
+                <option value="equal-principal">等额本金</option>
+              </select>
+            </div>
+            <div class="modal-btns">
+              <button type="button" class="modal-btn" id="modalCancel">取消</button>
+              <button type="button" class="modal-btn primary" id="modalConfirm">保存</button>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="input-group">
-        <label for="modalType">还款方式</label>
-        <select id="modalType">
-          <option value="equal-payment">等额本息</option>
-          <option value="equal-principal">等额本金</option>
-        </select>
-      </div>
-      <div class="modal-btns">
-        <button type="button" class="modal-btn" id="modalCancel">取消</button>
-        <button type="button" class="modal-btn primary" id="modalConfirm">保存</button>
-      </div>
     </div>
-  </div>
-</div>
-    </div>
-    
+
     <script>
-  (function () {
-    const colors = ["#6366f1", "#f59e0b", "#10b981", "#ec4899"];
-    let plans = [
-      { id: 1, name: "等额本息30年", amount: 100, years: 30, rate: 3.1, type: "equal-payment" },
-      {
-        id: 2,
-        name: "等额本金30年",
-        amount: 100,
-        years: 30,
-        rate: 3.1,
-        type: "equal-principal"
-      }
-    ];
-    let nextId = 3;
-    let editingId = null;
-
-    const $ = (id) => document.getElementById(id);
-
-    // 格式化金额
-    function formatMoney(value) {
-      return (
-        "¥" +
-        value.toLocaleString("zh-CN", {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2
-        })
-      );
-    }
-
-    function formatWan(value) {
-      return (
-        "¥" +
-        (value / 10000).toLocaleString("zh-CN", {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2
-        }) +
-        "万"
-      );
-    }
-
-    // 等额本息计算
-    function calcEqualPayment(principal, months, monthlyRate) {
-      if (monthlyRate === 0) {
-        return {
-          monthlyPayment: principal / months,
-          totalPayment: principal,
-          totalInterest: 0
-        };
-      }
-
-      const monthlyPayment =
-        (principal * monthlyRate * Math.pow(1 + monthlyRate, months)) /
-        (Math.pow(1 + monthlyRate, months) - 1);
-      const totalPayment = monthlyPayment * months;
-      const totalInterest = totalPayment - principal;
-
-      return { monthlyPayment, totalPayment, totalInterest };
-    }
-
-    // 等额本金计算
-    function calcEqualPrincipal(principal, months, monthlyRate) {
-      const monthlyPrincipal = principal / months;
-      let totalInterest = 0;
-      let remaining = principal;
-
-      for (let i = 0; i < months; i++) {
-        totalInterest += remaining * monthlyRate;
-        remaining -= monthlyPrincipal;
-      }
-
-      const firstMonthPayment = monthlyPrincipal + principal * monthlyRate;
-      const lastMonthPayment = monthlyPrincipal + monthlyPrincipal * monthlyRate;
-
-      return {
-        monthlyPayment: firstMonthPayment,
-        lastMonthPayment: lastMonthPayment,
-        totalPayment: principal + totalInterest,
-        totalInterest: totalInterest
-      };
-    }
-
-    // 计算方案结果
-    function calcPlan(plan) {
-      const principal = plan.amount * 10000;
-      const months = plan.years * 12;
-      const monthlyRate = plan.rate / 100 / 12;
-
-      if (plan.type === "equal-payment") {
-        return calcEqualPayment(principal, months, monthlyRate);
-      } else {
-        return calcEqualPrincipal(principal, months, monthlyRate);
-      }
-    }
-
-    // 渲染方案卡片
-    function renderPlans() {
-      const grid = $("plansGrid");
-      grid.textContent = "";
-
-      // 计算所有方案结果
-      const results = plans.map((plan) => ({
-        ...plan,
-        result: calcPlan(plan)
-      }));
-
-      // 找出最优方案（总利息最少）
-      let bestId = null;
-      let minInterest = Infinity;
-      results.forEach((r) => {
-        if (r.result.totalInterest < minInterest) {
-          minInterest = r.result.totalInterest;
-          bestId = r.id;
-        }
-      });
-
-      // 渲染卡片
-      results.forEach((plan, index) => {
-        const card = document.createElement("div");
-        card.className = "plan-card" + (plan.id === bestId ? " best" : "");
-
-        const header = document.createElement("div");
-        header.className = "plan-header";
-
-        const nameSpan = document.createElement("span");
-        nameSpan.className = "plan-name";
-        nameSpan.textContent = plan.name;
-
-        const headerRight = document.createElement("div");
-        headerRight.style.display = "flex";
-        headerRight.style.alignItems = "center";
-        headerRight.style.gap = "8px";
-
-        const typeSpan = document.createElement("span");
-        typeSpan.className = "plan-type";
-        typeSpan.textContent = plan.type === "equal-payment" ? "等额本息" : "等额本金";
-
-        const removeBtn = document.createElement("button");
-        removeBtn.className = "remove-btn";
-        removeBtn.textContent = "×";
-        removeBtn.addEventListener("click", () => removePlan(plan.id));
-
-        headerRight.appendChild(typeSpan);
-        if (plans.length > 1) {
-          headerRight.appendChild(removeBtn);
-        }
-
-        header.appendChild(nameSpan);
-        header.appendChild(headerRight);
-        card.appendChild(header);
-
-        // 方案详情
-        const details = [
-          { label: "贷款金额", value: plan.amount + "万元" },
-          { label: "贷款年限", value: plan.years + "年" },
-          { label: "年利率", value: plan.rate + "%" },
-          { label: "月供", value: formatMoney(plan.result.monthlyPayment), highlight: true },
-          { label: "总利息", value: formatWan(plan.result.totalInterest) },
-          { label: "还款总额", value: formatWan(plan.result.totalPayment) }
+      (function () {
+        const colors = ["#6366f1", "#f59e0b", "#10b981", "#ec4899"];
+        let plans = [
+          { id: 1, name: "等额本息30年", amount: 100, years: 30, rate: 3.1, type: "equal-payment" },
+          {
+            id: 2,
+            name: "等额本金30年",
+            amount: 100,
+            years: 30,
+            rate: 3.1,
+            type: "equal-principal"
+          }
         ];
+        let nextId = 3;
+        let editingId = null;
 
-        if (plan.type === "equal-principal") {
-          details.splice(4, 0, {
-            label: "末月月供",
-            value: formatMoney(plan.result.lastMonthPayment)
+        const $ = (id) => document.getElementById(id);
+
+        // 格式化金额
+        function formatMoney(value) {
+          return (
+            "¥" +
+            value.toLocaleString("zh-CN", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })
+          );
+        }
+
+        function formatWan(value) {
+          return (
+            "¥" +
+            (value / 10000).toLocaleString("zh-CN", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            }) +
+            "万"
+          );
+        }
+
+        // 等额本息计算
+        function calcEqualPayment(principal, months, monthlyRate) {
+          if (monthlyRate === 0) {
+            return {
+              monthlyPayment: principal / months,
+              totalPayment: principal,
+              totalInterest: 0
+            };
+          }
+
+          const monthlyPayment =
+            (principal * monthlyRate * Math.pow(1 + monthlyRate, months)) /
+            (Math.pow(1 + monthlyRate, months) - 1);
+          const totalPayment = monthlyPayment * months;
+          const totalInterest = totalPayment - principal;
+
+          return { monthlyPayment, totalPayment, totalInterest };
+        }
+
+        // 等额本金计算
+        function calcEqualPrincipal(principal, months, monthlyRate) {
+          const monthlyPrincipal = principal / months;
+          let totalInterest = 0;
+          let remaining = principal;
+
+          for (let i = 0; i < months; i++) {
+            totalInterest += remaining * monthlyRate;
+            remaining -= monthlyPrincipal;
+          }
+
+          const firstMonthPayment = monthlyPrincipal + principal * monthlyRate;
+          const lastMonthPayment = monthlyPrincipal + monthlyPrincipal * monthlyRate;
+
+          return {
+            monthlyPayment: firstMonthPayment,
+            lastMonthPayment: lastMonthPayment,
+            totalPayment: principal + totalInterest,
+            totalInterest: totalInterest
+          };
+        }
+
+        // 计算方案结果
+        function calcPlan(plan) {
+          const principal = plan.amount * 10000;
+          const months = plan.years * 12;
+          const monthlyRate = plan.rate / 100 / 12;
+
+          if (plan.type === "equal-payment") {
+            return calcEqualPayment(principal, months, monthlyRate);
+          } else {
+            return calcEqualPrincipal(principal, months, monthlyRate);
+          }
+        }
+
+        // 渲染方案卡片
+        function renderPlans() {
+          const grid = $("plansGrid");
+          grid.textContent = "";
+
+          // 计算所有方案结果
+          const results = plans.map((plan) => ({
+            ...plan,
+            result: calcPlan(plan)
+          }));
+
+          // 找出最优方案（总利息最少）
+          let bestId = null;
+          let minInterest = Infinity;
+          results.forEach((r) => {
+            if (r.result.totalInterest < minInterest) {
+              minInterest = r.result.totalInterest;
+              bestId = r.id;
+            }
+          });
+
+          // 渲染卡片
+          results.forEach((plan, index) => {
+            const card = document.createElement("div");
+            card.className = "plan-card" + (plan.id === bestId ? " best" : "");
+
+            const header = document.createElement("div");
+            header.className = "plan-header";
+
+            const nameSpan = document.createElement("span");
+            nameSpan.className = "plan-name";
+            nameSpan.textContent = plan.name;
+
+            const headerRight = document.createElement("div");
+            headerRight.style.display = "flex";
+            headerRight.style.alignItems = "center";
+            headerRight.style.gap = "8px";
+
+            const typeSpan = document.createElement("span");
+            typeSpan.className = "plan-type";
+            typeSpan.textContent = plan.type === "equal-payment" ? "等额本息" : "等额本金";
+
+            const removeBtn = document.createElement("button");
+            removeBtn.className = "remove-btn";
+            removeBtn.textContent = "×";
+            removeBtn.addEventListener("click", () => removePlan(plan.id));
+
+            headerRight.appendChild(typeSpan);
+            if (plans.length > 1) {
+              headerRight.appendChild(removeBtn);
+            }
+
+            header.appendChild(nameSpan);
+            header.appendChild(headerRight);
+            card.appendChild(header);
+
+            // 方案详情
+            const details = [
+              { label: "贷款金额", value: plan.amount + "万元" },
+              { label: "贷款年限", value: plan.years + "年" },
+              { label: "年利率", value: plan.rate + "%" },
+              { label: "月供", value: formatMoney(plan.result.monthlyPayment), highlight: true },
+              { label: "总利息", value: formatWan(plan.result.totalInterest) },
+              { label: "还款总额", value: formatWan(plan.result.totalPayment) }
+            ];
+
+            if (plan.type === "equal-principal") {
+              details.splice(4, 0, {
+                label: "末月月供",
+                value: formatMoney(plan.result.lastMonthPayment)
+              });
+            }
+
+            details.forEach((item) => {
+              const row = document.createElement("div");
+              row.className = "plan-row" + (item.highlight ? " highlight" : "");
+
+              const label = document.createElement("span");
+              label.className = "label";
+              label.textContent = item.label;
+
+              const value = document.createElement("span");
+              value.className = "value";
+              value.textContent = item.value;
+
+              row.appendChild(label);
+              row.appendChild(value);
+              card.appendChild(row);
+            });
+
+            // 点击编辑
+            card.addEventListener("dblclick", () => editPlan(plan.id));
+
+            grid.appendChild(card);
+          });
+
+          // 添加按钮
+          if (plans.length < 4) {
+            const addBtn = document.createElement("button");
+            addBtn.className = "add-plan-btn";
+            addBtn.textContent = "+ 添加方案";
+            addBtn.addEventListener("click", () => showModal());
+            grid.appendChild(addBtn);
+          }
+
+          // 更新图表
+          renderCharts(results);
+          renderSummary(results, bestId);
+        }
+
+        // 渲染图表
+        function renderCharts(results) {
+          // 月供图表
+          const monthlyChart = $("monthlyChart");
+          monthlyChart.textContent = "";
+
+          const maxMonthly = Math.max(...results.map((r) => r.result.monthlyPayment));
+
+          results.forEach((plan, index) => {
+            const item = document.createElement("div");
+            item.className = "bar-item";
+
+            const label = document.createElement("div");
+            label.className = "bar-label";
+            label.textContent = plan.name.substring(0, 6);
+
+            const track = document.createElement("div");
+            track.className = "bar-track";
+
+            const fill = document.createElement("div");
+            fill.className = "bar-fill";
+            fill.style.width = (plan.result.monthlyPayment / maxMonthly) * 100 + "%";
+            fill.style.background = colors[index % colors.length];
+
+            const value = document.createElement("span");
+            value.className = "bar-value";
+            value.textContent = formatMoney(plan.result.monthlyPayment);
+
+            fill.appendChild(value);
+            track.appendChild(fill);
+            item.appendChild(label);
+            item.appendChild(track);
+            monthlyChart.appendChild(item);
+          });
+
+          // 利息图表
+          const interestChart = $("interestChart");
+          interestChart.textContent = "";
+
+          const maxInterest = Math.max(...results.map((r) => r.result.totalInterest));
+
+          results.forEach((plan, index) => {
+            const item = document.createElement("div");
+            item.className = "bar-item";
+
+            const label = document.createElement("div");
+            label.className = "bar-label";
+            label.textContent = plan.name.substring(0, 6);
+
+            const track = document.createElement("div");
+            track.className = "bar-track";
+
+            const fill = document.createElement("div");
+            fill.className = "bar-fill";
+            fill.style.width = (plan.result.totalInterest / maxInterest) * 100 + "%";
+            fill.style.background = colors[index % colors.length];
+
+            const value = document.createElement("span");
+            value.className = "bar-value";
+            value.textContent = formatWan(plan.result.totalInterest);
+
+            fill.appendChild(value);
+            track.appendChild(fill);
+            item.appendChild(label);
+            item.appendChild(track);
+            interestChart.appendChild(item);
           });
         }
 
-        details.forEach((item) => {
-          const row = document.createElement("div");
-          row.className = "plan-row" + (item.highlight ? " highlight" : "");
+        // 渲染汇总
+        function renderSummary(results, bestId) {
+          const grid = $("summaryGrid");
+          grid.textContent = "";
 
-          const label = document.createElement("span");
-          label.className = "label";
-          label.textContent = item.label;
+          if (results.length < 2) return;
 
-          const value = document.createElement("span");
-          value.className = "value";
-          value.textContent = item.value;
+          const bestPlan = results.find((r) => r.id === bestId);
+          const worstInterest = Math.max(...results.map((r) => r.result.totalInterest));
+          const savedInterest = worstInterest - bestPlan.result.totalInterest;
 
-          row.appendChild(label);
-          row.appendChild(value);
-          card.appendChild(row);
+          const summaries = [
+            {
+              title: "最低月供",
+              value: formatMoney(Math.min(...results.map((r) => r.result.monthlyPayment))),
+              best: true
+            },
+            { title: "最低总利息", value: formatWan(bestPlan.result.totalInterest), best: true },
+            { title: "最优方案", value: bestPlan.name, best: true },
+            { title: "可节省利息", value: formatWan(savedInterest), best: savedInterest > 0 }
+          ];
+
+          summaries.forEach((item) => {
+            const card = document.createElement("div");
+            card.className = "summary-card" + (item.best ? " best" : "");
+
+            const title = document.createElement("div");
+            title.className = "title";
+            title.textContent = item.title;
+
+            const value = document.createElement("div");
+            value.className = "value";
+            value.textContent = item.value;
+
+            card.appendChild(title);
+            card.appendChild(value);
+            grid.appendChild(card);
+          });
+        }
+
+        // 显示弹窗
+        function showModal(planId) {
+          editingId = planId || null;
+
+          if (planId) {
+            const plan = plans.find((p) => p.id === planId);
+            $("modalName").value = plan.name;
+            $("modalAmount").value = plan.amount;
+            $("modalYears").value = plan.years;
+            $("modalRate").value = plan.rate;
+            $("modalType").value = plan.type;
+          } else {
+            $("modalName").value = "方案" + nextId;
+            $("modalAmount").value = 100;
+            $("modalYears").value = 30;
+            $("modalRate").value = 3.1;
+            $("modalType").value = "equal-payment";
+          }
+
+          $("modalOverlay").classList.add("show");
+        }
+
+        // 隐藏弹窗
+        function hideModal() {
+          $("modalOverlay").classList.remove("show");
+          editingId = null;
+        }
+
+        // 添加/编辑方案
+        function savePlan() {
+          const name = $("modalName").value.trim() || "方案";
+          const amount = parseFloat($("modalAmount").value) || 100;
+          const years = parseInt($("modalYears").value) || 30;
+          const rate = parseFloat($("modalRate").value) || 3.1;
+          const type = $("modalType").value;
+
+          if (editingId) {
+            const plan = plans.find((p) => p.id === editingId);
+            plan.name = name;
+            plan.amount = amount;
+            plan.years = years;
+            plan.rate = rate;
+            plan.type = type;
+          } else {
+            plans.push({
+              id: nextId++,
+              name: name,
+              amount: amount,
+              years: years,
+              rate: rate,
+              type: type
+            });
+          }
+
+          hideModal();
+          renderPlans();
+        }
+
+        // 删除方案
+        function removePlan(id) {
+          plans = plans.filter((p) => p.id !== id);
+          renderPlans();
+        }
+
+        // 编辑方案
+        function editPlan(id) {
+          showModal(id);
+        }
+
+        // 事件绑定
+        $("modalCancel")?.addEventListener("click", hideModal);
+        $("modalConfirm")?.addEventListener("click", savePlan);
+        $("modalOverlay")?.addEventListener("click", function (e) {
+          if (e.target === this) hideModal();
         });
 
-        // 点击编辑
-        card.addEventListener("dblclick", () => editPlan(plan.id));
-
-        grid.appendChild(card);
-      });
-
-      // 添加按钮
-      if (plans.length < 4) {
-        const addBtn = document.createElement("button");
-        addBtn.className = "add-plan-btn";
-        addBtn.textContent = "+ 添加方案";
-        addBtn.addEventListener("click", () => showModal());
-        grid.appendChild(addBtn);
-      }
-
-      // 更新图表
-      renderCharts(results);
-      renderSummary(results, bestId);
-    }
-
-    // 渲染图表
-    function renderCharts(results) {
-      // 月供图表
-      const monthlyChart = $("monthlyChart");
-      monthlyChart.textContent = "";
-
-      const maxMonthly = Math.max(...results.map((r) => r.result.monthlyPayment));
-
-      results.forEach((plan, index) => {
-        const item = document.createElement("div");
-        item.className = "bar-item";
-
-        const label = document.createElement("div");
-        label.className = "bar-label";
-        label.textContent = plan.name.substring(0, 6);
-
-        const track = document.createElement("div");
-        track.className = "bar-track";
-
-        const fill = document.createElement("div");
-        fill.className = "bar-fill";
-        fill.style.width = (plan.result.monthlyPayment / maxMonthly) * 100 + "%";
-        fill.style.background = colors[index % colors.length];
-
-        const value = document.createElement("span");
-        value.className = "bar-value";
-        value.textContent = formatMoney(plan.result.monthlyPayment);
-
-        fill.appendChild(value);
-        track.appendChild(fill);
-        item.appendChild(label);
-        item.appendChild(track);
-        monthlyChart.appendChild(item);
-      });
-
-      // 利息图表
-      const interestChart = $("interestChart");
-      interestChart.textContent = "";
-
-      const maxInterest = Math.max(...results.map((r) => r.result.totalInterest));
-
-      results.forEach((plan, index) => {
-        const item = document.createElement("div");
-        item.className = "bar-item";
-
-        const label = document.createElement("div");
-        label.className = "bar-label";
-        label.textContent = plan.name.substring(0, 6);
-
-        const track = document.createElement("div");
-        track.className = "bar-track";
-
-        const fill = document.createElement("div");
-        fill.className = "bar-fill";
-        fill.style.width = (plan.result.totalInterest / maxInterest) * 100 + "%";
-        fill.style.background = colors[index % colors.length];
-
-        const value = document.createElement("span");
-        value.className = "bar-value";
-        value.textContent = formatWan(plan.result.totalInterest);
-
-        fill.appendChild(value);
-        track.appendChild(fill);
-        item.appendChild(label);
-        item.appendChild(track);
-        interestChart.appendChild(item);
-      });
-    }
-
-    // 渲染汇总
-    function renderSummary(results, bestId) {
-      const grid = $("summaryGrid");
-      grid.textContent = "";
-
-      if (results.length < 2) return;
-
-      const bestPlan = results.find((r) => r.id === bestId);
-      const worstInterest = Math.max(...results.map((r) => r.result.totalInterest));
-      const savedInterest = worstInterest - bestPlan.result.totalInterest;
-
-      const summaries = [
-        {
-          title: "最低月供",
-          value: formatMoney(Math.min(...results.map((r) => r.result.monthlyPayment))),
-          best: true
-        },
-        { title: "最低总利息", value: formatWan(bestPlan.result.totalInterest), best: true },
-        { title: "最优方案", value: bestPlan.name, best: true },
-        { title: "可节省利息", value: formatWan(savedInterest), best: savedInterest > 0 }
-      ];
-
-      summaries.forEach((item) => {
-        const card = document.createElement("div");
-        card.className = "summary-card" + (item.best ? " best" : "");
-
-        const title = document.createElement("div");
-        title.className = "title";
-        title.textContent = item.title;
-
-        const value = document.createElement("div");
-        value.className = "value";
-        value.textContent = item.value;
-
-        card.appendChild(title);
-        card.appendChild(value);
-        grid.appendChild(card);
-      });
-    }
-
-    // 显示弹窗
-    function showModal(planId) {
-      editingId = planId || null;
-
-      if (planId) {
-        const plan = plans.find((p) => p.id === planId);
-        $("modalName").value = plan.name;
-        $("modalAmount").value = plan.amount;
-        $("modalYears").value = plan.years;
-        $("modalRate").value = plan.rate;
-        $("modalType").value = plan.type;
-      } else {
-        $("modalName").value = "方案" + nextId;
-        $("modalAmount").value = 100;
-        $("modalYears").value = 30;
-        $("modalRate").value = 3.1;
-        $("modalType").value = "equal-payment";
-      }
-
-      $("modalOverlay").classList.add("show");
-    }
-
-    // 隐藏弹窗
-    function hideModal() {
-      $("modalOverlay").classList.remove("show");
-      editingId = null;
-    }
-
-    // 添加/编辑方案
-    function savePlan() {
-      const name = $("modalName").value.trim() || "方案";
-      const amount = parseFloat($("modalAmount").value) || 100;
-      const years = parseInt($("modalYears").value) || 30;
-      const rate = parseFloat($("modalRate").value) || 3.1;
-      const type = $("modalType").value;
-
-      if (editingId) {
-        const plan = plans.find((p) => p.id === editingId);
-        plan.name = name;
-        plan.amount = amount;
-        plan.years = years;
-        plan.rate = rate;
-        plan.type = type;
-      } else {
-        plans.push({
-          id: nextId++,
-          name: name,
-          amount: amount,
-          years: years,
-          rate: rate,
-          type: type
+        // 快捷利率按钮
+        document.querySelectorAll(".quick-btn[data-rate]").forEach((btn) => {
+          btn.addEventListener("click", function () {
+            $("modalRate").value = this.dataset.rate;
+          });
         });
+
+        // 初始化
+        renderPlans();
+      })();
+
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        const icon = document.getElementById("theme-icon");
+        if (icon) icon.textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
       }
 
-      hideModal();
-      renderPlans();
-    }
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        const icon = document.getElementById("theme-icon");
+        if (icon) icon.textContent = "☀️";
+      }
+    </script>
 
-    // 删除方案
-    function removePlan(id) {
-      plans = plans.filter((p) => p.id !== id);
-      renderPlans();
-    }
-
-    // 编辑方案
-    function editPlan(id) {
-      showModal(id);
-    }
-
-    // 事件绑定
-    $("modalCancel")?.addEventListener("click", hideModal);
-    $("modalConfirm")?.addEventListener("click", savePlan);
-    $("modalOverlay")?.addEventListener("click", function (e) {
-      if (e.target === this) hideModal();
-    });
-
-    // 快捷利率按钮
-    document.querySelectorAll(".quick-btn[data-rate]").forEach((btn) => {
-      btn.addEventListener("click", function () {
-        $("modalRate").value = this.dataset.rate;
-      });
-    });
-
-    // 初始化
-    renderPlans();
-  })();
-
-  // Theme toggle
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme");
-    const newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    const icon = document.getElementById("theme-icon");
-    if (icon) icon.textContent = newTheme === "light" ? "☀️" : "🌙";
-    localStorage.setItem("theme", newTheme);
-  }
-
-  // Load saved theme
-  const savedTheme = localStorage.getItem("theme") || "dark";
-  if (savedTheme === "light") {
-    document.documentElement.setAttribute("data-theme", "light");
-    const icon = document.getElementById("theme-icon");
-    if (icon) icon.textContent = "☀️";
-  }
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/security/hash-generator.html
+++ b/tools/security/hash-generator.html
@@ -10,13 +10,19 @@
     <meta name="keywords" content="hash md5 sha 哈希 加密 摘要" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/security/hash-generator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/security/hash-generator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="哈希生成器 - WebUtils" />
     <meta property="og:description" content="计算文本或文件的哈希值" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/security/hash-generator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/security/hash-generator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +47,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "安全工具",
-      "item": "https://tools.realtime-ai.chat/tools/security/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "哈希生成器",
-      "item": "https://tools.realtime-ai.chat/tools/security/hash-generator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "安全工具",
+            "item": "https://tools.realtime-ai.chat/tools/security/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "哈希生成器",
+            "item": "https://tools.realtime-ai.chat/tools/security/hash-generator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "哈希生成器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "哈希生成器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,700 +94,713 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg-primary: #0a0a0f;
-    --bg-secondary: #12121a;
-    --bg-tertiary: #1a1a25;
-    --color-text-primary: #fff;
-    --color-text-secondary: #88a;
-    --accent: #6366f1;
-    --border: #2a2a3a;
-    --success: #22c55e;
-  }
-  [data-theme="light"] {
-    --bg-primary: #f8fafc;
-    --bg-secondary: #fff;
-    --bg-tertiary: #f1f5f9;
-    --color-text-primary: #1e293b;
-    --color-text-secondary: #64748b;
-    --border: #e2e8f0;
-  }
-  body {
-    font-family: var(--font-sans);
-    font-size: 16px;
-    line-height: 1.6;
-    background: var(--bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-  }
-  .header {
-    background: linear-gradient(135deg, #10b981, #059669);
-    padding: 2rem;
-    text-align: center;
-  }
-  .header h1 {
-    font-size: 1.8rem;
-    margin-bottom: 0.5rem;
-  }
-  .nav {
-    display: flex;
-    justify-content: space-between;
-    max-width: 1200px;
-    margin: 0 auto 1rem;
-  }
-  .back-link {
-    color: rgba(255, 255, 255, 0.9);
-    text-decoration: none;
-  }
-  .theme-toggle {
-    background: rgba(255, 255, 255, 0.2);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 0.5rem;
-    color: white;
-    cursor: pointer;
-  }
-  .container {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 2rem;
-  }
-  .card {
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-subtle);
-    border-radius: 1rem;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .tabs {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .tab {
-    padding: 0.75rem 1.5rem;
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.5rem;
-    background: var(--bg-tertiary);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .tab.active {
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-    color: white;
-  }
-  .input-group {
-    margin-bottom: 1rem;
-  }
-  .input-group label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-  }
-  textarea {
-    width: 100%;
-    height: 120px;
-    padding: 1rem;
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.5rem;
-    background: var(--bg-tertiary);
-    color: var(--color-text-primary);
-    font-size: 1rem;
-    resize: vertical;
-    font-family: var(--font-mono);
-  }
-  .file-drop {
-    border: 2px dashed var(--border-subtle);
-    border-radius: 0.5rem;
-    padding: 2rem;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .file-drop:hover,
-  .file-drop.dragover {
-    border-color: var(--accent-cyan);
-    background: rgba(99, 102, 241, 0.1);
-  }
-  .file-drop input {
-    display: none;
-  }
-  .results {
-    margin-top: 1.5rem;
-  }
-  .result-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    background: var(--bg-tertiary);
-    border-radius: 0.5rem;
-    margin-bottom: 0.5rem;
-  }
-  .result-item .algo {
-    min-width: 80px;
-    font-weight: 600;
-    color: var(--accent-cyan);
-  }
-  .result-item .hash {
-    flex: 1;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    word-break: break-all;
-  }
-  .result-item .copy-btn {
-    background: none;
-    border: none;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    padding: 0.25rem;
-  }
-  .result-item .copy-btn:hover {
-    color: var(--accent-cyan);
-  }
-  .toast {
-    position: fixed;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: white;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.5rem;
-    opacity: 0;
-    transition: all 0.3s;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  .hidden {
-    display: none;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-    max-width: 900px;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 0 2rem 2rem;
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg-primary: #0a0a0f;
+        --bg-secondary: #12121a;
+        --bg-tertiary: #1a1a25;
+        --color-text-primary: #fff;
+        --color-text-secondary: #88a;
+        --accent: #6366f1;
+        --border: #2a2a3a;
+        --success: #22c55e;
+      }
+      [data-theme="light"] {
+        --bg-primary: #f8fafc;
+        --bg-secondary: #fff;
+        --bg-tertiary: #f1f5f9;
+        --color-text-primary: #1e293b;
+        --color-text-secondary: #64748b;
+        --border: #e2e8f0;
+      }
+      body {
+        font-family: var(--font-sans);
+        font-size: 16px;
+        line-height: 1.6;
+        background: var(--bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+      }
+      .header {
+        background: linear-gradient(135deg, #10b981, #059669);
+        padding: 2rem;
+        text-align: center;
+      }
+      .header h1 {
+        font-size: 1.8rem;
+        margin-bottom: 0.5rem;
+      }
+      .nav {
+        display: flex;
+        justify-content: space-between;
+        max-width: 1200px;
+        margin: 0 auto 1rem;
+      }
+      .back-link {
+        color: rgba(255, 255, 255, 0.9);
+        text-decoration: none;
+      }
+      .theme-toggle {
+        background: rgba(255, 255, 255, 0.2);
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
+        color: white;
+        cursor: pointer;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+      .card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-subtle);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+      }
+      .tab {
+        padding: 0.75rem 1.5rem;
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.5rem;
+        background: var(--bg-tertiary);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .tab.active {
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+        color: white;
+      }
+      .input-group {
+        margin-bottom: 1rem;
+      }
+      .input-group label {
+        display: block;
+        margin-bottom: 0.5rem;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+      }
+      textarea {
+        width: 100%;
+        height: 120px;
+        padding: 1rem;
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.5rem;
+        background: var(--bg-tertiary);
+        color: var(--color-text-primary);
+        font-size: 1rem;
+        resize: vertical;
+        font-family: var(--font-mono);
+      }
+      .file-drop {
+        border: 2px dashed var(--border-subtle);
+        border-radius: 0.5rem;
+        padding: 2rem;
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .file-drop:hover,
+      .file-drop.dragover {
+        border-color: var(--accent-cyan);
+        background: rgba(99, 102, 241, 0.1);
+      }
+      .file-drop input {
+        display: none;
+      }
+      .results {
+        margin-top: 1.5rem;
+      }
+      .result-item {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem;
+        background: var(--bg-tertiary);
+        border-radius: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+      .result-item .algo {
+        min-width: 80px;
+        font-weight: 600;
+        color: var(--accent-cyan);
+      }
+      .result-item .hash {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        word-break: break-all;
+      }
+      .result-item .copy-btn {
+        background: none;
+        border: none;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        padding: 0.25rem;
+      }
+      .result-item .copy-btn:hover {
+        color: var(--accent-cyan);
+      }
+      .toast {
+        position: fixed;
+        bottom: 2rem;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: white;
+        padding: 0.75rem 1.5rem;
+        border-radius: 0.5rem;
+        opacity: 0;
+        transition: all 0.3s;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .hidden {
+        display: none;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+        max-width: 900px;
+        margin-left: auto;
+        margin-right: auto;
+        padding: 0 2rem 2rem;
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <div class="card">
-    <div class="tabs">
-      <button class="tab active" onclick="switchTab('text')">文本输入</button>
-      <button class="tab" onclick="switchTab('file')">文件哈希</button>
-    </div>
+        <div class="card">
+          <div class="tabs">
+            <button class="tab active" onclick="switchTab('text')">文本输入</button>
+            <button class="tab" onclick="switchTab('file')">文件哈希</button>
+          </div>
 
-    <div id="textTab">
-      <div class="input-group">
-        <label>输入文本</label>
-        <textarea id="textInput" placeholder="输入要计算哈希的文本..." oninput="calculateTextHash()">Hello, World!</textarea>
+          <div id="textTab">
+            <div class="input-group">
+              <label>输入文本</label>
+              <textarea
+                id="textInput"
+                placeholder="输入要计算哈希的文本..."
+                oninput="calculateTextHash()"
+              >
+Hello, World!</textarea
+              >
+            </div>
+          </div>
+
+          <div id="fileTab" class="hidden">
+            <div
+              class="file-drop"
+              id="fileDrop"
+              onclick="document.getElementById('fileInput').click()"
+            >
+              <input type="file" id="fileInput" onchange="handleFile(this.files[0])" />
+              <p>📁 点击选择文件或拖放文件到此处</p>
+              <p style="font-size: 0.85rem; color: var(--color-text-secondary); margin-top: 0.5rem">
+                支持任意类型文件
+              </p>
+            </div>
+            <div id="fileInfo" style="margin-top: 1rem; display: none">
+              <p>
+                文件名:
+                <span id="fileName"></span>
+              </p>
+              <p>
+                大小:
+                <span id="fileSize"></span>
+              </p>
+            </div>
+          </div>
+
+          <div class="results" id="results"></div>
+        </div>
       </div>
     </div>
 
-    <div id="fileTab" class="hidden">
-      <div class="file-drop" id="fileDrop" onclick="document.getElementById('fileInput').click()">
-        <input type="file" id="fileInput" onchange="handleFile(this.files[0])">
-        <p>📁 点击选择文件或拖放文件到此处</p>
-        <p style="font-size: 0.85rem; color: var(--color-text-secondary); margin-top: 0.5rem">
-          支持任意类型文件
-        </p>
-      </div>
-      <div id="fileInfo" style="margin-top: 1rem; display: none">
-        <p>
-          文件名:
-          <span id="fileName"></span>
-        </p>
-        <p>
-          大小:
-          <span id="fileSize"></span>
-        </p>
-      </div>
-    </div>
-
-    <div class="results" id="results"></div>
-  </div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "哈希生成器安全吗？文本或文件内容会上传到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有哈希计算均在你的浏览器本地完成，使用 Web Crypto API 处理，文本和文件内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "SHA-1、SHA-256、SHA-384、SHA-512 有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "SHA-1 输出 160 位摘要，已不推荐用于安全场景；SHA-256 是目前最广泛使用的安全标准，输出 256 位；SHA-384 和 SHA-512 输出更长，安全性更高，适合对安全性有更高要求的场景。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "哈希值可以还原成原始内容吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "不能。哈希函数是单向的，无法从哈希值反推出原始内容。这正是哈希被用于密码存储和文件完整性校验的原因——即使哈希值泄露，攻击者也无法直接得到原始数据。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何用哈希值验证下载文件是否被篡改？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "切换到「文件哈希」标签页，拖放或选择下载的文件，工具会自动计算 SHA-256 等哈希值。将结果与软件官网提供的校验值逐字符对比，完全一致则文件未被篡改。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "哈希生成器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "哈希生成器安全吗？文本或文件内容会上传到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有哈希计算均在你的浏览器本地完成，使用 Web Crypto API 处理，文本和文件内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-  }
+          },
+          {
+            "@type": "Question",
+            "name": "SHA-1、SHA-256、SHA-384、SHA-512 有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "SHA-1 输出 160 位摘要，已不推荐用于安全场景；SHA-256 是目前最广泛使用的安全标准，输出 256 位；SHA-384 和 SHA-512 输出更长，安全性更高，适合对安全性有更高要求的场景。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "哈希值可以还原成原始内容吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "不能。哈希函数是单向的，无法从哈希值反推出原始内容。这正是哈希被用于密码存储和文件完整性校验的原因——即使哈希值泄露，攻击者也无法直接得到原始数据。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何用哈希值验证下载文件是否被篡改？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "切换到「文件哈希」标签页，拖放或选择下载的文件，工具会自动计算 SHA-256 等哈希值。将结果与软件官网提供的校验值逐字符对比，完全一致则文件未被篡改。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "哈希生成器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后，即使断开网络也能正常计算哈希值，无需安装或注册任何账号。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
+      let currentTab = "text";
 
-  let currentTab = "text";
+      window.switchTab = function (tab) {
+        currentTab = tab;
+        document
+          .querySelectorAll(".tab")
+          .forEach((t, i) =>
+            t.classList.toggle("active", (i === 0 && tab === "text") || (i === 1 && tab === "file"))
+          );
+        document.getElementById("textTab").classList.toggle("hidden", tab !== "text");
+        document.getElementById("fileTab").classList.toggle("hidden", tab !== "file");
+        document.getElementById("results").innerHTML = "";
+        if (tab === "text") window.calculateTextHash();
+      };
 
-        window.switchTab = function (tab) {
-          currentTab = tab;
-          document
-            .querySelectorAll(".tab")
-            .forEach((t, i) =>
-              t.classList.toggle("active", (i === 0 && tab === "text") || (i === 1 && tab === "file"))
-            );
-          document.getElementById("textTab").classList.toggle("hidden", tab !== "text");
-          document.getElementById("fileTab").classList.toggle("hidden", tab !== "file");
-          document.getElementById("results").innerHTML = "";
-          if (tab === "text") window.calculateTextHash();
-        };
+      async function calculateHash(data, algorithm) {
+        const hashBuffer = await crypto.subtle.digest(algorithm, data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+      }
 
-        async function calculateHash(data, algorithm) {
-          const hashBuffer = await crypto.subtle.digest(algorithm, data);
-          const hashArray = Array.from(new Uint8Array(hashBuffer));
-          return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-        }
+      window.calculateTextHash = async function () {
+        const text = document.getElementById("textInput").value;
+        const encoder = new TextEncoder();
+        const data = encoder.encode(text);
 
-        window.calculateTextHash = async function () {
-          const text = document.getElementById("textInput").value;
-          const encoder = new TextEncoder();
-          const data = encoder.encode(text);
+        const algorithms = [
+          { name: "SHA-1", algo: "SHA-1" },
+          { name: "SHA-256", algo: "SHA-256" },
+          { name: "SHA-384", algo: "SHA-384" },
+          { name: "SHA-512", algo: "SHA-512" }
+        ];
 
-          const algorithms = [
-            { name: "SHA-1", algo: "SHA-1" },
-            { name: "SHA-256", algo: "SHA-256" },
-            { name: "SHA-384", algo: "SHA-384" },
-            { name: "SHA-512", algo: "SHA-512" }
-          ];
-
-          let html = "";
-          for (const { name, algo } of algorithms) {
-            const hash = await calculateHash(data, algo);
-            html += `<div class="result-item">
+        let html = "";
+        for (const { name, algo } of algorithms) {
+          const hash = await calculateHash(data, algo);
+          html += `<div class="result-item">
                       <span class="algo">${name}</span>
                       <span class="hash">${hash}</span>
                       <button class="copy-btn" onclick="copyHash('${hash}')">📋</button>
                   </div>`;
-          }
+        }
 
-          document.getElementById("results").innerHTML = html;
-        };
+        document.getElementById("results").innerHTML = html;
+      };
 
-        window.handleFile = async function (file) {
-          if (!file) return;
+      window.handleFile = async function (file) {
+        if (!file) return;
 
-          document.getElementById("fileInfo").style.display = "block";
-          document.getElementById("fileName").textContent = file.name;
-          document.getElementById("fileSize").textContent = formatSize(file.size);
+        document.getElementById("fileInfo").style.display = "block";
+        document.getElementById("fileName").textContent = file.name;
+        document.getElementById("fileSize").textContent = formatSize(file.size);
 
-          const arrayBuffer = await file.arrayBuffer();
-          const data = new Uint8Array(arrayBuffer);
+        const arrayBuffer = await file.arrayBuffer();
+        const data = new Uint8Array(arrayBuffer);
 
-          const algorithms = [
-            { name: "SHA-1", algo: "SHA-1" },
-            { name: "SHA-256", algo: "SHA-256" },
-            { name: "SHA-384", algo: "SHA-384" },
-            { name: "SHA-512", algo: "SHA-512" }
-          ];
+        const algorithms = [
+          { name: "SHA-1", algo: "SHA-1" },
+          { name: "SHA-256", algo: "SHA-256" },
+          { name: "SHA-384", algo: "SHA-384" },
+          { name: "SHA-512", algo: "SHA-512" }
+        ];
 
-          document.getElementById("results").innerHTML =
-            '<p style="text-align:center;color:var(--color-text-secondary)">计算中...</p>';
+        document.getElementById("results").innerHTML =
+          '<p style="text-align:center;color:var(--color-text-secondary)">计算中...</p>';
 
-          let html = "";
-          for (const { name, algo } of algorithms) {
-            const hash = await calculateHash(data, algo);
-            html += `<div class="result-item">
+        let html = "";
+        for (const { name, algo } of algorithms) {
+          const hash = await calculateHash(data, algo);
+          html += `<div class="result-item">
                       <span class="algo">${name}</span>
                       <span class="hash">${hash}</span>
                       <button class="copy-btn" onclick="copyHash('${hash}')">📋</button>
                   </div>`;
-          }
-
-          document.getElementById("results").innerHTML = html;
-        };
-
-        function formatSize(bytes) {
-          if (bytes < 1024) return bytes + " B";
-          if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(2) + " KB";
-          if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(2) + " MB";
-          return (bytes / 1024 / 1024 / 1024).toFixed(2) + " GB";
         }
 
-        function copyText(text) {
-          if (!navigator.clipboard || !navigator.clipboard.writeText) {
-            return Promise.reject(new Error("Clipboard API unavailable"));
-          }
-          return navigator.clipboard.writeText(text);
+        document.getElementById("results").innerHTML = html;
+      };
+
+      function formatSize(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(2) + " KB";
+        if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(2) + " MB";
+        return (bytes / 1024 / 1024 / 1024).toFixed(2) + " GB";
+      }
+
+      function copyText(text) {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          return Promise.reject(new Error("Clipboard API unavailable"));
         }
+        return navigator.clipboard.writeText(text);
+      }
 
-        window.copyHash = function (hash) {
-          copyText(hash).catch(function () {});
-          const toast = document.getElementById("toast");
-          if (toast) {
-            toast.classList.add("show");
-            setTimeout(() => toast.classList.remove("show"), 2000);
-          }
-        };
+      window.copyHash = function (hash) {
+        copyText(hash).catch(function () {});
+        const toast = document.getElementById("toast");
+        if (toast) {
+          toast.classList.add("show");
+          setTimeout(() => toast.classList.remove("show"), 2000);
+        }
+      };
 
-        // Drag and drop
-        const dropZone = document.getElementById("fileDrop");
-        dropZone.addEventListener("dragover", (e) => {
-          e.preventDefault();
-          dropZone.classList.add("dragover");
-        });
-        dropZone.addEventListener("dragleave", () => dropZone.classList.remove("dragover"));
-        dropZone.addEventListener("drop", (e) => {
-          e.preventDefault();
-          dropZone.classList.remove("dragover");
-          window.handleFile(e.dataTransfer.files[0]);
-        });
+      // Drag and drop
+      const dropZone = document.getElementById("fileDrop");
+      dropZone.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        dropZone.classList.add("dragover");
+      });
+      dropZone.addEventListener("dragleave", () => dropZone.classList.remove("dragover"));
+      dropZone.addEventListener("drop", (e) => {
+        e.preventDefault();
+        dropZone.classList.remove("dragover");
+        window.handleFile(e.dataTransfer.files[0]);
+      });
 
-        window.toggleTheme = function () {
-          const t = document.body.getAttribute("data-theme") === "light" ? "dark" : "light";
-          document.body.setAttribute("data-theme", t);
-          localStorage.setItem("theme", t);
-        };
+      window.toggleTheme = function () {
+        const t = document.body.getAttribute("data-theme") === "light" ? "dark" : "light";
+        document.body.setAttribute("data-theme", t);
+        localStorage.setItem("theme", t);
+      };
 
-        document.body.setAttribute("data-theme", localStorage.getItem("theme") || "dark");
-        window.calculateTextHash();
-</script>
-    
+      document.body.setAttribute("data-theme", localStorage.getItem("theme") || "dark");
+      window.calculateTextHash();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/text/diff-checker.html
+++ b/tools/text/diff-checker.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "文本工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "文本对比工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/diff-checker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "文本对比工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/diff-checker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "文本对比工具 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "文本对比工具 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,780 +88,787 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  :root {
-    --bg-primary: #0a0a0f;
-    --bg-secondary: #12121a;
-    --bg-tertiary: #1a1a25;
-    --color-text-primary: #fff;
-    --color-text-secondary: #88a;
-    --accent: #6366f1;
-    --border: #2a2a3a;
-    --success: #22c55e;
-    --danger: #ef4444;
-    --add-bg: rgba(34, 197, 94, 0.15);
-    --del-bg: rgba(239, 68, 68, 0.15);
-  }
-  [data-theme="light"] {
-    --bg-primary: #f8fafc;
-    --bg-secondary: #fff;
-    --bg-tertiary: #f1f5f9;
-    --color-text-primary: #1e293b;
-    --color-text-secondary: #64748b;
-    --border: #e2e8f0;
-    --add-bg: rgba(34, 197, 94, 0.2);
-    --del-bg: rgba(239, 68, 68, 0.2);
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-  }
-  .header {
-    background: linear-gradient(135deg, #14b8a6, #0ea5e9);
-    padding: 1.5rem 2rem;
-  }
-  .header-content {
-    max-width: 1400px;
-    margin: 0 auto;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .header h1 {
-    font-size: 1.5rem;
-  }
-  .back-link {
-    color: rgba(255, 255, 255, 0.9);
-    text-decoration: none;
-  }
-  .btn {
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    font-size: 0.9rem;
-    transition: all 0.2s;
-  }
-  .btn-ghost {
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-  }
-  .container {
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 1.5rem;
-  }
-  .input-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 1rem;
-  }
-  @media (max-width: 768px) {
-    .input-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  .input-panel {
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.75rem;
-    overflow: hidden;
-  }
-  .panel-header {
-    padding: 0.75rem 1rem;
-    background: var(--bg-tertiary);
-    border-bottom: 1px solid var(--border-subtle);
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-  }
-  textarea {
-    width: 100%;
-    height: 200px;
-    padding: 1rem;
-    border: none;
-    background: transparent;
-    color: var(--color-text-primary);
-    font-family: "Fira Code", monospace;
-    font-size: 0.9rem;
-    line-height: 1.6;
-    resize: vertical;
-    outline: none;
-  }
-  .btn-compare {
-    width: 100%;
-    padding: 0.75rem;
-    background: var(--accent-cyan);
-    color: white;
-    border: none;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  .btn-compare:hover {
-    opacity: 0.9;
-  }
-  .stats {
-    display: flex;
-    gap: 1rem;
-    margin: 1rem 0;
-    flex-wrap: wrap;
-  }
-  .stat {
-    padding: 0.5rem 1rem;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.5rem;
-    font-size: 0.85rem;
-  }
-  .stat.add {
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-  }
-  .stat.del {
-    border-color: var(--accent-red);
-    color: var(--accent-red);
-  }
-  .diff-output {
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.75rem;
-    overflow: hidden;
-  }
-  .diff-header {
-    padding: 0.75rem 1rem;
-    background: var(--bg-tertiary);
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .diff-content {
-    padding: 0;
-    max-height: 500px;
-    overflow: auto;
-  }
-  .diff-line {
-    display: flex;
-    font-family: "Fira Code", monospace;
-    font-size: 0.85rem;
-    line-height: 1.6;
-  }
-  .diff-line:hover {
-    background: var(--bg-tertiary);
-  }
-  .line-num {
-    min-width: 50px;
-    padding: 0 0.5rem;
-    color: var(--color-text-secondary);
-    text-align: right;
-    background: var(--bg-tertiary);
-    border-right: 1px solid var(--border-subtle);
-    user-select: none;
-  }
-  .line-content {
-    flex: 1;
-    padding: 0 1rem;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-  .diff-line.add {
-    background: var(--add-bg);
-  }
-  .diff-line.add .line-content::before {
-    content: "+ ";
-    color: var(--accent-green);
-  }
-  .diff-line.del {
-    background: var(--del-bg);
-  }
-  .diff-line.del .line-content::before {
-    content: "- ";
-    color: var(--accent-red);
-  }
-  .diff-line.unchanged .line-content::before {
-    content: "  ";
-  }
-  .view-toggle {
-    display: flex;
-    gap: 0.25rem;
-  }
-  .view-btn {
-    padding: 0.25rem 0.75rem;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: 0.25rem;
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    font-size: 0.8rem;
-  }
-  .view-btn.active {
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-    color: white;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg-primary: #0a0a0f;
+        --bg-secondary: #12121a;
+        --bg-tertiary: #1a1a25;
+        --color-text-primary: #fff;
+        --color-text-secondary: #88a;
+        --accent: #6366f1;
+        --border: #2a2a3a;
+        --success: #22c55e;
+        --danger: #ef4444;
+        --add-bg: rgba(34, 197, 94, 0.15);
+        --del-bg: rgba(239, 68, 68, 0.15);
+      }
+      [data-theme="light"] {
+        --bg-primary: #f8fafc;
+        --bg-secondary: #fff;
+        --bg-tertiary: #f1f5f9;
+        --color-text-primary: #1e293b;
+        --color-text-secondary: #64748b;
+        --border: #e2e8f0;
+        --add-bg: rgba(34, 197, 94, 0.2);
+        --del-bg: rgba(239, 68, 68, 0.2);
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+      }
+      .header {
+        background: linear-gradient(135deg, #14b8a6, #0ea5e9);
+        padding: 1.5rem 2rem;
+      }
+      .header-content {
+        max-width: 1400px;
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .header h1 {
+        font-size: 1.5rem;
+      }
+      .back-link {
+        color: rgba(255, 255, 255, 0.9);
+        text-decoration: none;
+      }
+      .btn {
+        padding: 0.5rem 1rem;
+        border: none;
+        border-radius: 0.5rem;
+        cursor: pointer;
+        font-size: 0.9rem;
+        transition: all 0.2s;
+      }
+      .btn-ghost {
+        background: rgba(255, 255, 255, 0.2);
+        color: white;
+      }
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      .input-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      @media (max-width: 768px) {
+        .input-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .input-panel {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.75rem;
+        overflow: hidden;
+      }
+      .panel-header {
+        padding: 0.75rem 1rem;
+        background: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-subtle);
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+      }
+      textarea {
+        width: 100%;
+        height: 200px;
+        padding: 1rem;
+        border: none;
+        background: transparent;
+        color: var(--color-text-primary);
+        font-family: "Fira Code", monospace;
+        font-size: 0.9rem;
+        line-height: 1.6;
+        resize: vertical;
+        outline: none;
+      }
+      .btn-compare {
+        width: 100%;
+        padding: 0.75rem;
+        background: var(--accent-cyan);
+        color: white;
+        border: none;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .btn-compare:hover {
+        opacity: 0.9;
+      }
+      .stats {
+        display: flex;
+        gap: 1rem;
+        margin: 1rem 0;
+        flex-wrap: wrap;
+      }
+      .stat {
+        padding: 0.5rem 1rem;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.5rem;
+        font-size: 0.85rem;
+      }
+      .stat.add {
+        border-color: var(--accent-green);
+        color: var(--accent-green);
+      }
+      .stat.del {
+        border-color: var(--accent-red);
+        color: var(--accent-red);
+      }
+      .diff-output {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.75rem;
+        overflow: hidden;
+      }
+      .diff-header {
+        padding: 0.75rem 1rem;
+        background: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .diff-content {
+        padding: 0;
+        max-height: 500px;
+        overflow: auto;
+      }
+      .diff-line {
+        display: flex;
+        font-family: "Fira Code", monospace;
+        font-size: 0.85rem;
+        line-height: 1.6;
+      }
+      .diff-line:hover {
+        background: var(--bg-tertiary);
+      }
+      .line-num {
+        min-width: 50px;
+        padding: 0 0.5rem;
+        color: var(--color-text-secondary);
+        text-align: right;
+        background: var(--bg-tertiary);
+        border-right: 1px solid var(--border-subtle);
+        user-select: none;
+      }
+      .line-content {
+        flex: 1;
+        padding: 0 1rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+      .diff-line.add {
+        background: var(--add-bg);
+      }
+      .diff-line.add .line-content::before {
+        content: "+ ";
+        color: var(--accent-green);
+      }
+      .diff-line.del {
+        background: var(--del-bg);
+      }
+      .diff-line.del .line-content::before {
+        content: "- ";
+        color: var(--accent-red);
+      }
+      .diff-line.unchanged .line-content::before {
+        content: "  ";
+      }
+      .view-toggle {
+        display: flex;
+        gap: 0.25rem;
+      }
+      .view-btn {
+        padding: 0.25rem 0.75rem;
+        background: var(--bg-deep);
+        border: 1px solid var(--border-subtle);
+        border-radius: 0.25rem;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        font-size: 0.8rem;
+      }
+      .view-btn.active {
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+        color: white;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <div class="input-grid">
-    <div class="input-panel">
-      <div class="panel-header">原始文本</div>
-      <textarea id="text1" placeholder="输入原始文本...">Hello World
+        <div class="input-grid">
+          <div class="input-panel">
+            <div class="panel-header">原始文本</div>
+            <textarea id="text1" placeholder="输入原始文本...">
+Hello World
 This is a test
 Line three
-Line four</textarea>
-    </div>
-    <div class="input-panel">
-      <div class="panel-header">对比文本</div>
-      <textarea id="text2" placeholder="输入对比文本...">Hello World!
+Line four</textarea
+            >
+          </div>
+          <div class="input-panel">
+            <div class="panel-header">对比文本</div>
+            <textarea id="text2" placeholder="输入对比文本...">
+Hello World!
 This is a test
 Line three modified
-Line five</textarea>
-    </div>
-  </div>
+Line five</textarea
+            >
+          </div>
+        </div>
 
-  <button class="btn-compare" onclick="compare()">🔍 对比文本</button>
+        <button class="btn-compare" onclick="compare()">🔍 对比文本</button>
 
-  <div class="stats" id="stats" style="display: none"></div>
+        <div class="stats" id="stats" style="display: none"></div>
 
-  <div class="diff-output" id="diffOutput" style="display: none">
-    <div class="diff-header">
-      <span>对比结果</span>
-      <div class="view-toggle">
-        <button class="view-btn active" onclick="setView('unified')">统一视图</button>
-        <button class="view-btn" onclick="setView('split')">分栏视图</button>
+        <div class="diff-output" id="diffOutput" style="display: none">
+          <div class="diff-header">
+            <span>对比结果</span>
+            <div class="view-toggle">
+              <button class="view-btn active" onclick="setView('unified')">统一视图</button>
+              <button class="view-btn" onclick="setView('split')">分栏视图</button>
+            </div>
+          </div>
+          <div class="diff-content" id="diffContent"></div>
+        </div>
       </div>
+      <section class="faq-section container">
+        <h2>常见问题</h2>
+        <details class="faq-item">
+          <summary>文本对比工具安全吗？输入内容会上传服务器吗？</summary>
+          <p>
+            完全安全。所有文本对比都在你的浏览器本地完成，输入的任何内容不会上传到任何服务器，也不会被记录。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>如何使用统一视图和分栏视图？</summary>
+          <p>
+            统一视图把两段文本的差异混合展示在一列，绿色行（+）为新增，红色行（-）为删除；分栏视图左侧显示原始文本，右侧显示对比文本，便于同时查看两个版本的上下文。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>对比结果中「行」的计算方式是什么？</summary>
+          <p>
+            工具使用最长公共子序列（LCS）算法逐行比较，完全新增的行标记为 +，完全删除的行标记为
+            -，未变化的行用普通样式展示。结果统计会显示新增行数、删除行数和未变化行数。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>能对比代码文件吗？</summary>
+          <p>
+            可以。本工具对纯文本进行逐行比较，代码、配置文件、日志等只要是文本格式都可以粘贴进来对比，对比结果使用等宽字体展示，便于阅读代码差异。
+          </p>
+        </details>
+        <details class="faq-item">
+          <summary>对比支持多大的文本？</summary>
+          <p>
+            没有固定上限，受限于浏览器内存。通常几千行以内的文本都能快速处理。文本过大时可能因 LCS
+            算法计算量大而稍慢，建议将大文件拆分为较小的片段分批对比。
+          </p>
+        </details>
+      </section>
     </div>
-    <div class="diff-content" id="diffContent"></div>
-  </div>
-</div>
-<section class="faq-section container">
-  <h2>常见问题</h2>
-  <details class="faq-item">
-    <summary>文本对比工具安全吗？输入内容会上传服务器吗？</summary>
-    <p>
-      完全安全。所有文本对比都在你的浏览器本地完成，输入的任何内容不会上传到任何服务器，也不会被记录。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>如何使用统一视图和分栏视图？</summary>
-    <p>
-      统一视图把两段文本的差异混合展示在一列，绿色行（+）为新增，红色行（-）为删除；分栏视图左侧显示原始文本，右侧显示对比文本，便于同时查看两个版本的上下文。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>对比结果中「行」的计算方式是什么？</summary>
-    <p>
-      工具使用最长公共子序列（LCS）算法逐行比较，完全新增的行标记为 +，完全删除的行标记为
-      -，未变化的行用普通样式展示。结果统计会显示新增行数、删除行数和未变化行数。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>能对比代码文件吗？</summary>
-    <p>
-      可以。本工具对纯文本进行逐行比较，代码、配置文件、日志等只要是文本格式都可以粘贴进来对比，对比结果使用等宽字体展示，便于阅读代码差异。
-    </p>
-  </details>
-  <details class="faq-item">
-    <summary>对比支持多大的文本？</summary>
-    <p>
-      没有固定上限，受限于浏览器内存。通常几千行以内的文本都能快速处理。文本过大时可能因 LCS
-      算法计算量大而稍慢，建议将大文件拆分为较小的片段分批对比。
-    </p>
-  </details>
-</section>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "文本对比工具安全吗？输入内容会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有文本对比都在你的浏览器本地完成，输入的任何内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何使用统一视图和分栏视图？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "统一视图把两段文本的差异混合展示在一列，绿色行（+）为新增，红色行（-）为删除；分栏视图左侧显示原始文本，右侧显示对比文本，便于同时查看两个版本的上下文。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "对比结果中「行」的计算方式是什么？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "工具使用最长公共子序列（LCS）算法逐行比较，完全新增的行标记为 +，完全删除的行标记为 -，未变化的行用普通样式展示。结果统计会显示新增行数、删除行数和未变化行数。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "能对比代码文件吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具对纯文本进行逐行比较，代码、配置文件、日志等只要是文本格式都可以粘贴进来对比，对比结果使用等宽字体展示，便于阅读代码差异。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "对比支持多大的文本？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "没有固定上限，受限于浏览器内存。通常几千行以内的文本都能快速处理。文本过大时可能因 LCS 算法计算量大而稍慢，建议将大文件拆分为较小的片段分批对比。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "文本对比工具安全吗？输入内容会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有文本对比都在你的浏览器本地完成，输入的任何内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "如何使用统一视图和分栏视图？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "统一视图把两段文本的差异混合展示在一列，绿色行（+）为新增，红色行（-）为删除；分栏视图左侧显示原始文本，右侧显示对比文本，便于同时查看两个版本的上下文。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "对比结果中「行」的计算方式是什么？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "工具使用最长公共子序列（LCS）算法逐行比较，完全新增的行标记为 +，完全删除的行标记为 -，未变化的行用普通样式展示。结果统计会显示新增行数、删除行数和未变化行数。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "能对比代码文件吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具对纯文本进行逐行比较，代码、配置文件、日志等只要是文本格式都可以粘贴进来对比，对比结果使用等宽字体展示，便于阅读代码差异。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "对比支持多大的文本？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "没有固定上限，受限于浏览器内存。通常几千行以内的文本都能快速处理。文本过大时可能因 LCS 算法计算量大而稍慢，建议将大文件拆分为较小的片段分批对比。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
+      let currentView = "unified";
+      let lastDiff = null;
 
-  let currentView = "unified";
-        let lastDiff = null;
+      window.lcs = function (a, b) {
+        const m = a.length,
+          n = b.length;
+        const dp = Array(m + 1)
+          .fill(null)
+          .map(() => Array(n + 1).fill(0));
 
-        window.lcs = function (a, b) {
-          const m = a.length,
-            n = b.length;
-          const dp = Array(m + 1)
-            .fill(null)
-            .map(() => Array(n + 1).fill(0));
-
-          for (let i = 1; i <= m; i++) {
-            for (let j = 1; j <= n; j++) {
-              if (a[i - 1] === b[j - 1]) {
-                dp[i][j] = dp[i - 1][j - 1] + 1;
-              } else {
-                dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-              }
-            }
-          }
-
-          const result = [];
-          let i = m,
-            j = n;
-          while (i > 0 && j > 0) {
+        for (let i = 1; i <= m; i++) {
+          for (let j = 1; j <= n; j++) {
             if (a[i - 1] === b[j - 1]) {
-              result.unshift({ type: "unchanged", text: a[i - 1], lineA: i, lineB: j });
-              i--;
-              j--;
-            } else if (dp[i - 1][j] > dp[i][j - 1]) {
-              result.unshift({ type: "del", text: a[i - 1], lineA: i });
-              i--;
+              dp[i][j] = dp[i - 1][j - 1] + 1;
             } else {
-              result.unshift({ type: "add", text: b[j - 1], lineB: j });
-              j--;
+              dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
             }
           }
-          while (i > 0) {
+        }
+
+        const result = [];
+        let i = m,
+          j = n;
+        while (i > 0 && j > 0) {
+          if (a[i - 1] === b[j - 1]) {
+            result.unshift({ type: "unchanged", text: a[i - 1], lineA: i, lineB: j });
+            i--;
+            j--;
+          } else if (dp[i - 1][j] > dp[i][j - 1]) {
             result.unshift({ type: "del", text: a[i - 1], lineA: i });
             i--;
-          }
-          while (j > 0) {
+          } else {
             result.unshift({ type: "add", text: b[j - 1], lineB: j });
             j--;
           }
+        }
+        while (i > 0) {
+          result.unshift({ type: "del", text: a[i - 1], lineA: i });
+          i--;
+        }
+        while (j > 0) {
+          result.unshift({ type: "add", text: b[j - 1], lineB: j });
+          j--;
+        }
 
-          return result;
-        };
+        return result;
+      };
 
-        window.compare = function () {
-          const text1 = document.getElementById("text1").value;
-          const text2 = document.getElementById("text2").value;
+      window.compare = function () {
+        const text1 = document.getElementById("text1").value;
+        const text2 = document.getElementById("text2").value;
 
-          const lines1 = text1.split("\n");
-          const lines2 = text2.split("\n");
+        const lines1 = text1.split("\n");
+        const lines2 = text2.split("\n");
 
-          lastDiff = lcs(lines1, lines2);
+        lastDiff = lcs(lines1, lines2);
 
-          const adds = lastDiff.filter((d) => d.type === "add").length;
-          const dels = lastDiff.filter((d) => d.type === "del").length;
-          const unchanged = lastDiff.filter((d) => d.type === "unchanged").length;
+        const adds = lastDiff.filter((d) => d.type === "add").length;
+        const dels = lastDiff.filter((d) => d.type === "del").length;
+        const unchanged = lastDiff.filter((d) => d.type === "unchanged").length;
 
-          document.getElementById("stats").style.display = "flex";
-          document.getElementById("stats").innerHTML = `
+        document.getElementById("stats").style.display = "flex";
+        document.getElementById("stats").innerHTML = `
                   <div class="stat add">+ ${adds} 行添加</div>
                   <div class="stat del">- ${dels} 行删除</div>
                   <div class="stat">${unchanged} 行未变</div>
                   <div class="stat">共 ${lines1.length} → ${lines2.length} 行</div>
               `;
 
-          document.getElementById("diffOutput").style.display = "block";
-          renderDiff();
-        };
+        document.getElementById("diffOutput").style.display = "block";
+        renderDiff();
+      };
 
-        function renderDiff() {
-          if (!lastDiff) return;
+      function renderDiff() {
+        if (!lastDiff) return;
 
-          const content = document.getElementById("diffContent");
+        const content = document.getElementById("diffContent");
 
-          if (currentView === "unified") {
-            let lineNum = 0;
-            content.innerHTML = lastDiff
-              .map((d) => {
-                if (d.type !== "del") lineNum++;
-                const num = d.type === "del" ? d.lineA : d.type === "add" ? d.lineB : d.lineA;
-                return `<div class="diff-line ${d.type}">
+        if (currentView === "unified") {
+          let lineNum = 0;
+          content.innerHTML = lastDiff
+            .map((d) => {
+              if (d.type !== "del") lineNum++;
+              const num = d.type === "del" ? d.lineA : d.type === "add" ? d.lineB : d.lineA;
+              return `<div class="diff-line ${d.type}">
                           <span class="line-num">${num}</span>
                           <span class="line-content">${escapeHtml(d.text)}</span>
                       </div>`;
-              })
-              .join("");
-          } else {
-            // Split view - simplified
-            let html = '<div style="display: grid; grid-template-columns: 1fr 1fr;">';
-            html +=
-              "<div>" +
-              lastDiff
-                .filter((d) => d.type !== "add")
-                .map(
-                  (d) =>
-                    `<div class="diff-line ${d.type === "del" ? "del" : ""}">
+            })
+            .join("");
+        } else {
+          // Split view - simplified
+          let html = '<div style="display: grid; grid-template-columns: 1fr 1fr;">';
+          html +=
+            "<div>" +
+            lastDiff
+              .filter((d) => d.type !== "add")
+              .map(
+                (d) =>
+                  `<div class="diff-line ${d.type === "del" ? "del" : ""}">
                           <span class="line-num">${d.lineA || ""}</span>
                           <span class="line-content">${escapeHtml(d.text)}</span>
                       </div>`
-                )
-                .join("") +
-              "</div>";
-            html +=
-              "<div>" +
-              lastDiff
-                .filter((d) => d.type !== "del")
-                .map(
-                  (d) =>
-                    `<div class="diff-line ${d.type === "add" ? "add" : ""}">
+              )
+              .join("") +
+            "</div>";
+          html +=
+            "<div>" +
+            lastDiff
+              .filter((d) => d.type !== "del")
+              .map(
+                (d) =>
+                  `<div class="diff-line ${d.type === "add" ? "add" : ""}">
                           <span class="line-num">${d.lineB || ""}</span>
                           <span class="line-content">${escapeHtml(d.text)}</span>
                       </div>`
-                )
-                .join("") +
-              "</div>";
-            html += "</div>";
-            content.innerHTML = html;
-          }
+              )
+              .join("") +
+            "</div>";
+          html += "</div>";
+          content.innerHTML = html;
         }
+      }
 
-        window.setView = function (view) {
-          currentView = view;
-          document.querySelectorAll(".view-btn").forEach((btn) => btn.classList.remove("active"));
-          document
-            .querySelector(`.view-btn:nth-child(${view === "unified" ? 1 : 2})`)
-            .classList.add("active");
-          renderDiff();
-        };
+      window.setView = function (view) {
+        currentView = view;
+        document.querySelectorAll(".view-btn").forEach((btn) => btn.classList.remove("active"));
+        document
+          .querySelector(`.view-btn:nth-child(${view === "unified" ? 1 : 2})`)
+          .classList.add("active");
+        renderDiff();
+      };
 
-        window.escapeHtml = function (text) {
-          const div = document.createElement("div");
-          div.textContent = text;
-          return div.innerHTML;
-        };
+      window.escapeHtml = function (text) {
+        const div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      };
 
-        window.toggleTheme = function () {
-          const t = document.body.getAttribute("data-theme") === "light" ? "dark" : "light";
-          document.body.setAttribute("data-theme", t);
-          localStorage.setItem("theme", t);
-        };
+      window.toggleTheme = function () {
+        const t = document.body.getAttribute("data-theme") === "light" ? "dark" : "light";
+        document.body.setAttribute("data-theme", t);
+        localStorage.setItem("theme", t);
+      };
 
-        document.body.setAttribute("data-theme", localStorage.getItem("theme") || "dark");
-</script>
-    
+      document.body.setAttribute("data-theme", localStorage.getItem("theme") || "dark");
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/text/markdown-editor.html
+++ b/tools/text/markdown-editor.html
@@ -6,7 +6,10 @@
     <title>Markdown 编辑器 - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="markdown 编辑器" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Markdown 编辑器 - WebUtils" />
-    <meta property="og:description" content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/text/markdown-editor.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/text/markdown-editor.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Markdown 编辑器 - WebUtils" />
-    <meta name="twitter:description" content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Markdown 编辑器，在线编辑，文本工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "文本工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Markdown 编辑器",
-      "item": "https://tools.realtime-ai.chat/tools/text/markdown-editor.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Markdown 编辑器",
+            "item": "https://tools.realtime-ai.chat/tools/text/markdown-editor.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Markdown 编辑器 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Markdown 编辑器 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,551 +100,556 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: #1a1a2e;
-    min-height: 100vh;
-  }
-  .header {
-    background: #16213e;
-    padding: 15px 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  h1 {
-    color: white;
-    font-size: 20px;
-  }
-  .toolbar {
-    display: flex;
-    gap: 5px;
-  }
-  .toolbar button {
-    background: #0f3460;
-    color: white;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 14px;
-  }
-  .toolbar button:hover {
-    background: #e94560;
-  }
-  .container {
-    display: flex;
-    height: calc(100vh - 60px);
-  }
-  .editor,
-  .preview {
-    flex: 1;
-    padding: 20px;
-    overflow-y: auto;
-  }
-  .editor {
-    background: #16213e;
-  }
-  textarea {
-    width: 100%;
-    height: 100%;
-    background: transparent;
-    border: none;
-    color: #e0e0e0;
-    font-family: Monaco, Menlo, monospace;
-    font-size: 14px;
-    line-height: 1.6;
-    resize: none;
-    outline: none;
-  }
-  .preview {
-    background: #1a1a2e;
-    color: #e0e0e0;
-  }
-  .preview h1,
-  .preview h2,
-  .preview h3 {
-    color: #e94560;
-    margin: 20px 0 10px;
-  }
-  .preview h1 {
-    font-size: 28px;
-    border-bottom: 2px solid #0f3460;
-    padding-bottom: 10px;
-  }
-  .preview h2 {
-    font-size: 24px;
-  }
-  .preview h3 {
-    font-size: 20px;
-  }
-  .preview p {
-    margin: 10px 0;
-    line-height: 1.8;
-  }
-  .preview code {
-    background: #0f3460;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-family: var(--font-mono);
-  }
-  .preview pre {
-    background: #0f3460;
-    padding: 15px;
-    border-radius: 8px;
-    overflow-x: auto;
-    margin: 15px 0;
-  }
-  .preview pre code {
-    background: none;
-    padding: 0;
-  }
-  .preview blockquote {
-    border-left: 4px solid #e94560;
-    padding-left: 15px;
-    margin: 15px 0;
-    color: #aaa;
-  }
-  .preview ul,
-  .preview ol {
-    margin: 10px 0;
-    padding-left: 25px;
-  }
-  .preview li {
-    margin: 5px 0;
-  }
-  .preview a {
-    color: #4facfe;
-    text-decoration: none;
-  }
-  .preview a:hover {
-    text-decoration: underline;
-  }
-  .preview img {
-    max-width: 100%;
-    border-radius: 8px;
-    margin: 10px 0;
-  }
-  .preview table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 15px 0;
-  }
-  .preview th,
-  .preview td {
-    border: 1px solid #0f3460;
-    padding: 10px;
-    text-align: left;
-  }
-  .preview th {
-    background: #0f3460;
-  }
-  .preview hr {
-    border: none;
-    border-top: 2px solid #0f3460;
-    margin: 20px 0;
-  }
-  .divider {
-    width: 4px;
-    background: #0f3460;
-    cursor: col-resize;
-  }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-  @media (max-width: 480px) {
-    body {
-      padding: 0;
-    }
-    h1 {
-      font-size: 1.3rem;
-    }
-    .header {
-      flex-direction: column;
-      gap: 10px;
-      padding: 10px 12px;
-    }
-    .toolbar {
-      flex-wrap: wrap;
-      gap: 4px;
-      justify-content: flex-start;
-    }
-    .toolbar button {
-      padding: 6px 8px;
-      font-size: 12px;
-    }
-    .container {
-      flex-direction: column;
-      height: auto;
-      min-height: calc(100vh - 80px);
-    }
-    .editor,
-    .preview {
-      flex: none;
-      min-width: 0;
-      width: 100%;
-      max-width: 100%;
-      overflow-x: hidden;
-      padding: 12px;
-    }
-    .editor {
-      height: 40vh;
-    }
-    .preview {
-      min-height: 40vh;
-    }
-    textarea {
-      font-size: 12px;
-    }
-    .card {
-      padding: 12px;
-    }
-    .main-grid,
-    .grid {
-      grid-template-columns: 1fr !important;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .btn-row button {
-      width: 100%;
-    }
-    pre,
-    code,
-    textarea {
-      font-size: 0.7rem;
-      white-space: pre-wrap;
-      word-break: break-all;
-    }
-    .editor-panel,
-    .preview-panel {
-      min-width: 0;
-      overflow: hidden;
-    }
-    .preview pre {
-      overflow-x: auto;
-      max-width: 100%;
-    }
-    .preview table {
-      display: block;
-      overflow-x: auto;
-      max-width: 100%;
-    }
-  }
-</style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: #1a1a2e;
+        min-height: 100vh;
+      }
+      .header {
+        background: #16213e;
+        padding: 15px 20px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      h1 {
+        color: white;
+        font-size: 20px;
+      }
+      .toolbar {
+        display: flex;
+        gap: 5px;
+      }
+      .toolbar button {
+        background: #0f3460;
+        color: white;
+        border: none;
+        padding: 8px 12px;
+        border-radius: 5px;
+        cursor: pointer;
+        font-size: 14px;
+      }
+      .toolbar button:hover {
+        background: #e94560;
+      }
+      .container {
+        display: flex;
+        height: calc(100vh - 60px);
+      }
+      .editor,
+      .preview {
+        flex: 1;
+        padding: 20px;
+        overflow-y: auto;
+      }
+      .editor {
+        background: #16213e;
+      }
+      textarea {
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        border: none;
+        color: #e0e0e0;
+        font-family: Monaco, Menlo, monospace;
+        font-size: 14px;
+        line-height: 1.6;
+        resize: none;
+        outline: none;
+      }
+      .preview {
+        background: #1a1a2e;
+        color: #e0e0e0;
+      }
+      .preview h1,
+      .preview h2,
+      .preview h3 {
+        color: #e94560;
+        margin: 20px 0 10px;
+      }
+      .preview h1 {
+        font-size: 28px;
+        border-bottom: 2px solid #0f3460;
+        padding-bottom: 10px;
+      }
+      .preview h2 {
+        font-size: 24px;
+      }
+      .preview h3 {
+        font-size: 20px;
+      }
+      .preview p {
+        margin: 10px 0;
+        line-height: 1.8;
+      }
+      .preview code {
+        background: #0f3460;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-family: var(--font-mono);
+      }
+      .preview pre {
+        background: #0f3460;
+        padding: 15px;
+        border-radius: 8px;
+        overflow-x: auto;
+        margin: 15px 0;
+      }
+      .preview pre code {
+        background: none;
+        padding: 0;
+      }
+      .preview blockquote {
+        border-left: 4px solid #e94560;
+        padding-left: 15px;
+        margin: 15px 0;
+        color: #aaa;
+      }
+      .preview ul,
+      .preview ol {
+        margin: 10px 0;
+        padding-left: 25px;
+      }
+      .preview li {
+        margin: 5px 0;
+      }
+      .preview a {
+        color: #4facfe;
+        text-decoration: none;
+      }
+      .preview a:hover {
+        text-decoration: underline;
+      }
+      .preview img {
+        max-width: 100%;
+        border-radius: 8px;
+        margin: 10px 0;
+      }
+      .preview table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 15px 0;
+      }
+      .preview th,
+      .preview td {
+        border: 1px solid #0f3460;
+        padding: 10px;
+        text-align: left;
+      }
+      .preview th {
+        background: #0f3460;
+      }
+      .preview hr {
+        border: none;
+        border-top: 2px solid #0f3460;
+        margin: 20px 0;
+      }
+      .divider {
+        width: 4px;
+        background: #0f3460;
+        cursor: col-resize;
+      }
+
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+      @media (max-width: 480px) {
+        body {
+          padding: 0;
+        }
+        h1 {
+          font-size: 1.3rem;
+        }
+        .header {
+          flex-direction: column;
+          gap: 10px;
+          padding: 10px 12px;
+        }
+        .toolbar {
+          flex-wrap: wrap;
+          gap: 4px;
+          justify-content: flex-start;
+        }
+        .toolbar button {
+          padding: 6px 8px;
+          font-size: 12px;
+        }
+        .container {
+          flex-direction: column;
+          height: auto;
+          min-height: calc(100vh - 80px);
+        }
+        .editor,
+        .preview {
+          flex: none;
+          min-width: 0;
+          width: 100%;
+          max-width: 100%;
+          overflow-x: hidden;
+          padding: 12px;
+        }
+        .editor {
+          height: 40vh;
+        }
+        .preview {
+          min-height: 40vh;
+        }
+        textarea {
+          font-size: 12px;
+        }
+        .card {
+          padding: 12px;
+        }
+        .main-grid,
+        .grid {
+          grid-template-columns: 1fr !important;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .btn-row button {
+          width: 100%;
+        }
+        pre,
+        code,
+        textarea {
+          font-size: 0.7rem;
+          white-space: pre-wrap;
+          word-break: break-all;
+        }
+        .editor-panel,
+        .preview-panel {
+          min-width: 0;
+          overflow: hidden;
+        }
+        .preview pre {
+          overflow-x: auto;
+          max-width: 100%;
+        }
+        .preview table {
+          display: block;
+          overflow-x: auto;
+          max-width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <div class="editor">
-    <textarea id="input" placeholder="在这里输入Markdown..."># 欢迎使用Markdown编辑器
+        <div class="editor">
+          <textarea id="input" placeholder="在这里输入Markdown...">
+# 欢迎使用Markdown编辑器
 
 这是一个**实时预览**的Markdown编辑器。
 
@@ -659,136 +676,136 @@ function hello() {
 ---
 
 [访问链接](https://example.com)
-</textarea>
-  </div>
-  <div class="divider"></div>
-  <div class="preview" id="preview"></div>
-</div>
+</textarea
+          >
+        </div>
+        <div class="divider"></div>
+        <div class="preview" id="preview"></div>
+      </div>
     </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Markdown 编辑器安全吗？我的文档会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 Markdown 解析与预览都在浏览器本地完成，你的文档内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何快速插入粗体、标题等格式？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "工具栏提供了粗体、斜体、标题、链接、行内代码、代码块、引用和列表快捷按钮，选中文本后点击对应按钮即可自动在两端插入 Markdown 标记。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "编辑器支持哪些 Markdown 语法？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "支持标题（# ~ ###）、粗体（**）、斜体（*）、行内代码、代码块（```）、引用（>）、无序列表（-）、有序列表（1.）、链接（[文字](url)）、图片、表格和分割线（---）等常见语法。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何下载写好的 Markdown 文件？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "点击工具栏的「下载」按钮，即可将当前编辑区的内容保存为 document.md 文件到本地，无需联网。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Markdown 编辑器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册任何账号。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Markdown 编辑器安全吗？我的文档会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 Markdown 解析与预览都在浏览器本地完成，你的文档内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "如何快速插入粗体、标题等格式？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "工具栏提供了粗体、斜体、标题、链接、行内代码、代码块、引用和列表快捷按钮，选中文本后点击对应按钮即可自动在两端插入 Markdown 标记。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "编辑器支持哪些 Markdown 语法？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "支持标题（# ~ ###）、粗体（**）、斜体（*）、行内代码、代码块（```）、引用（>）、无序列表（-）、有序列表（1.）、链接（[文字](url)）、图片、表格和分割线（---）等常见语法。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何下载写好的 Markdown 文件？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "点击工具栏的「下载」按钮，即可将当前编辑区的内容保存为 document.md 文件到本地，无需联网。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Markdown 编辑器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册任何账号。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
-
-  function parseMarkdown(md) {
-          let html = md
-            .replace(/^### (.*$)/gm, "<h3>$1</h3>")
-            .replace(/^## (.*$)/gm, "<h2>$1</h2>")
-            .replace(/^# (.*$)/gm, "<h2>$1</h2>")
-            .replace(/```(\w*)\n([\s\S]*?)```/g, "<pre><code>$2</code></pre>")
-            .replace(/`([^`]+)`/g, "<code>$1</code>")
-            .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-            .replace(/\*([^*]+)\*/g, "<em>$1</em>")
-            .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">')
-            .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
-            .replace(/^> (.*$)/gm, "<blockquote>$1</blockquote>")
-            .replace(/^- (.*$)/gm, "<li>$1</li>")
-            .replace(/^\d+\. (.*$)/gm, "<li>$1</li>")
-            .replace(/^---$/gm, "<hr>")
-            .replace(/\|(.+)\|/g, (match) => {
-              const cells = match.split("|").filter((c) => c.trim());
-              if (cells.every((c) => /^[\s-]+$/.test(c))) return "";
-              const tag = match.includes("---") ? "th" : "td";
-              return "<tr>" + cells.map((c) => `<${tag}>${c.trim()}</${tag}>`).join("") + "</tr>";
-            })
-            .replace(/(<tr>.*<\/tr>\n?)+/g, "<table>$&</table>")
-            .replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>")
-            .replace(/(<blockquote>.*<\/blockquote>\n?)+/g, (m) =>
-              m.replace(/<\/blockquote>\n?<blockquote>/g, "<br>")
-            )
-            .replace(/\n\n/g, "</p><p>")
-            .replace(/\n/g, "<br>");
-          return "<p>" + html + "</p>";
-        }
-        function render() {
-          document.getElementById("preview").innerHTML = parseMarkdown(
-            document.getElementById("input").value
-          );
-        }
-        function insert(before, after) {
-          const ta = document.getElementById("input");
-          const start = ta.selectionStart;
-          const end = ta.selectionEnd;
-          const text = ta.value;
-          ta.value = text.slice(0, start) + before + text.slice(start, end) + after + text.slice(end);
-          ta.focus();
-          ta.setSelectionRange(start + before.length, end + before.length);
-          render();
-        }
-        function download() {
-          const blob = new Blob([document.getElementById("input").value], { type: "text/markdown" });
-          const a = document.createElement("a");
-          a.href = URL.createObjectURL(blob);
-          a.download = "document.md";
-          a.click();
-        }
-        document.getElementById("input").addEventListener("input", render);
+      function parseMarkdown(md) {
+        let html = md
+          .replace(/^### (.*$)/gm, "<h3>$1</h3>")
+          .replace(/^## (.*$)/gm, "<h2>$1</h2>")
+          .replace(/^# (.*$)/gm, "<h2>$1</h2>")
+          .replace(/```(\w*)\n([\s\S]*?)```/g, "<pre><code>$2</code></pre>")
+          .replace(/`([^`]+)`/g, "<code>$1</code>")
+          .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+          .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+          .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">')
+          .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+          .replace(/^> (.*$)/gm, "<blockquote>$1</blockquote>")
+          .replace(/^- (.*$)/gm, "<li>$1</li>")
+          .replace(/^\d+\. (.*$)/gm, "<li>$1</li>")
+          .replace(/^---$/gm, "<hr>")
+          .replace(/\|(.+)\|/g, (match) => {
+            const cells = match.split("|").filter((c) => c.trim());
+            if (cells.every((c) => /^[\s-]+$/.test(c))) return "";
+            const tag = match.includes("---") ? "th" : "td";
+            return "<tr>" + cells.map((c) => `<${tag}>${c.trim()}</${tag}>`).join("") + "</tr>";
+          })
+          .replace(/(<tr>.*<\/tr>\n?)+/g, "<table>$&</table>")
+          .replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>")
+          .replace(/(<blockquote>.*<\/blockquote>\n?)+/g, (m) =>
+            m.replace(/<\/blockquote>\n?<blockquote>/g, "<br>")
+          )
+          .replace(/\n\n/g, "</p><p>")
+          .replace(/\n/g, "<br>");
+        return "<p>" + html + "</p>";
+      }
+      function render() {
+        document.getElementById("preview").innerHTML = parseMarkdown(
+          document.getElementById("input").value
+        );
+      }
+      function insert(before, after) {
+        const ta = document.getElementById("input");
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        const text = ta.value;
+        ta.value = text.slice(0, start) + before + text.slice(start, end) + after + text.slice(end);
+        ta.focus();
+        ta.setSelectionRange(start + before.length, end + before.length);
         render();
+      }
+      function download() {
+        const blob = new Blob([document.getElementById("input").value], { type: "text/markdown" });
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = "document.md";
+        a.click();
+      }
+      document.getElementById("input").addEventListener("input", render);
+      render();
 
-        // Theme toggle
-        function toggleTheme() {
-          const html = document.documentElement;
-          const currentTheme = html.getAttribute("data-theme");
-          const newTheme = currentTheme === "light" ? "dark" : "light";
-          html.setAttribute("data-theme", newTheme);
-          document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
-          localStorage.setItem("theme", newTheme);
-        }
+      // Theme toggle
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        document.getElementById("theme-icon").textContent = newTheme === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", newTheme);
+      }
 
-        // Load saved theme
-        const savedTheme = localStorage.getItem("theme") || "dark";
-        if (savedTheme === "light") {
-          document.documentElement.setAttribute("data-theme", "light");
-          document.getElementById("theme-icon").textContent = "☀️";
-        }
-</script>
-    
+      // Load saved theme
+      const savedTheme = localStorage.getItem("theme") || "dark";
+      if (savedTheme === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+        document.getElementById("theme-icon").textContent = "☀️";
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/text/markdown-preview.html
+++ b/tools/text/markdown-preview.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="Markdown 预览 - WebUtils" />
     <meta property="og:description" content="实时 Markdown 预览，支持 GFM 语法，可导出 HTML" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/text/markdown-preview.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "文本工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Markdown 预览",
-      "item": "https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Markdown 预览",
+            "item": "https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Markdown 预览 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Markdown 预览 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,900 +91,917 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet" media="print" onload="this.media = 'all'">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap"
+      rel="stylesheet"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle:focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      .theme-toggle:focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Breadcrumb Navigation
          ============================================ */
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: var(--space-3) var(--space-4);
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-sm);
-    margin-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-    margin-left: var(--space-6);
-    margin-right: var(--space-6);
-    flex-wrap: wrap;
-    max-width: 90%;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-sm);
+        margin-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+        margin-left: var(--space-6);
+        margin-right: var(--space-6);
+        flex-wrap: wrap;
+        max-width: 90%;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
 
-  .breadcrumb a:hover {
-    color: var(--color-accent-primary);
-  }
+      .breadcrumb a:hover {
+        color: var(--color-accent-primary);
+      }
 
-  .breadcrumb-separator {
-    color: var(--text-muted);
-    user-select: none;
-  }
+      .breadcrumb-separator {
+        color: var(--text-muted);
+        user-select: none;
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Layout
          ============================================ */
-  .main-container {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-bottom: var(--safe-area-bottom);
-    display: flex;
-    flex-direction: column;
-  }
+      .main-container {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-bottom: var(--safe-area-bottom);
+        display: flex;
+        flex-direction: column;
+      }
 
-  .toolbar {
-    display: flex;
-    gap: var(--space-3);
-    padding: var(--space-4) var(--space-6);
-    justify-content: center;
-    flex-wrap: wrap;
-  }
+      .toolbar {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-4) var(--space-6);
+        justify-content: center;
+        flex-wrap: wrap;
+      }
 
-  /* View Toggle Buttons */
-  .view-toggle {
-    display: flex;
-    gap: var(--space-2);
-    background: var(--color-bg-subtle);
-    padding: var(--space-2);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--color-border-subtle);
-  }
+      /* View Toggle Buttons */
+      .view-toggle {
+        display: flex;
+        gap: var(--space-2);
+        background: var(--color-bg-subtle);
+        padding: var(--space-2);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-subtle);
+      }
 
-  .view-btn {
-    padding: var(--space-2) var(--space-4);
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
-    font-family: var(--font-sans);
-    transition: all var(--transition-fast);
-  }
+      .view-btn {
+        padding: var(--space-2) var(--space-4);
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        font-size: 0.875rem;
+        font-weight: 500;
+        font-family: var(--font-sans);
+        transition: all var(--transition-fast);
+      }
 
-  .view-btn:hover {
-    color: var(--color-text-primary);
-    background: var(--color-bg-surface);
-  }
+      .view-btn:hover {
+        color: var(--color-text-primary);
+        background: var(--color-bg-surface);
+      }
 
-  .view-btn.active {
-    background: var(--color-accent-primary);
-    color: #fff;
-  }
+      .view-btn.active {
+        background: var(--color-accent-primary);
+        color: #fff;
+      }
 
-  .view-btn:focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: -2px;
-  }
+      .view-btn:focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: -2px;
+      }
 
-  /* Editor and Preview Panels */
-  .editor-container {
-    flex: 1;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-4);
-    padding: var(--space-6);
-    max-width: var(--container-max);
-    margin: 0 auto;
-    width: 100%;
-    overflow: hidden;
-  }
+      /* Editor and Preview Panels */
+      .editor-container {
+        flex: 1;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-6);
+        max-width: var(--container-max);
+        margin: 0 auto;
+        width: 100%;
+        overflow: hidden;
+      }
 
-  .panel {
-    display: flex;
-    flex-direction: column;
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-    box-shadow: var(--shadow-md);
-  }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        box-shadow: var(--shadow-md);
+      }
 
-  .panel.hidden {
-    display: none;
-  }
+      .panel.hidden {
+        display: none;
+      }
 
-  .panel-header {
-    padding: var(--space-4);
-    background: var(--color-bg-subtle);
-    border-bottom: 1px solid var(--color-border-subtle);
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
+      .panel-header {
+        padding: var(--space-4);
+        background: var(--color-bg-subtle);
+        border-bottom: 1px solid var(--color-border-subtle);
+        font-size: 0.9375rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
 
-  .panel-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: var(--space-4);
-  }
+      .panel-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: var(--space-4);
+      }
 
-  .editor {
-    flex: 1;
-    width: 100%;
-    border: none;
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    padding: var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.9375rem;
-    line-height: 1.6;
-    resize: none;
-    outline: none;
-    transition: all var(--transition-fast);
-  }
+      .editor {
+        flex: 1;
+        width: 100%;
+        border: none;
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        padding: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.9375rem;
+        line-height: 1.6;
+        resize: none;
+        outline: none;
+        transition: all var(--transition-fast);
+      }
 
-  .editor:focus {
-    box-shadow: inset 0 0 0 2px var(--color-accent-primary);
-  }
+      .editor:focus {
+        box-shadow: inset 0 0 0 2px var(--color-accent-primary);
+      }
 
-  .preview {
-    flex: 1;
-    overflow-y: auto;
-    font-size: 0.95rem;
-    line-height: 1.7;
-  }
+      .preview {
+        flex: 1;
+        overflow-y: auto;
+        font-size: 0.95rem;
+        line-height: 1.7;
+      }
 
-  /* Markdown Preview Styles */
-  .preview h1 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin: var(--space-5) 0 var(--space-3);
-    padding-bottom: var(--space-3);
-    border-bottom: 1px solid var(--color-border-default);
-    color: var(--color-text-primary);
-  }
+      /* Markdown Preview Styles */
+      .preview h1 {
+        font-size: 2rem;
+        font-weight: 700;
+        margin: var(--space-5) 0 var(--space-3);
+        padding-bottom: var(--space-3);
+        border-bottom: 1px solid var(--color-border-default);
+        color: var(--color-text-primary);
+      }
 
-  .preview h2 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin: var(--space-4) 0 var(--space-2);
-    padding-bottom: var(--space-2);
-    border-bottom: 1px solid var(--color-border-subtle);
-    color: var(--color-text-primary);
-  }
+      .preview h2 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin: var(--space-4) 0 var(--space-2);
+        padding-bottom: var(--space-2);
+        border-bottom: 1px solid var(--color-border-subtle);
+        color: var(--color-text-primary);
+      }
 
-  .preview h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin: var(--space-3) 0 var(--space-2);
-    color: var(--color-text-primary);
-  }
+      .preview h3 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: var(--space-3) 0 var(--space-2);
+        color: var(--color-text-primary);
+      }
 
-  .preview h4,
-  .preview h5,
-  .preview h6 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: var(--space-3) 0 var(--space-1);
-    color: var(--color-text-primary);
-  }
+      .preview h4,
+      .preview h5,
+      .preview h6 {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: var(--space-3) 0 var(--space-1);
+        color: var(--color-text-primary);
+      }
 
-  .preview p {
-    margin: var(--space-3) 0;
-    color: var(--color-text-primary);
-  }
+      .preview p {
+        margin: var(--space-3) 0;
+        color: var(--color-text-primary);
+      }
 
-  .preview ul,
-  .preview ol {
-    margin: var(--space-3) 0 var(--space-3) var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .preview ul,
+      .preview ol {
+        margin: var(--space-3) 0 var(--space-3) var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  .preview li {
-    margin: var(--space-1) 0;
-  }
+      .preview li {
+        margin: var(--space-1) 0;
+      }
 
-  .preview code {
-    background: var(--color-bg-subtle);
-    color: var(--color-accent-primary);
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.9em;
-  }
+      .preview code {
+        background: var(--color-bg-subtle);
+        color: var(--color-accent-primary);
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: 0.9em;
+      }
 
-  .preview pre {
-    background: var(--color-bg-subtle);
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    margin: var(--space-3) 0;
-    overflow-x: auto;
-  }
+      .preview pre {
+        background: var(--color-bg-subtle);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        margin: var(--space-3) 0;
+        overflow-x: auto;
+      }
 
-  .preview pre code {
-    background: none;
-    color: var(--color-accent-tertiary);
-    padding: 0;
-    border-radius: 0;
-  }
+      .preview pre code {
+        background: none;
+        color: var(--color-accent-tertiary);
+        padding: 0;
+        border-radius: 0;
+      }
 
-  .preview blockquote {
-    border-left: 3px solid var(--color-accent-primary);
-    padding-left: var(--space-4);
-    margin: var(--space-3) 0;
-    color: var(--color-text-secondary);
-    font-style: italic;
-  }
+      .preview blockquote {
+        border-left: 3px solid var(--color-accent-primary);
+        padding-left: var(--space-4);
+        margin: var(--space-3) 0;
+        color: var(--color-text-secondary);
+        font-style: italic;
+      }
 
-  .preview a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
+      .preview a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
 
-  .preview a:hover {
-    color: #00c299;
-    text-decoration: underline;
-  }
+      .preview a:hover {
+        color: #00c299;
+        text-decoration: underline;
+      }
 
-  .preview table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: var(--space-3) 0;
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-  }
+      .preview table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: var(--space-3) 0;
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
 
-  .preview th {
-    background: var(--color-bg-subtle);
-    border-bottom: 1px solid var(--color-border-subtle);
-    padding: var(--space-3);
-    text-align: left;
-    font-weight: 600;
-    color: var(--color-text-primary);
-  }
+      .preview th {
+        background: var(--color-bg-subtle);
+        border-bottom: 1px solid var(--color-border-subtle);
+        padding: var(--space-3);
+        text-align: left;
+        font-weight: 600;
+        color: var(--color-text-primary);
+      }
 
-  .preview td {
-    border-bottom: 1px solid var(--color-border-subtle);
-    padding: var(--space-3);
-    color: var(--color-text-primary);
-  }
+      .preview td {
+        border-bottom: 1px solid var(--color-border-subtle);
+        padding: var(--space-3);
+        color: var(--color-text-primary);
+      }
 
-  .preview tr:last-child td {
-    border-bottom: none;
-  }
+      .preview tr:last-child td {
+        border-bottom: none;
+      }
 
-  .preview img {
-    max-width: 100%;
-    height: auto;
-    border-radius: var(--radius-md);
-    margin: var(--space-3) 0;
-  }
+      .preview img {
+        max-width: 100%;
+        height: auto;
+        border-radius: var(--radius-md);
+        margin: var(--space-3) 0;
+      }
 
-  .preview hr {
-    border: none;
-    border-top: 1px solid var(--color-border-subtle);
-    margin: var(--space-4) 0;
-  }
+      .preview hr {
+        border: none;
+        border-top: 1px solid var(--color-border-subtle);
+        margin: var(--space-4) 0;
+      }
 
-  /* Char Counter */
-  .char-counter {
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-  }
+      /* Char Counter */
+      .char-counter {
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .breadcrumb {
-      margin-left: var(--space-4);
-      margin-right: var(--space-4);
-      max-width: calc(100% - var(--space-8));
-    }
+        .breadcrumb {
+          margin-left: var(--space-4);
+          margin-right: var(--space-4);
+          max-width: calc(100% - var(--space-8));
+        }
 
-    .toolbar {
-      padding: var(--space-3) var(--space-4);
-    }
+        .toolbar {
+          padding: var(--space-3) var(--space-4);
+        }
 
-    .editor-container {
-      grid-template-columns: 1fr;
-      gap: var(--space-3);
-      padding: var(--space-4);
-    }
+        .editor-container {
+          grid-template-columns: 1fr;
+          gap: var(--space-3);
+          padding: var(--space-4);
+        }
 
-    .panel.hidden {
-      display: none;
-    }
+        .panel.hidden {
+          display: none;
+        }
 
-    .view-toggle {
-      width: 100%;
-      justify-content: space-between;
-    }
+        .view-toggle {
+          width: 100%;
+          justify-content: space-between;
+        }
 
-    .view-btn {
-      flex: 1;
-    }
+        .view-btn {
+          flex: 1;
+        }
 
-    .editor {
-      min-height: 300px;
-    }
+        .editor {
+          min-height: 300px;
+        }
 
-    .preview {
-      min-height: 300px;
-    }
-  }
+        .preview {
+          min-height: 300px;
+        }
+      }
 
-  /* Tablet */
-  @media (min-width: 481px) and (max-width: 767px) {
-    .editor-container {
-      grid-template-columns: 1fr;
-      gap: var(--space-3);
-      padding: var(--space-5);
-    }
+      /* Tablet */
+      @media (min-width: 481px) and (max-width: 767px) {
+        .editor-container {
+          grid-template-columns: 1fr;
+          gap: var(--space-3);
+          padding: var(--space-5);
+        }
 
-    .panel.hidden {
-      display: none;
-    }
+        .panel.hidden {
+          display: none;
+        }
 
-    .editor {
-      min-height: 350px;
-    }
+        .editor {
+          min-height: 350px;
+        }
 
-    .preview {
-      min-height: 350px;
-    }
-  }
+        .preview {
+          min-height: 350px;
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
 
-    .editor-container {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
+        .editor-container {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-container {
-      padding-top: var(--space-6);
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-container {
+          padding-top: var(--space-6);
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-container">
-  <!-- Toolbar with View Toggle -->
-  <div class="toolbar">
-    <div class="view-toggle">
-      <button class="view-btn active" onclick="setView('split')" aria-label="分栏视图">分栏</button>
-      <button class="view-btn" onclick="setView('edit')" aria-label="编辑视图">编辑</button>
-      <button class="view-btn" onclick="setView('preview')" aria-label="预览视图">预览</button>
-    </div>
-  </div>
+        <!-- Toolbar with View Toggle -->
+        <div class="toolbar">
+          <div class="view-toggle">
+            <button class="view-btn active" onclick="setView('split')" aria-label="分栏视图">
+              分栏
+            </button>
+            <button class="view-btn" onclick="setView('edit')" aria-label="编辑视图">编辑</button>
+            <button class="view-btn" onclick="setView('preview')" aria-label="预览视图">
+              预览
+            </button>
+          </div>
+        </div>
 
-  <!-- Editor Container -->
-  <div class="editor-container">
-    <!-- Editor Panel -->
-    <div class="panel" id="editorPanel">
-      <div class="panel-header">
-        <span>Markdown 编辑器</span>
-        <span class="char-counter" id="charCount">0 字符</span>
-      </div>
-      <textarea class="editor" id="editor" oninput="updatePreview()" placeholder="在此输入 Markdown 内容..." aria-label="Markdown 编辑器"># Hello Markdown!
+        <!-- Editor Container -->
+        <div class="editor-container">
+          <!-- Editor Panel -->
+          <div class="panel" id="editorPanel">
+            <div class="panel-header">
+              <span>Markdown 编辑器</span>
+              <span class="char-counter" id="charCount">0 字符</span>
+            </div>
+            <textarea
+              class="editor"
+              id="editor"
+              oninput="updatePreview()"
+              placeholder="在此输入 Markdown 内容..."
+              aria-label="Markdown 编辑器"
+            >
+# Hello Markdown!
 
 欢迎使用 **Markdown 预览器**。
 
@@ -1016,225 +1036,226 @@ function greet(name) {
 
 ---
 
-*斜体* 和 **粗体** 和 ~~删除线~~</textarea>
+*斜体* 和 **粗体** 和 ~~删除线~~</textarea
+            >
+          </div>
+
+          <!-- Preview Panel -->
+          <div class="panel" id="previewPanel">
+            <div class="panel-header">
+              <span>实时预览</span>
+            </div>
+            <div class="panel-content preview" id="preview"></div>
+          </div>
+        </div>
+        <section class="faq-section" style="padding: var(--space-5) var(--space-6)">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>Markdown 预览器安全吗？我的内容会上传服务器吗？</summary>
+            <p>
+              完全安全。所有 Markdown 解析与 HTML 渲染都在浏览器本地完成，并经过 DOMPurify 净化防止
+              XSS，你的内容不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>分栏、编辑、预览三种视图有什么区别？</summary>
+            <p>
+              分栏视图同时显示编辑器和预览区，方便边写边看；编辑视图只显示输入区，适合专注写作；预览视图只显示渲染结果，适合检查最终效果或全屏阅读。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>这个预览器使用的是哪个 Markdown 库？支持 GFM 吗？</summary>
+            <p>
+              使用 marked.js 解析 Markdown，默认支持 GitHub Flavored
+              Markdown（GFM），包括表格、任务列表、删除线（~~text~~）和自动链接等扩展语法。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>预览内容安全吗？会执行 Markdown 里的 JavaScript 吗？</summary>
+            <p>
+              不会。预览结果通过 DOMPurify 进行 XSS 净化处理，所有内嵌的 script
+              标签和危险属性都会被自动移除，可以放心粘贴来自未知来源的 Markdown。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>Markdown 预览器可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件
+              HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册。marked.js 和 DOMPurify
+              通过 CDN 加载，离线时需提前缓存。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
 
-    <!-- Preview Panel -->
-    <div class="panel" id="previewPanel">
-      <div class="panel-header">
-        <span>实时预览</span>
-      </div>
-      <div class="panel-content preview" id="preview"></div>
-    </div>
-  </div>
-  <section class="faq-section" style="padding: var(--space-5) var(--space-6)">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>Markdown 预览器安全吗？我的内容会上传服务器吗？</summary>
-      <p>
-        完全安全。所有 Markdown 解析与 HTML 渲染都在浏览器本地完成，并经过 DOMPurify 净化防止
-        XSS，你的内容不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>分栏、编辑、预览三种视图有什么区别？</summary>
-      <p>
-        分栏视图同时显示编辑器和预览区，方便边写边看；编辑视图只显示输入区，适合专注写作；预览视图只显示渲染结果，适合检查最终效果或全屏阅读。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>这个预览器使用的是哪个 Markdown 库？支持 GFM 吗？</summary>
-      <p>
-        使用 marked.js 解析 Markdown，默认支持 GitHub Flavored
-        Markdown（GFM），包括表格、任务列表、删除线（~~text~~）和自动链接等扩展语法。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>预览内容安全吗？会执行 Markdown 里的 JavaScript 吗？</summary>
-      <p>
-        不会。预览结果通过 DOMPurify 进行 XSS 净化处理，所有内嵌的 script
-        标签和危险属性都会被自动移除，可以放心粘贴来自未知来源的 Markdown。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>Markdown 预览器可以离线使用吗？</summary>
-      <p>
-        可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册。marked.js
-        和 DOMPurify 通过 CDN 加载，离线时需提前缓存。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "文本工具",
-              "item": "https://tools.realtime-ai.chat/#text"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "Markdown 预览器",
-              "item": "https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
-            }
-          ]
-        }
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/#text"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Markdown 预览器",
+            "item": "https://tools.realtime-ai.chat/tools/text/markdown-preview.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Markdown 预览器安全吗？我的内容会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有 Markdown 解析与 HTML 渲染都在浏览器本地完成，并经过 DOMPurify 净化防止 XSS，你的内容不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "分栏、编辑、预览三种视图有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "分栏视图同时显示编辑器和预览区，方便边写边看；编辑视图只显示输入区，适合专注写作；预览视图只显示渲染结果，适合检查最终效果或全屏阅读。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "这个预览器使用的是哪个 Markdown 库？支持 GFM 吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "使用 marked.js 解析 Markdown，默认支持 GitHub Flavored Markdown（GFM），包括表格、任务列表、删除线（~~text~~）和自动链接等扩展语法。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "预览内容安全吗？会执行 Markdown 里的 JavaScript 吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "不会。预览结果通过 DOMPurify 进行 XSS 净化处理，所有内嵌的 script 标签和危险属性都会被自动移除，可以放心粘贴来自未知来源的 Markdown。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Markdown 预览器可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册。marked.js 和 DOMPurify 通过 CDN 加载，离线时需提前缓存。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Markdown 预览器安全吗？我的内容会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有 Markdown 解析与 HTML 渲染都在浏览器本地完成，并经过 DOMPurify 净化防止 XSS，你的内容不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "分栏、编辑、预览三种视图有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "分栏视图同时显示编辑器和预览区，方便边写边看；编辑视图只显示输入区，适合专注写作；预览视图只显示渲染结果，适合检查最终效果或全屏阅读。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "这个预览器使用的是哪个 Markdown 库？支持 GFM 吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "使用 marked.js 解析 Markdown，默认支持 GitHub Flavored Markdown（GFM），包括表格、任务列表、删除线（~~text~~）和自动链接等扩展语法。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "预览内容安全吗？会执行 Markdown 里的 JavaScript 吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "不会。预览结果通过 DOMPurify 进行 XSS 净化处理，所有内嵌的 script 标签和危险属性都会被自动移除，可以放心粘贴来自未知来源的 Markdown。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Markdown 预览器可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，将页面保存到本地后即使断网也能正常运行，无需安装或注册。marked.js 和 DOMPurify 通过 CDN 加载，离线时需提前缓存。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // Variables
-  // ============================================
-  let currentView = "split";
-  const editor = document.getElementById("editor");
-  const preview = document.getElementById("preview");
-  const editorPanel = document.getElementById("editorPanel");
-  const previewPanel = document.getElementById("previewPanel");
-  const charCountEl = document.getElementById("charCount");
+    <script>
+      // ============================================
+      // Variables
+      // ============================================
+      let currentView = "split";
+      const editor = document.getElementById("editor");
+      const preview = document.getElementById("preview");
+      const editorPanel = document.getElementById("editorPanel");
+      const previewPanel = document.getElementById("previewPanel");
+      const charCountEl = document.getElementById("charCount");
 
-  // ============================================
-  // Markdown Preview Update
-  // ============================================
-  window.updatePreview = function () {
-    const markdown = editor.value;
-    const html = marked.parse(markdown);
-    const sanitized = DOMPurify.sanitize(html);
-    preview.innerHTML = sanitized;
-    updateCharCount();
-  };
+      // ============================================
+      // Markdown Preview Update
+      // ============================================
+      window.updatePreview = function () {
+        const markdown = editor.value;
+        const html = marked.parse(markdown);
+        const sanitized = DOMPurify.sanitize(html);
+        preview.innerHTML = sanitized;
+        updateCharCount();
+      };
 
-  function updateCharCount() {
-    const count = editor.value.length;
-    charCountEl.textContent = count + " 字符";
-  }
+      function updateCharCount() {
+        const count = editor.value.length;
+        charCountEl.textContent = count + " 字符";
+      }
 
-  // ============================================
-  // View Mode Toggle
-  // ============================================
-  window.setView = function (view) {
-    currentView = view;
+      // ============================================
+      // View Mode Toggle
+      // ============================================
+      window.setView = function (view) {
+        currentView = view;
 
-    // Update button states
-    document.querySelectorAll(".view-btn").forEach((btn) => btn.classList.remove("active"));
-    document
-      .querySelector(`.view-btn:nth-child(${view === "split" ? 1 : view === "edit" ? 2 : 3})`)
-      .classList.add("active");
+        // Update button states
+        document.querySelectorAll(".view-btn").forEach((btn) => btn.classList.remove("active"));
+        document
+          .querySelector(`.view-btn:nth-child(${view === "split" ? 1 : view === "edit" ? 2 : 3})`)
+          .classList.add("active");
 
-    // Update panel visibility
-    editorPanel.classList.toggle("hidden", view === "preview");
-    previewPanel.classList.toggle("hidden", view === "edit");
+        // Update panel visibility
+        editorPanel.classList.toggle("hidden", view === "preview");
+        previewPanel.classList.toggle("hidden", view === "edit");
 
-    // Adjust grid for single panel
-    const container = document.querySelector(".editor-container");
-    if (view === "split") {
-      container.style.gridTemplateColumns = window.innerWidth >= 768 ? "1fr 1fr" : "1fr";
-    } else {
-      container.style.gridTemplateColumns = "1fr";
-    }
-  };
+        // Adjust grid for single panel
+        const container = document.querySelector(".editor-container");
+        if (view === "split") {
+          container.style.gridTemplateColumns = window.innerWidth >= 768 ? "1fr 1fr" : "1fr";
+        } else {
+          container.style.gridTemplateColumns = "1fr";
+        }
+      };
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  window.toggleTheme = function () {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
+      // ============================================
+      // Theme Management
+      // ============================================
+      window.toggleTheme = function () {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      };
 
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
 
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  updatePreview();
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      updatePreview();
 
-  // Handle resize for responsive view
-  window.addEventListener("resize", function () {
-    if (currentView === "split" && window.innerWidth >= 768) {
-      document.querySelector(".editor-container").style.gridTemplateColumns = "1fr 1fr";
-    } else if (currentView === "split" && window.innerWidth < 768) {
-      document.querySelector(".editor-container").style.gridTemplateColumns = "1fr";
-      // Show both panels stacked
-      editorPanel.classList.remove("hidden");
-      previewPanel.classList.remove("hidden");
-    }
-  });
-</script>
-    
+      // Handle resize for responsive view
+      window.addEventListener("resize", function () {
+        if (currentView === "split" && window.innerWidth >= 768) {
+          document.querySelector(".editor-container").style.gridTemplateColumns = "1fr 1fr";
+        } else if (currentView === "split" && window.innerWidth < 768) {
+          document.querySelector(".editor-container").style.gridTemplateColumns = "1fr";
+          // Show both panels stacked
+          editorPanel.classList.remove("hidden");
+          previewPanel.classList.remove("hidden");
+        }
+      });
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/text/text-diff.html
+++ b/tools/text/text-diff.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "文本工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "文本 Diff",
-      "item": "https://tools.realtime-ai.chat/tools/text/text-diff.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "文本 Diff",
+            "item": "https://tools.realtime-ai.chat/tools/text/text-diff.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "文本 Diff - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "文本 Diff - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1105 +88,1114 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
-  .nav-back-text {
-    display: inline;
-  }
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
-    padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  .tool-card {
-    width: 100%;
-    max-width: var(--container-max);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
-    border: 1px solid var(--glass-border);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    box-shadow: var(--shadow-lg);
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    transition: all var(--transition-normal);
-    animation: fade-in-up 0.4s ease-out;
-  }
-  @keyframes fade-in-up {
-    from {
-      opacity: 0;
-      transform: translateY(16px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-  .tool-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    margin-bottom: var(--space-5);
-    padding-bottom: var(--space-5);
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-  .tool-icon {
-    width: 48px;
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-tertiary));
-    border-radius: var(--radius-md);
-    font-size: 1.5rem;
-    color: var(--color-bg-deep);
-    box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
-  }
-  .tool-info h1 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text-primary);
-  }
-  .tool-info .desc {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-top: var(--space-1);
-  }
-  .toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-3);
-    margin-bottom: var(--space-5);
-  }
-  .btn-group {
-    display: flex;
-    gap: 2px;
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-sm);
-    padding: 2px;
-  }
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    height: 36px;
-    padding: 0 var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    white-space: nowrap;
-  }
-  .btn:hover {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-  }
-  .btn-primary {
-    background: var(--color-accent-primary);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    background: #00b894;
-    box-shadow: var(--shadow-glow);
-  }
-  .options-bar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-5);
-    align-items: center;
-    margin-bottom: var(--space-5);
-    font-size: 0.875rem;
-  }
-  .option-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    color: var(--color-text-secondary);
-  }
-  .option-item input[type="radio"] {
-    width: 16px;
-    height: 16px;
-    accent-color: var(--color-accent-primary);
-    cursor: pointer;
-  }
-  .option-item label {
-    cursor: pointer;
-  }
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-5);
-    margin-bottom: var(--space-5);
-  }
-  .panel {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-  .panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-3);
-  }
-  .panel-label {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-  .panel-textarea {
-    flex: 1;
-    width: 100%;
-    min-height: 250px;
-    padding: var(--space-4);
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--color-text-primary);
-    background: var(--color-bg-input);
-    border: 2px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    resize: vertical;
-    tab-size: 2;
-    transition: all var(--transition-fast);
-  }
-  .panel-textarea::placeholder {
-    color: var(--text-muted);
-  }
-  .panel-textarea:hover {
-    border-color: var(--color-border-strong);
-  }
-  .panel-textarea:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
-  }
-  .result-panel {
-    background: var(--color-bg-input);
-    border: 2px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    min-height: 200px;
-    max-height: 400px;
-    overflow-y: auto;
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.8;
-  }
-  .result-panel pre {
-    margin: 0;
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-  }
-  .diff-line {
-    padding: 2px var(--space-2);
-    margin: 0 calc(var(--space-4) * -1);
-  }
-  .diff-added {
-    background: rgba(34, 197, 94, 0.15);
-    border-left: 3px solid var(--color-success);
-    color: var(--color-success);
-  }
-  .diff-removed {
-    background: rgba(239, 68, 68, 0.15);
-    border-left: 3px solid var(--color-error);
-    color: var(--color-error);
-    text-decoration: line-through;
-  }
-  .diff-unchanged {
-    color: var(--color-text-secondary);
-  }
-  .status-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-    margin-top: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--color-border-subtle);
-  }
-  .status {
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-  .status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--text-muted);
-  }
-  .status-dot.active {
-    background: var(--color-accent-primary);
-    box-shadow: 0 0 10px rgba(0, 212, 170, 0.5);
-  }
-  .footer {
-    text-align: center;
-    margin-top: var(--space-5);
-    padding-top: var(--space-4);
-  }
-  .footer p {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    flex-wrap: wrap;
-  }
-  .footer a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
-  .footer a:hover {
-    color: var(--color-text-primary);
-  }
-  @media (max-width: 900px) {
-    .panels {
-      grid-template-columns: 1fr;
-      gap: var(--space-4);
-    }
-    .panel-textarea {
-      min-height: 180px;
-    }
-  }
-  @media (max-width: 640px) {
-    :root {
-      --nav-height: 52px;
-    }
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
-    .nav-back-text {
-      display: none;
-    }
-    .main-content {
-      padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
-        calc(var(--space-5) + var(--safe-area-bottom));
-    }
-    .tool-card {
-      padding: var(--space-4);
-      border-radius: var(--radius-md);
-    }
-    .tool-header {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-      margin-bottom: var(--space-4);
-      padding-bottom: var(--space-4);
-    }
-    .tool-icon {
-      width: 40px;
-      height: 40px;
-      font-size: 1.25rem;
-    }
-    .tool-info h1 {
-      font-size: 1.125rem;
-    }
-    .toolbar {
-      gap: var(--space-2);
-      margin-bottom: var(--space-4);
-    }
-    .btn-group {
-      flex-wrap: wrap;
-    }
-    .btn {
-      height: 34px;
-      padding: 0 var(--space-3);
-      font-size: 0.75rem;
-    }
-    .options-bar {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-      margin-bottom: var(--space-4);
-    }
-    .panel-textarea {
-      min-height: 150px;
-    }
-    .result-panel {
-      min-height: 150px;
-      max-height: 300px;
-    }
-    .status-bar {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-3);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible),
-  textarea:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
+      .nav-back-text {
+        display: inline;
+      }
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-5));
+        padding-bottom: calc(var(--space-6) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      .tool-card {
+        width: 100%;
+        max-width: var(--container-max);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(16px);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        box-shadow: var(--shadow-lg);
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        transition: all var(--transition-normal);
+        animation: fade-in-up 0.4s ease-out;
+      }
+      @keyframes fade-in-up {
+        from {
+          opacity: 0;
+          transform: translateY(16px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .tool-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        margin-bottom: var(--space-5);
+        padding-bottom: var(--space-5);
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+      .tool-icon {
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(
+          135deg,
+          var(--color-accent-primary),
+          var(--color-accent-tertiary)
+        );
+        border-radius: var(--radius-md);
+        font-size: 1.5rem;
+        color: var(--color-bg-deep);
+        box-shadow: 0 4px 12px rgba(0, 212, 170, 0.25);
+      }
+      .tool-info h1 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--color-text-primary);
+      }
+      .tool-info .desc {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        margin-top: var(--space-1);
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-bottom: var(--space-5);
+      }
+      .btn-group {
+        display: flex;
+        gap: 2px;
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-sm);
+        padding: 2px;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        height: 36px;
+        padding: 0 var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        white-space: nowrap;
+      }
+      .btn:hover {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+      }
+      .btn-primary {
+        background: var(--color-accent-primary);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        background: #00b894;
+        box-shadow: var(--shadow-glow);
+      }
+      .options-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-5);
+        align-items: center;
+        margin-bottom: var(--space-5);
+        font-size: 0.875rem;
+      }
+      .option-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--color-text-secondary);
+      }
+      .option-item input[type="radio"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-accent-primary);
+        cursor: pointer;
+      }
+      .option-item label {
+        cursor: pointer;
+      }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+        margin-bottom: var(--space-5);
+      }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      .panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--space-3);
+      }
+      .panel-label {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .panel-textarea {
+        flex: 1;
+        width: 100%;
+        min-height: 250px;
+        padding: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: var(--color-text-primary);
+        background: var(--color-bg-input);
+        border: 2px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        resize: vertical;
+        tab-size: 2;
+        transition: all var(--transition-fast);
+      }
+      .panel-textarea::placeholder {
+        color: var(--text-muted);
+      }
+      .panel-textarea:hover {
+        border-color: var(--color-border-strong);
+      }
+      .panel-textarea:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.15);
+      }
+      .result-panel {
+        background: var(--color-bg-input);
+        border: 2px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        min-height: 200px;
+        max-height: 400px;
+        overflow-y: auto;
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        line-height: 1.8;
+      }
+      .result-panel pre {
+        margin: 0;
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
+      }
+      .diff-line {
+        padding: 2px var(--space-2);
+        margin: 0 calc(var(--space-4) * -1);
+      }
+      .diff-added {
+        background: rgba(34, 197, 94, 0.15);
+        border-left: 3px solid var(--color-success);
+        color: var(--color-success);
+      }
+      .diff-removed {
+        background: rgba(239, 68, 68, 0.15);
+        border-left: 3px solid var(--color-error);
+        color: var(--color-error);
+        text-decoration: line-through;
+      }
+      .diff-unchanged {
+        color: var(--color-text-secondary);
+      }
+      .status-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--space-4);
+        margin-top: var(--space-5);
+        padding-top: var(--space-5);
+        border-top: 1px solid var(--color-border-subtle);
+      }
+      .status {
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--text-muted);
+      }
+      .status-dot.active {
+        background: var(--color-accent-primary);
+        box-shadow: 0 0 10px rgba(0, 212, 170, 0.5);
+      }
+      .footer {
+        text-align: center;
+        margin-top: var(--space-5);
+        padding-top: var(--space-4);
+      }
+      .footer p {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .footer a {
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        transition: color var(--transition-fast);
+      }
+      .footer a:hover {
+        color: var(--color-text-primary);
+      }
+      @media (max-width: 900px) {
+        .panels {
+          grid-template-columns: 1fr;
+          gap: var(--space-4);
+        }
+        .panel-textarea {
+          min-height: 180px;
+        }
+      }
+      @media (max-width: 640px) {
+        :root {
+          --nav-height: 52px;
+        }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
+        .nav-back-text {
+          display: none;
+        }
+        .main-content {
+          padding: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4)) var(--space-4)
+            calc(var(--space-5) + var(--safe-area-bottom));
+        }
+        .tool-card {
+          padding: var(--space-4);
+          border-radius: var(--radius-md);
+        }
+        .tool-header {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+          margin-bottom: var(--space-4);
+          padding-bottom: var(--space-4);
+        }
+        .tool-icon {
+          width: 40px;
+          height: 40px;
+          font-size: 1.25rem;
+        }
+        .tool-info h1 {
+          font-size: 1.125rem;
+        }
+        .toolbar {
+          gap: var(--space-2);
+          margin-bottom: var(--space-4);
+        }
+        .btn-group {
+          flex-wrap: wrap;
+        }
+        .btn {
+          height: 34px;
+          padding: 0 var(--space-3);
+          font-size: 0.75rem;
+        }
+        .options-bar {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+          margin-bottom: var(--space-4);
+        }
+        .panel-textarea {
+          min-height: 150px;
+        }
+        .result-panel {
+          min-height: 150px;
+          max-height: 300px;
+        }
+        .status-bar {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: var(--space-3);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible),
+      textarea:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="tool-card">
-    <div class="tool-header">
-      <div class="tool-icon">📝</div>
-      <div class="tool-info">
-        <h1>文本对比 Diff</h1>
-        <p class="desc">智能文本差异对比，支持多种对比模式</p>
-      </div>
+        <div class="tool-card">
+          <div class="tool-header">
+            <div class="tool-icon">📝</div>
+            <div class="tool-info">
+              <h1>文本对比 Diff</h1>
+              <p class="desc">智能文本差异对比，支持多种对比模式</p>
+            </div>
+          </div>
+          <div class="toolbar">
+            <div class="btn-group">
+              <button class="btn btn-primary" onclick="compareTexts()">对比</button>
+              <button class="btn" onclick="clearAll()">清空</button>
+              <button class="btn" onclick="swapTexts()">交换</button>
+            </div>
+            <div class="btn-group">
+              <button class="btn" onclick="copyResult()">复制结果</button>
+            </div>
+          </div>
+          <div class="options-bar">
+            <div class="option-item"><strong>对比模式：</strong></div>
+            <div class="option-item">
+              <input type="radio" name="diffMode" id="modeLine" value="line" checked="" />
+              <label for="modeLine">逐行对比</label>
+            </div>
+            <div class="option-item">
+              <input type="radio" name="diffMode" id="modeWord" value="word" />
+              <label for="modeWord">词级对比</label>
+            </div>
+            <div class="option-item">
+              <input type="radio" name="diffMode" id="modeChar" value="char" />
+              <label for="modeChar">字符级对比</label>
+            </div>
+          </div>
+          <div class="panels">
+            <div class="panel">
+              <div class="panel-header"><span class="panel-label">原始文本</span></div>
+              <textarea id="text1" class="panel-textarea" placeholder="输入原始文本 ..."></textarea>
+            </div>
+            <div class="panel">
+              <div class="panel-header"><span class="panel-label">新文本</span></div>
+              <textarea id="text2" class="panel-textarea" placeholder="输入新文本 ..."></textarea>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="panel-header"><span class="panel-label">对比结果</span></div>
+            <div class="result-panel" id="result">
+              <pre class="diff-unchanged">点击"对比"按钮查看文本差异...</pre>
+            </div>
+          </div>
+          <div class="status-bar">
+            <div class="status">
+              <span class="status-dot" id="statusDot"></span>
+              <span id="statusText">就绪</span>
+            </div>
+          </div>
+        </div>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>这个文本对比工具安全吗？输入的文本会上传服务器吗？</summary>
+            <p>
+              完全安全。所有对比计算都在你的浏览器本地完成，输入的文本不会上传到任何服务器，也不会被记录或存储。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>逐行对比、词级对比、字符级对比有什么区别？</summary>
+            <p>
+              逐行对比以行为单位找出新增和删除的行，适合比较代码或配置文件；词级对比以空格分隔的词为单位，适合比较文章段落；字符级对比精确到每个字符，适合查找极细微的改动。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何快速定位两段文本的不同之处？</summary>
+            <p>
+              粘贴两段文本后点击「对比」，结果区会用绿色高亮显示新增内容（+
+              前缀），红色删除线显示被删除内容（- 前缀），相同部分用灰色展示，无需手动逐行比对。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>可以对比中文文本吗？</summary>
+            <p>
+              可以。本工具支持任意 Unicode
+              文本，包括中文、日文、韩文等。逐行模式对中文段落效果最佳；字符级模式可精确定位中文字符级别的差异。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>对比结果可以导出或复制吗？</summary>
+            <p>
+              可以。点击「复制结果」按钮，对比结果（含 +/-
+              前缀标记）会被复制到剪贴板，可以粘贴到任意编辑器或文档中保存。
+            </p>
+          </details>
+        </section>
+        <footer class="footer">
+          <p>
+            <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+            <span>·</span>
+            <span>纯前端 · 无服务器</span>
+            <span>·</span>
+            <a href="../../index.html">WebUtils</a>
+          </p>
+        </footer>
+      </main>
     </div>
-    <div class="toolbar">
-      <div class="btn-group">
-        <button class="btn btn-primary" onclick="compareTexts()">对比</button>
-        <button class="btn" onclick="clearAll()">清空</button>
-        <button class="btn" onclick="swapTexts()">交换</button>
-      </div>
-      <div class="btn-group">
-        <button class="btn" onclick="copyResult()">复制结果</button>
-      </div>
-    </div>
-    <div class="options-bar">
-      <div class="option-item"><strong>对比模式：</strong></div>
-      <div class="option-item">
-        <input type="radio" name="diffMode" id="modeLine" value="line" checked="">
-        <label for="modeLine">逐行对比</label>
-      </div>
-      <div class="option-item">
-        <input type="radio" name="diffMode" id="modeWord" value="word">
-        <label for="modeWord">词级对比</label>
-      </div>
-      <div class="option-item">
-        <input type="radio" name="diffMode" id="modeChar" value="char">
-        <label for="modeChar">字符级对比</label>
-      </div>
-    </div>
-    <div class="panels">
-      <div class="panel">
-        <div class="panel-header"><span class="panel-label">原始文本</span></div>
-        <textarea id="text1" class="panel-textarea" placeholder="输入原始文本 ..."></textarea>
-      </div>
-      <div class="panel">
-        <div class="panel-header"><span class="panel-label">新文本</span></div>
-        <textarea id="text2" class="panel-textarea" placeholder="输入新文本 ..."></textarea>
-      </div>
-    </div>
-    <div class="panel">
-      <div class="panel-header"><span class="panel-label">对比结果</span></div>
-      <div class="result-panel" id="result">
-        <pre class="diff-unchanged">点击"对比"按钮查看文本差异...</pre>
-      </div>
-    </div>
-    <div class="status-bar">
-      <div class="status">
-        <span class="status-dot" id="statusDot"></span>
-        <span id="statusText">就绪</span>
-      </div>
-    </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>这个文本对比工具安全吗？输入的文本会上传服务器吗？</summary>
-      <p>
-        完全安全。所有对比计算都在你的浏览器本地完成，输入的文本不会上传到任何服务器，也不会被记录或存储。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>逐行对比、词级对比、字符级对比有什么区别？</summary>
-      <p>
-        逐行对比以行为单位找出新增和删除的行，适合比较代码或配置文件；词级对比以空格分隔的词为单位，适合比较文章段落；字符级对比精确到每个字符，适合查找极细微的改动。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何快速定位两段文本的不同之处？</summary>
-      <p>
-        粘贴两段文本后点击「对比」，结果区会用绿色高亮显示新增内容（+
-        前缀），红色删除线显示被删除内容（- 前缀），相同部分用灰色展示，无需手动逐行比对。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>可以对比中文文本吗？</summary>
-      <p>
-        可以。本工具支持任意 Unicode
-        文本，包括中文、日文、韩文等。逐行模式对中文段落效果最佳；字符级模式可精确定位中文字符级别的差异。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>对比结果可以导出或复制吗？</summary>
-      <p>
-        可以。点击「复制结果」按钮，对比结果（含 +/-
-        前缀标记）会被复制到剪贴板，可以粘贴到任意编辑器或文档中保存。
-      </p>
-    </details>
-  </section>
-  <footer class="footer">
-    <p>
-      <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noreferrer">GitHub</a>
-      <span>·</span>
-      <span>纯前端 · 无服务器</span>
-      <span>·</span>
-      <a href="../../index.html">WebUtils</a>
-    </p>
-  </footer>
-</main>
-    </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/diff@5.1.0/dist/diff.min.js"></script>
-<script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "文本工具",
-              "item": "https://tools.realtime-ai.chat/#text"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "文本对比",
-              "item": "https://tools.realtime-ai.chat/tools/text/text-diff.html"
-            }
-          ]
-        }
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/#text"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "文本对比",
+            "item": "https://tools.realtime-ai.chat/tools/text/text-diff.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "这个文本对比工具安全吗？输入的文本会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有对比计算都在你的浏览器本地完成，输入的文本不会上传到任何服务器，也不会被记录或存储。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "逐行对比、词级对比、字符级对比有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "逐行对比以行为单位找出新增和删除的行，适合比较代码或配置文件；词级对比以空格分隔的词为单位，适合比较文章段落；字符级对比精确到每个字符，适合查找极细微的改动。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何快速定位两段文本的不同之处？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "粘贴两段文本后点击「对比」，结果区会用绿色高亮显示新增内容（+ 前缀），红色删除线显示被删除内容（- 前缀），相同部分用灰色展示，无需手动逐行比对。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "可以对比中文文本吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具支持任意 Unicode 文本，包括中文、日文、韩文等。逐行模式对中文段落效果最佳；字符级模式可精确定位中文字符级别的差异。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "对比结果可以导出或复制吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。点击「复制结果」按钮，对比结果（含 +/- 前缀标记）会被复制到剪贴板，可以粘贴到任意编辑器或文档中保存。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "这个文本对比工具安全吗？输入的文本会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有对比计算都在你的浏览器本地完成，输入的文本不会上传到任何服务器，也不会被记录或存储。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "逐行对比、词级对比、字符级对比有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "逐行对比以行为单位找出新增和删除的行，适合比较代码或配置文件；词级对比以空格分隔的词为单位，适合比较文章段落；字符级对比精确到每个字符，适合查找极细微的改动。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何快速定位两段文本的不同之处？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "粘贴两段文本后点击「对比」，结果区会用绿色高亮显示新增内容（+ 前缀），红色删除线显示被删除内容（- 前缀），相同部分用灰色展示，无需手动逐行比对。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "可以对比中文文本吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具支持任意 Unicode 文本，包括中文、日文、韩文等。逐行模式对中文段落效果最佳；字符级模式可精确定位中文字符级别的差异。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "对比结果可以导出或复制吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。点击「复制结果」按钮，对比结果（含 +/- 前缀标记）会被复制到剪贴板，可以粘贴到任意编辑器或文档中保存。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  function setStatus(text, active) {
-    document.getElementById("statusText").textContent = text;
-    document.getElementById("statusDot").classList.toggle("active", !!active);
-  }
-
-  function compareTexts() {
-    var text1 = document.getElementById("text1").value;
-    var text2 = document.getElementById("text2").value;
-    var resultEl = document.getElementById("result");
-
-    if (!text1 && !text2) {
-      resultEl.innerHTML = '<pre class="diff-unchanged">请输入要对比的文本...</pre>';
-      setStatus("就绪");
-      return;
-    }
-
-    var diffMode = document.querySelector('input[name="diffMode"]:checked').value;
-    var diff;
-
-    setStatus("对比中...", true);
-
-    setTimeout(function () {
-      switch (diffMode) {
-        case "line":
-          diff = Diff.diffLines(text1, text2);
-          break;
-        case "word":
-          diff = Diff.diffWords(text1, text2);
-          break;
-        case "char":
-          diff = Diff.diffChars(text1, text2);
-          break;
+    <script>
+      function setStatus(text, active) {
+        document.getElementById("statusText").textContent = text;
+        document.getElementById("statusDot").classList.toggle("active", !!active);
       }
 
-      var html = "<pre>";
-      var addedCount = 0,
-        removedCount = 0,
-        unchangedCount = 0;
+      function compareTexts() {
+        var text1 = document.getElementById("text1").value;
+        var text2 = document.getElementById("text2").value;
+        var resultEl = document.getElementById("result");
 
-      diff.forEach(function (part) {
-        var lines = part.value.split("\n");
-        lines.forEach(function (line, i) {
-          if (i === lines.length - 1 && line === "") return;
-          var className = "diff-unchanged";
-          var prefix = "  ";
-          if (part.added) {
-            className = "diff-added";
-            prefix = "+ ";
-            addedCount++;
-          } else if (part.removed) {
-            className = "diff-removed";
-            prefix = "- ";
-            removedCount++;
-          } else {
-            unchangedCount++;
+        if (!text1 && !text2) {
+          resultEl.innerHTML = '<pre class="diff-unchanged">请输入要对比的文本...</pre>';
+          setStatus("就绪");
+          return;
+        }
+
+        var diffMode = document.querySelector('input[name="diffMode"]:checked').value;
+        var diff;
+
+        setStatus("对比中...", true);
+
+        setTimeout(function () {
+          switch (diffMode) {
+            case "line":
+              diff = Diff.diffLines(text1, text2);
+              break;
+            case "word":
+              diff = Diff.diffWords(text1, text2);
+              break;
+            case "char":
+              diff = Diff.diffChars(text1, text2);
+              break;
           }
-          html +=
-            '<div class="diff-line ' + className + '">' + escapeHtml(prefix + line) + "</div>";
+
+          var html = "<pre>";
+          var addedCount = 0,
+            removedCount = 0,
+            unchangedCount = 0;
+
+          diff.forEach(function (part) {
+            var lines = part.value.split("\n");
+            lines.forEach(function (line, i) {
+              if (i === lines.length - 1 && line === "") return;
+              var className = "diff-unchanged";
+              var prefix = "  ";
+              if (part.added) {
+                className = "diff-added";
+                prefix = "+ ";
+                addedCount++;
+              } else if (part.removed) {
+                className = "diff-removed";
+                prefix = "- ";
+                removedCount++;
+              } else {
+                unchangedCount++;
+              }
+              html +=
+                '<div class="diff-line ' + className + '">' + escapeHtml(prefix + line) + "</div>";
+            });
+          });
+
+          html += "</pre>";
+          resultEl.innerHTML = html;
+          setStatus(
+            "对比完成: " +
+              addedCount +
+              " 处新增, " +
+              removedCount +
+              " 处删除, " +
+              unchangedCount +
+              " 处不变",
+            false
+          );
+        }, 100);
+      }
+
+      function clearAll() {
+        document.getElementById("text1").value = "";
+        document.getElementById("text2").value = "";
+        document.getElementById("result").innerHTML =
+          '<pre class="diff-unchanged">点击"对比"按钮查看文本差异...</pre>';
+        setStatus("已清空");
+      }
+
+      function swapTexts() {
+        var text1 = document.getElementById("text1");
+        var text2 = document.getElementById("text2");
+        var temp = text1.value;
+        text1.value = text2.value;
+        text2.value = temp;
+        setStatus("已交换文本");
+      }
+
+      function copyResult() {
+        var text = document.getElementById("result").textContent;
+        navigator.clipboard
+          .writeText(text)
+          .then(function () {
+            setStatus("已复制到剪贴板", true);
+            setTimeout(function () {
+              setStatus("就绪");
+            }, 2000);
+          })
+          .catch(function () {
+            setStatus("复制失败");
+          });
+      }
+
+      function escapeHtml(text) {
+        var div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
+
+      // Auto-compare on mode change
+      document.querySelectorAll('input[name="diffMode"]').forEach(function (radio) {
+        radio.addEventListener("change", function () {
+          var text1 = document.getElementById("text1").value;
+          var text2 = document.getElementById("text2").value;
+          if (text1 || text2) compareTexts();
         });
       });
 
-      html += "</pre>";
-      resultEl.innerHTML = html;
-      setStatus(
-        "对比完成: " +
-          addedCount +
-          " 处新增, " +
-          removedCount +
-          " 处删除, " +
-          unchangedCount +
-          " 处不变",
-        false
-      );
-    }, 100);
-  }
+      // Theme
+      window.toggleTheme = function () {
+        var html = document.documentElement;
+        var currentTheme = html.getAttribute("data-theme") || "dark";
+        var newTheme = currentTheme === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      };
 
-  function clearAll() {
-    document.getElementById("text1").value = "";
-    document.getElementById("text2").value = "";
-    document.getElementById("result").innerHTML =
-      '<pre class="diff-unchanged">点击"对比"按钮查看文本差异...</pre>';
-    setStatus("已清空");
-  }
+      function initTheme() {
+        var savedTheme = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = savedTheme || (prefersDark ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  function swapTexts() {
-    var text1 = document.getElementById("text1");
-    var text2 = document.getElementById("text2");
-    var temp = text1.value;
-    text1.value = text2.value;
-    text2.value = temp;
-    setStatus("已交换文本");
-  }
-
-  function copyResult() {
-    var text = document.getElementById("result").textContent;
-    navigator.clipboard
-      .writeText(text)
-      .then(function () {
-        setStatus("已复制到剪贴板", true);
-        setTimeout(function () {
-          setStatus("就绪");
-        }, 2000);
-      })
-      .catch(function () {
-        setStatus("复制失败");
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+        if (!localStorage.getItem("theme"))
+          document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
       });
-  }
 
-  function escapeHtml(text) {
-    var div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
-  }
+      initTheme();
+    </script>
 
-  // Auto-compare on mode change
-  document.querySelectorAll('input[name="diffMode"]').forEach(function (radio) {
-    radio.addEventListener("change", function () {
-      var text1 = document.getElementById("text1").value;
-      var text2 = document.getElementById("text2").value;
-      if (text1 || text2) compareTexts();
-    });
-  });
-
-  // Theme
-  window.toggleTheme = function () {
-    var html = document.documentElement;
-    var currentTheme = html.getAttribute("data-theme") || "dark";
-    var newTheme = currentTheme === "light" ? "dark" : "light";
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
-
-  function initTheme() {
-    var savedTheme = localStorage.getItem("theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    var theme = savedTheme || (prefersDark ? "dark" : "light");
-    document.documentElement.setAttribute("data-theme", theme);
-  }
-
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
-    if (!localStorage.getItem("theme"))
-      document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
-  });
-
-  initTheme();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/text/word-counter.html
+++ b/tools/text/word-counter.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "文本工具",
-      "item": "https://tools.realtime-ai.chat/tools/text/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "字数统计",
-      "item": "https://tools.realtime-ai.chat/tools/text/word-counter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/tools/text/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "字数统计",
+            "item": "https://tools.realtime-ai.chat/tools/text/word-counter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "字数统计 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "字数统计 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,501 +88,503 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap" rel="stylesheet">
-<style>
-  body {
-    min-height: 100vh;
-    background:
-      radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent), var(--bg-deep);
-  }
 
-  .tool-wrap {
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 56px 20px 140px;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@500;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        min-height: 100vh;
+        background:
+          radial-gradient(ellipse 70% 50% at 50% -10%, var(--glow-cyan), transparent),
+          var(--bg-deep);
+      }
 
-  .tool-head {
-    text-align: center;
-    margin-bottom: var(--space-8);
-  }
+      .tool-wrap {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 56px 20px 140px;
+      }
 
-  .tool-badge {
-    display: inline-block;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--accent-cyan);
-    background: var(--glow-cyan);
-    border: 1px solid var(--tb-glass-border);
-    border-radius: var(--radius-full);
-  }
+      .tool-head {
+        text-align: center;
+        margin-bottom: var(--space-8);
+      }
 
-  .tool-head h1 {
-    margin: var(--space-4) 0 var(--space-2);
-    font-size: 29px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-  }
+      .tool-badge {
+        display: inline-block;
+        padding: 5px 12px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-cyan);
+        background: var(--glow-cyan);
+        border: 1px solid var(--tb-glass-border);
+        border-radius: var(--radius-full);
+      }
 
-  .tool-head p {
-    margin: 0;
-    font-size: 14px;
-    color: var(--text-muted);
-  }
+      .tool-head h1 {
+        margin: var(--space-4) 0 var(--space-2);
+        font-size: 29px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
 
-  .panel {
-    position: relative;
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-  }
+      .tool-head p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
 
-  .panel::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
-  }
+      .panel {
+        position: relative;
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-lg);
+        overflow: hidden;
+      }
 
-  .panel-body {
-    padding: var(--space-6);
-  }
+      .panel::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-cyan), var(--accent-magenta));
+      }
 
-  #text {
-    width: 100%;
-    min-height: 220px;
-    padding: var(--space-4);
-    font-family: var(--font-sans);
-    font-size: 15px;
-    line-height: 1.7;
-    color: var(--text-primary);
-    background: var(--bg-input);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    resize: vertical;
-    transition:
-      border-color var(--transition-fast),
-      box-shadow var(--transition-fast);
-  }
+      .panel-body {
+        padding: var(--space-6);
+      }
 
-  #text:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-    box-shadow: 0 0 0 3px var(--glow-cyan);
-  }
+      #text {
+        width: 100%;
+        min-height: 220px;
+        padding: var(--space-4);
+        font-family: var(--font-sans);
+        font-size: 15px;
+        line-height: 1.7;
+        color: var(--text-primary);
+        background: var(--bg-input);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        resize: vertical;
+        transition:
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
 
-  .stats {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--space-3);
-    margin-top: var(--space-5);
-  }
+      #text:focus {
+        outline: none;
+        border-color: var(--accent-cyan);
+        box-shadow: 0 0 0 3px var(--glow-cyan);
+      }
 
-  .stat {
-    text-align: center;
-    padding: var(--space-4) var(--space-2);
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-  }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: var(--space-3);
+        margin-top: var(--space-5);
+      }
 
-  .stat .num {
-    font-family: var(--font-mono);
-    font-size: 26px;
-    font-weight: 700;
-    line-height: 1.1;
-    color: var(--accent-cyan);
-  }
+      .stat {
+        text-align: center;
+        padding: var(--space-4) var(--space-2);
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+      }
 
-  .stat .cap {
-    margin-top: 6px;
-    font-size: 12px;
-    color: var(--text-muted);
-  }
+      .stat .num {
+        font-family: var(--font-mono);
+        font-size: 26px;
+        font-weight: 700;
+        line-height: 1.1;
+        color: var(--accent-cyan);
+      }
 
-  .actions {
-    display: flex;
-    gap: var(--space-3);
-    margin-top: var(--space-5);
-  }
+      .stat .cap {
+        margin-top: 6px;
+        font-size: 12px;
+        color: var(--text-muted);
+      }
 
-  .actions button {
-    flex: 1;
-    padding: 12px;
-    font-family: var(--font-sans);
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-primary);
-    background: var(--bg-card-hover);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      .actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-top: var(--space-5);
+      }
 
-  .actions button:hover {
-    transform: translateY(-1px);
-    border-color: var(--accent-cyan);
-  }
+      .actions button {
+        flex: 1;
+        padding: 12px;
+        font-family: var(--font-sans);
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        background: var(--bg-card-hover);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .actions button.primary {
-    color: #06121a;
-    background: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-  }
+      .actions button:hover {
+        transform: translateY(-1px);
+        border-color: var(--accent-cyan);
+      }
 
-  #status {
-    margin-top: var(--space-3);
-    min-height: 18px;
-    text-align: center;
-    font-size: 13px;
-    color: var(--accent-green);
-  }
+      .actions button.primary {
+        color: #06121a;
+        background: var(--accent-cyan);
+        border-color: var(--accent-cyan);
+      }
 
-  .tool-foot {
-    margin-top: var(--space-6);
-    text-align: center;
-    font-size: 12px;
-    color: var(--text-muted);
-  }
+      #status {
+        margin-top: var(--space-3);
+        min-height: 18px;
+        text-align: center;
+        font-size: 13px;
+        color: var(--accent-green);
+      }
 
-  @media (max-width: 560px) {
-    .tool-wrap {
-      padding: 36px 14px 140px;
-    }
+      .tool-foot {
+        margin-top: var(--space-6);
+        text-align: center;
+        font-size: 12px;
+        color: var(--text-muted);
+      }
 
-    .tool-head h1 {
-      font-size: 24px;
-    }
+      @media (max-width: 560px) {
+        .tool-wrap {
+          padding: 36px 14px 140px;
+        }
 
-    .stats {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+        .tool-head h1 {
+          font-size: 24px;
+        }
+
+        .stats {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="tool-wrap">
-  <header class="tool-head">
-    <span class="tool-badge">文本工具</span>
-    <h1>字数统计</h1>
-    <p>实时统计字符、词数、汉字、行数、段落与预计阅读时间</p>
-  </header>
+        <header class="tool-head">
+          <span class="tool-badge">文本工具</span>
+          <h1>字数统计</h1>
+          <p>实时统计字符、词数、汉字、行数、段落与预计阅读时间</p>
+        </header>
 
-  <section class="panel">
-    <div class="panel-body">
-      <textarea id="text" placeholder="在此输入或粘贴文本，下方实时显示统计结果……"></textarea>
+        <section class="panel">
+          <div class="panel-body">
+            <textarea id="text" placeholder="在此输入或粘贴文本，下方实时显示统计结果……"></textarea>
 
-      <div class="stats">
-        <div class="stat">
-          <div class="num" id="chars">0</div>
-          <div class="cap">字符</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="charsNoSpace">0</div>
-          <div class="cap">字符 (无空格)</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="words">0</div>
-          <div class="cap">词数</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="cjk">0</div>
-          <div class="cap">汉字</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="lines">0</div>
-          <div class="cap">行数</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="paragraphs">0</div>
-          <div class="cap">段落</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="sentences">0</div>
-          <div class="cap">句子</div>
-        </div>
-        <div class="stat">
-          <div class="num" id="readTime">0′</div>
-          <div class="cap">阅读时间</div>
-        </div>
-      </div>
+            <div class="stats">
+              <div class="stat">
+                <div class="num" id="chars">0</div>
+                <div class="cap">字符</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="charsNoSpace">0</div>
+                <div class="cap">字符 (无空格)</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="words">0</div>
+                <div class="cap">词数</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="cjk">0</div>
+                <div class="cap">汉字</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="lines">0</div>
+                <div class="cap">行数</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="paragraphs">0</div>
+                <div class="cap">段落</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="sentences">0</div>
+                <div class="cap">句子</div>
+              </div>
+              <div class="stat">
+                <div class="num" id="readTime">0′</div>
+                <div class="cap">阅读时间</div>
+              </div>
+            </div>
 
-      <div class="actions">
-        <button type="button" id="btnClear">清空</button>
-        <button type="button" id="btnCopy" class="primary">复制统计结果</button>
-      </div>
-      <div id="status" role="status"></div>
+            <div class="actions">
+              <button type="button" id="btnClear">清空</button>
+              <button type="button" id="btnCopy" class="primary">复制统计结果</button>
+            </div>
+            <div id="status" role="status"></div>
+          </div>
+        </section>
+
+        <p class="tool-foot">全部统计在你的浏览器本地完成，文本不会上传到任何服务器。</p>
+
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>字数统计工具安全吗？粘贴的文本会上传到服务器吗？</summary>
+            <p>
+              完全安全。所有统计运算在你的浏览器本地完成，粘贴的文本不会上传到任何服务器，页面底部也明确标注「文本不会上传到任何服务器」。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>汉字数和词数有什么区别？</summary>
+            <p>
+              汉字数统计 Unicode CJK
+              区块的汉字个数（不含标点和英文）；词数在汉字数基础上加上英文/数字单词数（按空格分隔），更接近「全文信息单元」的概念，适合用于阅读时间估算。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>阅读时间是怎么算的？</summary>
+            <p>
+              阅读时间按中文约 300 字/分钟、英文约 200
+              词/分钟的平均阅读速度估算，结果以分钟为单位显示（不足 1 分钟显示为
+              &lt;1′）。实际阅读速度因人而异，此数值仅供参考。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>段落数是如何统计的？</summary>
+            <p>
+              段落数统计连续两个及以上换行符分隔的非空文本块数量（即双换行分段）。若文本全部在一段中（仅有单换行），则段落数为
+              1。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>「复制统计结果」会复制什么内容？</summary>
+            <p>
+              点击「复制统计结果」会将字符、字符(无空格)、词数、汉字、行数、段落、句子、阅读时间等全部统计数据以文本格式复制到剪贴板，方便粘贴到文档或笔记中留存。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
-  </section>
 
-  <p class="tool-foot">全部统计在你的浏览器本地完成，文本不会上传到任何服务器。</p>
-
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>字数统计工具安全吗？粘贴的文本会上传到服务器吗？</summary>
-      <p>
-        完全安全。所有统计运算在你的浏览器本地完成，粘贴的文本不会上传到任何服务器，页面底部也明确标注「文本不会上传到任何服务器」。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>汉字数和词数有什么区别？</summary>
-      <p>
-        汉字数统计 Unicode CJK
-        区块的汉字个数（不含标点和英文）；词数在汉字数基础上加上英文/数字单词数（按空格分隔），更接近「全文信息单元」的概念，适合用于阅读时间估算。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>阅读时间是怎么算的？</summary>
-      <p>
-        阅读时间按中文约 300 字/分钟、英文约 200
-        词/分钟的平均阅读速度估算，结果以分钟为单位显示（不足 1 分钟显示为
-        &lt;1′）。实际阅读速度因人而异，此数值仅供参考。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>段落数是如何统计的？</summary>
-      <p>
-        段落数统计连续两个及以上换行符分隔的非空文本块数量（即双换行分段）。若文本全部在一段中（仅有单换行），则段落数为
-        1。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>「复制统计结果」会复制什么内容？</summary>
-      <p>
-        点击「复制统计结果」会将字符、字符(无空格)、词数、汉字、行数、段落、句子、阅读时间等全部统计数据以文本格式复制到剪贴板，方便粘贴到文档或笔记中留存。
-      </p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "文本工具",
-              "item": "https://tools.realtime-ai.chat/#text"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "字数统计",
-              "item": "https://tools.realtime-ai.chat/tools/text/word-counter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "文本工具",
+            "item": "https://tools.realtime-ai.chat/#text"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "字数统计",
+            "item": "https://tools.realtime-ai.chat/tools/text/word-counter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "字数统计工具安全吗？粘贴的文本会上传到服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有统计运算在你的浏览器本地完成，粘贴的文本不会上传到任何服务器，页面底部也明确标注「文本不会上传到任何服务器」。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "汉字数和词数有什么区别？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "汉字数统计 Unicode CJK 区块的汉字个数（不含标点和英文）；词数在汉字数基础上加上英文/数字单词数（按空格分隔），更接近「全文信息单元」的概念，适合用于阅读时间估算。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "阅读时间是怎么算的？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "阅读时间按中文约 300 字/分钟、英文约 200 词/分钟的平均阅读速度估算，结果以分钟为单位显示（不足 1 分钟显示为 &lt;1′）。实际阅读速度因人而异，此数值仅供参考。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "段落数是如何统计的？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "段落数统计连续两个及以上换行符分隔的非空文本块数量（即双换行分段）。若文本全部在一段中（仅有单换行），则段落数为 1。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "「复制统计结果」会复制什么内容？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "点击「复制统计结果」会将字符、字符(无空格)、词数、汉字、行数、段落、句子、阅读时间等全部统计数据以文本格式复制到剪贴板，方便粘贴到文档或笔记中留存。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "字数统计工具安全吗？粘贴的文本会上传到服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有统计运算在你的浏览器本地完成，粘贴的文本不会上传到任何服务器，页面底部也明确标注「文本不会上传到任何服务器」。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "汉字数和词数有什么区别？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "汉字数统计 Unicode CJK 区块的汉字个数（不含标点和英文）；词数在汉字数基础上加上英文/数字单词数（按空格分隔），更接近「全文信息单元」的概念，适合用于阅读时间估算。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "阅读时间是怎么算的？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "阅读时间按中文约 300 字/分钟、英文约 200 词/分钟的平均阅读速度估算，结果以分钟为单位显示（不足 1 分钟显示为 &lt;1′）。实际阅读速度因人而异，此数值仅供参考。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "段落数是如何统计的？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "段落数统计连续两个及以上换行符分隔的非空文本块数量（即双换行分段）。若文本全部在一段中（仅有单换行），则段落数为 1。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "「复制统计结果」会复制什么内容？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "点击「复制统计结果」会将字符、字符(无空格)、词数、汉字、行数、段落、句子、阅读时间等全部统计数据以文本格式复制到剪贴板，方便粘贴到文档或笔记中留存。"
+            }
+          }
+        ]
+      }
     </script>
     <script>
+      (function () {
+        var textEl = document.getElementById("text");
+        var statusEl = document.getElementById("status");
+        var statusTimer;
 
-  (function () {
-          var textEl = document.getElementById("text");
-          var statusEl = document.getElementById("status");
-          var statusTimer;
+        var els = {
+          chars: document.getElementById("chars"),
+          charsNoSpace: document.getElementById("charsNoSpace"),
+          words: document.getElementById("words"),
+          cjk: document.getElementById("cjk"),
+          lines: document.getElementById("lines"),
+          paragraphs: document.getElementById("paragraphs"),
+          sentences: document.getElementById("sentences"),
+          readTime: document.getElementById("readTime")
+        };
 
-          var els = {
-            chars: document.getElementById("chars"),
-            charsNoSpace: document.getElementById("charsNoSpace"),
-            words: document.getElementById("words"),
-            cjk: document.getElementById("cjk"),
-            lines: document.getElementById("lines"),
-            paragraphs: document.getElementById("paragraphs"),
-            sentences: document.getElementById("sentences"),
-            readTime: document.getElementById("readTime")
-          };
+        function count() {
+          var text = textEl.value;
+          var trimmed = text.trim();
+          var cjkMatches = text.match(/[一-鿿㐀-䶿]/g);
+          var cjk = cjkMatches ? cjkMatches.length : 0;
+          var latinWords = trimmed ? (trimmed.match(/[A-Za-z0-9]+/g) || []).length : 0;
+          var words = cjk + latinWords;
+          var sentences = trimmed ? (trimmed.match(/[.!?。！？…]+/g) || []).length : 0;
+          var paragraphs = trimmed
+            ? trimmed.split(/\n{2,}/).filter(function (p) {
+                return p.trim();
+              }).length
+            : 0;
+          // 阅读速度：中文 ~300 字/分，英文 ~200 词/分
+          var minutes = cjk / 300 + latinWords / 200;
 
-          function count() {
-            var text = textEl.value;
-            var trimmed = text.trim();
-            var cjkMatches = text.match(/[一-鿿㐀-䶿]/g);
-            var cjk = cjkMatches ? cjkMatches.length : 0;
-            var latinWords = trimmed ? (trimmed.match(/[A-Za-z0-9]+/g) || []).length : 0;
-            var words = cjk + latinWords;
-            var sentences = trimmed ? (trimmed.match(/[.!?。！？…]+/g) || []).length : 0;
-            var paragraphs = trimmed
-              ? trimmed.split(/\n{2,}/).filter(function (p) {
-                  return p.trim();
-                }).length
-              : 0;
-            // 阅读速度：中文 ~300 字/分，英文 ~200 词/分
-            var minutes = cjk / 300 + latinWords / 200;
+          els.chars.textContent = text.length;
+          els.charsNoSpace.textContent = text.replace(/\s/g, "").length;
+          els.words.textContent = words;
+          els.cjk.textContent = cjk;
+          els.lines.textContent = text ? text.split("\n").length : 0;
+          els.paragraphs.textContent = paragraphs;
+          els.sentences.textContent = sentences;
+          els.readTime.textContent = minutes < 1 && minutes > 0 ? "<1′" : Math.round(minutes) + "′";
+        }
 
-            els.chars.textContent = text.length;
-            els.charsNoSpace.textContent = text.replace(/\s/g, "").length;
-            els.words.textContent = words;
-            els.cjk.textContent = cjk;
-            els.lines.textContent = text ? text.split("\n").length : 0;
-            els.paragraphs.textContent = paragraphs;
-            els.sentences.textContent = sentences;
-            els.readTime.textContent = minutes < 1 && minutes > 0 ? "<1′" : Math.round(minutes) + "′";
-          }
+        function flash(msg) {
+          statusEl.textContent = msg;
+          clearTimeout(statusTimer);
+          statusTimer = setTimeout(function () {
+            statusEl.textContent = "";
+          }, 2200);
+        }
 
-          function flash(msg) {
-            statusEl.textContent = msg;
-            clearTimeout(statusTimer);
-            statusTimer = setTimeout(function () {
-              statusEl.textContent = "";
-            }, 2200);
-          }
+        textEl.addEventListener("input", count);
 
-          textEl.addEventListener("input", count);
-
-          document.getElementById("btnClear").addEventListener("click", function () {
-            textEl.value = "";
-            count();
-            textEl.focus();
-          });
-
-          document.getElementById("btnCopy").addEventListener("click", function () {
-            var summary =
-              "字数统计结果\n" +
-              "字符：" +
-              els.chars.textContent +
-              "\n" +
-              "字符(无空格)：" +
-              els.charsNoSpace.textContent +
-              "\n" +
-              "词数：" +
-              els.words.textContent +
-              "\n" +
-              "汉字：" +
-              els.cjk.textContent +
-              "\n" +
-              "行数：" +
-              els.lines.textContent +
-              "\n" +
-              "段落：" +
-              els.paragraphs.textContent +
-              "\n" +
-              "句子：" +
-              els.sentences.textContent +
-              "\n" +
-              "阅读时间：" +
-              els.readTime.textContent;
-            navigator.clipboard.writeText(summary).then(
-              function () {
-                flash("✓ 统计结果已复制到剪贴板");
-              },
-              function () {
-                flash("复制失败，请手动选择");
-              }
-            );
-          });
-
+        document.getElementById("btnClear").addEventListener("click", function () {
+          textEl.value = "";
           count();
-        })();
-</script>
-    
+          textEl.focus();
+        });
+
+        document.getElementById("btnCopy").addEventListener("click", function () {
+          var summary =
+            "字数统计结果\n" +
+            "字符：" +
+            els.chars.textContent +
+            "\n" +
+            "字符(无空格)：" +
+            els.charsNoSpace.textContent +
+            "\n" +
+            "词数：" +
+            els.words.textContent +
+            "\n" +
+            "汉字：" +
+            els.cjk.textContent +
+            "\n" +
+            "行数：" +
+            els.lines.textContent +
+            "\n" +
+            "段落：" +
+            els.paragraphs.textContent +
+            "\n" +
+            "句子：" +
+            els.sentences.textContent +
+            "\n" +
+            "阅读时间：" +
+            els.readTime.textContent;
+          navigator.clipboard.writeText(summary).then(
+            function () {
+              flash("✓ 统计结果已复制到剪贴板");
+            },
+            function () {
+              flash("复制失败，请手动选择");
+            }
+          );
+        });
+
+        count();
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/time/chinese-calendar.html
+++ b/tools/time/chinese-calendar.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="农历日历 - WebUtils" />
-    <meta property="og:description" content="农历日历，在线使用，时间工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="农历日历，在线使用，时间工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/time/chinese-calendar.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/time/chinese-calendar.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="农历日历 - WebUtils" />
-    <meta name="twitter:description" content="农历日历，在线使用，时间工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="农历日历，在线使用，时间工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "时间工具",
-      "item": "https://tools.realtime-ai.chat/tools/time/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "农历日历",
-      "item": "https://tools.realtime-ai.chat/tools/time/chinese-calendar.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "时间工具",
+            "item": "https://tools.realtime-ai.chat/tools/time/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "农历日历",
+            "item": "https://tools.realtime-ai.chat/tools/time/chinese-calendar.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "农历日历 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "农历日历 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,740 +97,741 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  :root {
-    --primary-color: #dc2626;
-  }
-  body {
-    padding: 1rem;
-    min-height: 100vh;
-  }
-  .container {
-    max-width: 500px;
-    margin: 0 auto;
-    overflow-x: hidden;
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  @media (max-width: 480px) {
-    body {
-      padding: 0.75rem;
-    }
+      :root {
+        --primary-color: #dc2626;
+      }
+      body {
+        padding: 1rem;
+        min-height: 100vh;
+      }
+      .container {
+        max-width: 500px;
+        margin: 0 auto;
+        overflow-x: hidden;
+      }
 
-    .panel {
-      padding: 1rem;
-    }
+      @media (max-width: 480px) {
+        body {
+          padding: 0.75rem;
+        }
 
-    .day {
-      font-size: 0.8rem;
-    }
+        .panel {
+          padding: 1rem;
+        }
 
-    .day .lunar {
-      font-size: 0.55rem;
-    }
-  }
-  header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-  }
-  header h1 {
-    margin: 0;
-    font-size: 1.5rem;
-  }
-  .theme-toggle {
-    background: var(--primary-color);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    color: white;
-    cursor: pointer;
-  }
-  .panel {
-    background: var(--card-background-color);
-    border-radius: 12px;
-    padding: 1.5rem;
-    border: 1px solid var(--muted-border-color);
-  }
-  .nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-  }
-  .nav button {
-    background: none;
-    border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0.5rem;
-  }
-  .nav .current {
-    font-size: 1.2rem;
-    font-weight: 600;
-  }
-  .weekdays {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    text-align: center;
-    font-size: 0.8rem;
-    color: var(--muted-color);
-    margin-bottom: 0.5rem;
-  }
-  .days {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 2px;
-  }
-  .day {
-    aspect-ratio: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.2s;
-    font-size: 0.9rem;
-  }
-  .day:hover {
-    background: rgba(220, 38, 38, 0.1);
-  }
-  .day.today {
-    background: var(--primary-color);
-    color: white;
-  }
-  .day.selected {
-    outline: 2px solid var(--primary-color);
-  }
-  .day.other-month {
-    opacity: 0.3;
-  }
-  .day .lunar {
-    font-size: 0.6rem;
-    color: var(--muted-color);
-    margin-top: 2px;
-  }
-  .day.today .lunar {
-    color: rgba(255, 255, 255, 0.8);
-  }
-  .day.festival .lunar {
-    color: var(--primary-color);
-    font-weight: 500;
-  }
-  .day.today.festival .lunar {
-    color: #fef08a;
-  }
-  .detail {
-    margin-top: 1rem;
-    padding: 1rem;
-    background: var(--code-background-color);
-    border-radius: 8px;
-  }
-  .detail h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1.2rem;
-    color: var(--primary-color);
-  }
-  .detail-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
-    font-size: 0.85rem;
-  }
-  .detail-grid .label {
-    color: var(--muted-color);
-  }
-  .toast {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    padding: 1rem 1.5rem;
-    background: var(--primary-color);
-    color: white;
-    border-radius: 8px;
-    z-index: 1000;
-  }
+        .day {
+          font-size: 0.8rem;
+        }
 
-  .breadcrumb {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 8px 15px;
-    border-radius: 20px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    font-size: 0.85rem;
-  }
-  .breadcrumb a {
-    color: #667eea;
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumb span {
-    color: #999;
-    margin: 0 5px;
-  }
+        .day .lunar {
+          font-size: 0.55rem;
+        }
+      }
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+      .theme-toggle {
+        background: var(--primary-color);
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        color: white;
+        cursor: pointer;
+      }
+      .panel {
+        background: var(--card-background-color);
+        border-radius: 12px;
+        padding: 1.5rem;
+        border: 1px solid var(--muted-border-color);
+      }
+      .nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+      }
+      .nav button {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        padding: 0.5rem;
+      }
+      .nav .current {
+        font-size: 1.2rem;
+        font-weight: 600;
+      }
+      .weekdays {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        text-align: center;
+        font-size: 0.8rem;
+        color: var(--muted-color);
+        margin-bottom: 0.5rem;
+      }
+      .days {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 2px;
+      }
+      .day {
+        aspect-ratio: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.2s;
+        font-size: 0.9rem;
+      }
+      .day:hover {
+        background: rgba(220, 38, 38, 0.1);
+      }
+      .day.today {
+        background: var(--primary-color);
+        color: white;
+      }
+      .day.selected {
+        outline: 2px solid var(--primary-color);
+      }
+      .day.other-month {
+        opacity: 0.3;
+      }
+      .day .lunar {
+        font-size: 0.6rem;
+        color: var(--muted-color);
+        margin-top: 2px;
+      }
+      .day.today .lunar {
+        color: rgba(255, 255, 255, 0.8);
+      }
+      .day.festival .lunar {
+        color: var(--primary-color);
+        font-weight: 500;
+      }
+      .day.today.festival .lunar {
+        color: #fef08a;
+      }
+      .detail {
+        margin-top: 1rem;
+        padding: 1rem;
+        background: var(--code-background-color);
+        border-radius: 8px;
+      }
+      .detail h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.2rem;
+        color: var(--primary-color);
+      }
+      .detail-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.5rem;
+        font-size: 0.85rem;
+      }
+      .detail-grid .label {
+        color: var(--muted-color);
+      }
+      .toast {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        padding: 1rem 1.5rem;
+        background: var(--primary-color);
+        color: white;
+        border-radius: 8px;
+        z-index: 1000;
+      }
 
-  @media (max-width: 400px) {
-    .breadcrumb {
-      font-size: 0.75rem;
-      padding: 6px 10px;
-    }
+      .breadcrumb {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 8px 15px;
+        border-radius: 20px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        font-size: 0.85rem;
+      }
+      .breadcrumb a {
+        color: #667eea;
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+      .breadcrumb span {
+        color: #999;
+        margin: 0 5px;
+      }
 
-    .detail-grid {
-      grid-template-columns: auto 1fr;
-      gap: 0.25rem 0.5rem;
-      font-size: 0.8rem;
-    }
+      @media (max-width: 400px) {
+        .breadcrumb {
+          font-size: 0.75rem;
+          padding: 6px 10px;
+        }
 
-    header h1 {
-      font-size: 1.2rem;
-    }
-  }
-</style>
+        .detail-grid {
+          grid-template-columns: auto 1fr;
+          gap: 0.25rem 0.5rem;
+          font-size: 0.8rem;
+        }
+
+        header h1 {
+          font-size: 1.2rem;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header>
-    <h1>📅 农历日历</h1>
-    <button class="theme-toggle" onclick="toggleTheme()">🌓</button>
-  </header>
-  <div class="panel">
-    <div class="nav">
-      <button onclick="changeMonth(-1)">◀</button>
-      <span class="current" id="currentMonth"></span>
-      <button onclick="changeMonth(1)">▶</button>
+        <header>
+          <h1>📅 农历日历</h1>
+          <button class="theme-toggle" onclick="toggleTheme()">🌓</button>
+        </header>
+        <div class="panel">
+          <div class="nav">
+            <button onclick="changeMonth(-1)">◀</button>
+            <span class="current" id="currentMonth"></span>
+            <button onclick="changeMonth(1)">▶</button>
+          </div>
+          <div class="weekdays">
+            <span>日</span>
+            <span>一</span>
+            <span>二</span>
+            <span>三</span>
+            <span>四</span>
+            <span>五</span>
+            <span>六</span>
+          </div>
+          <div class="days" id="daysGrid"></div>
+          <div class="detail" id="detail"></div>
+        </div>
+      </div>
     </div>
-    <div class="weekdays">
-      <span>日</span>
-      <span>一</span>
-      <span>二</span>
-      <span>三</span>
-      <span>四</span>
-      <span>五</span>
-      <span>六</span>
-    </div>
-    <div class="days" id="daysGrid"></div>
-    <div class="detail" id="detail"></div>
-  </div>
-</div>
-    </div>
-    
+
     <script>
-  const LUNAR_INFO = [
-    0x04bd8, 0x04ae0, 0x0a570, 0x054d5, 0x0d260, 0x0d950, 0x16554, 0x056a0, 0x09ad0, 0x055d2,
-    0x04ae0, 0x0a5b6, 0x0a4d0, 0x0d250, 0x1d255, 0x0b540, 0x0d6a0, 0x0ada2, 0x095b0, 0x14977,
-    0x04970, 0x0a4b0, 0x0b4b5, 0x06a50, 0x06d40, 0x1ab54, 0x02b60, 0x09570, 0x052f2, 0x04970,
-    0x06566, 0x0d4a0, 0x0ea50, 0x06e95, 0x05ad0, 0x02b60, 0x186e3, 0x092e0, 0x1c8d7, 0x0c950,
-    0x0d4a0, 0x1d8a6, 0x0b550, 0x056a0, 0x1a5b4, 0x025d0, 0x092d0, 0x0d2b2, 0x0a950, 0x0b557,
-    0x06ca0, 0x0b550, 0x15355, 0x04da0, 0x0a5d0, 0x14573, 0x052d0, 0x0a9a8, 0x0e950, 0x06aa0,
-    0x0aea6, 0x0ab50, 0x04b60, 0x0aae4, 0x0a570, 0x05260, 0x0f263, 0x0d950, 0x05b57, 0x056a0,
-    0x096d0, 0x04dd5, 0x04ad0, 0x0a4d0, 0x0d4d4, 0x0d250, 0x0d558, 0x0b540, 0x0b5a0, 0x195a6,
-    0x095b0, 0x049b0, 0x0a974, 0x0a4b0, 0x0b27a, 0x06a50, 0x06d40, 0x0af46, 0x0ab60, 0x09570,
-    0x04af5, 0x04970, 0x064b0, 0x074a3, 0x0ea50, 0x06b58, 0x055c0, 0x0ab60, 0x096d5, 0x092e0,
-    0x0c960, 0x0d954, 0x0d4a0, 0x0da50, 0x07552, 0x056a0, 0x0abb7, 0x025d0, 0x092d0, 0x0cab5,
-    0x0a950, 0x0b4a0, 0x0baa4, 0x0ad50, 0x055d9, 0x04ba0, 0x0a5b0, 0x15176, 0x052b0, 0x0a930,
-    0x07954, 0x06aa0, 0x0ad50, 0x05b52, 0x04b60, 0x0a6e6, 0x0a4e0, 0x0d260, 0x0ea65, 0x0d530,
-    0x05aa0, 0x076a3, 0x096d0, 0x04bd7, 0x04ad0, 0x0a4d0, 0x1d0b6, 0x0d250, 0x0d520, 0x0dd45,
-    0x0b5a0, 0x056d0, 0x055b2, 0x049b0, 0x0a577, 0x0a4b0, 0x0aa50, 0x1b255, 0x06d20, 0x0ada0
-  ];
-  const LUNAR_MONTH = ["正", "二", "三", "四", "五", "六", "七", "八", "九", "十", "冬", "腊"];
-  const LUNAR_DAY = [
-    "初一",
-    "初二",
-    "初三",
-    "初四",
-    "初五",
-    "初六",
-    "初七",
-    "初八",
-    "初九",
-    "初十",
-    "十一",
-    "十二",
-    "十三",
-    "十四",
-    "十五",
-    "十六",
-    "十七",
-    "十八",
-    "十九",
-    "二十",
-    "廿一",
-    "廿二",
-    "廿三",
-    "廿四",
-    "廿五",
-    "廿六",
-    "廿七",
-    "廿八",
-    "廿九",
-    "三十"
-  ];
-  const ANIMALS = ["鼠", "牛", "虎", "兔", "龙", "蛇", "马", "羊", "猴", "鸡", "狗", "猪"];
-  const GAN = ["甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"];
-  const ZHI = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
-  const FESTIVALS = {
-    "1-1": "春节",
-    "1-15": "元宵节",
-    "5-5": "端午节",
-    "7-7": "七夕",
-    "8-15": "中秋节",
-    "9-9": "重阳节",
-    "12-30": "除夕"
-  };
-  const SOLAR_FESTIVALS = {
-    "1-1": "元旦",
-    "2-14": "情人节",
-    "3-8": "妇女节",
-    "4-1": "愚人节",
-    "5-1": "劳动节",
-    "6-1": "儿童节",
-    "10-1": "国庆节",
-    "12-25": "圣诞节"
-  };
+      const LUNAR_INFO = [
+        0x04bd8, 0x04ae0, 0x0a570, 0x054d5, 0x0d260, 0x0d950, 0x16554, 0x056a0, 0x09ad0, 0x055d2,
+        0x04ae0, 0x0a5b6, 0x0a4d0, 0x0d250, 0x1d255, 0x0b540, 0x0d6a0, 0x0ada2, 0x095b0, 0x14977,
+        0x04970, 0x0a4b0, 0x0b4b5, 0x06a50, 0x06d40, 0x1ab54, 0x02b60, 0x09570, 0x052f2, 0x04970,
+        0x06566, 0x0d4a0, 0x0ea50, 0x06e95, 0x05ad0, 0x02b60, 0x186e3, 0x092e0, 0x1c8d7, 0x0c950,
+        0x0d4a0, 0x1d8a6, 0x0b550, 0x056a0, 0x1a5b4, 0x025d0, 0x092d0, 0x0d2b2, 0x0a950, 0x0b557,
+        0x06ca0, 0x0b550, 0x15355, 0x04da0, 0x0a5d0, 0x14573, 0x052d0, 0x0a9a8, 0x0e950, 0x06aa0,
+        0x0aea6, 0x0ab50, 0x04b60, 0x0aae4, 0x0a570, 0x05260, 0x0f263, 0x0d950, 0x05b57, 0x056a0,
+        0x096d0, 0x04dd5, 0x04ad0, 0x0a4d0, 0x0d4d4, 0x0d250, 0x0d558, 0x0b540, 0x0b5a0, 0x195a6,
+        0x095b0, 0x049b0, 0x0a974, 0x0a4b0, 0x0b27a, 0x06a50, 0x06d40, 0x0af46, 0x0ab60, 0x09570,
+        0x04af5, 0x04970, 0x064b0, 0x074a3, 0x0ea50, 0x06b58, 0x055c0, 0x0ab60, 0x096d5, 0x092e0,
+        0x0c960, 0x0d954, 0x0d4a0, 0x0da50, 0x07552, 0x056a0, 0x0abb7, 0x025d0, 0x092d0, 0x0cab5,
+        0x0a950, 0x0b4a0, 0x0baa4, 0x0ad50, 0x055d9, 0x04ba0, 0x0a5b0, 0x15176, 0x052b0, 0x0a930,
+        0x07954, 0x06aa0, 0x0ad50, 0x05b52, 0x04b60, 0x0a6e6, 0x0a4e0, 0x0d260, 0x0ea65, 0x0d530,
+        0x05aa0, 0x076a3, 0x096d0, 0x04bd7, 0x04ad0, 0x0a4d0, 0x1d0b6, 0x0d250, 0x0d520, 0x0dd45,
+        0x0b5a0, 0x056d0, 0x055b2, 0x049b0, 0x0a577, 0x0a4b0, 0x0aa50, 0x1b255, 0x06d20, 0x0ada0
+      ];
+      const LUNAR_MONTH = ["正", "二", "三", "四", "五", "六", "七", "八", "九", "十", "冬", "腊"];
+      const LUNAR_DAY = [
+        "初一",
+        "初二",
+        "初三",
+        "初四",
+        "初五",
+        "初六",
+        "初七",
+        "初八",
+        "初九",
+        "初十",
+        "十一",
+        "十二",
+        "十三",
+        "十四",
+        "十五",
+        "十六",
+        "十七",
+        "十八",
+        "十九",
+        "二十",
+        "廿一",
+        "廿二",
+        "廿三",
+        "廿四",
+        "廿五",
+        "廿六",
+        "廿七",
+        "廿八",
+        "廿九",
+        "三十"
+      ];
+      const ANIMALS = ["鼠", "牛", "虎", "兔", "龙", "蛇", "马", "羊", "猴", "鸡", "狗", "猪"];
+      const GAN = ["甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"];
+      const ZHI = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
+      const FESTIVALS = {
+        "1-1": "春节",
+        "1-15": "元宵节",
+        "5-5": "端午节",
+        "7-7": "七夕",
+        "8-15": "中秋节",
+        "9-9": "重阳节",
+        "12-30": "除夕"
+      };
+      const SOLAR_FESTIVALS = {
+        "1-1": "元旦",
+        "2-14": "情人节",
+        "3-8": "妇女节",
+        "4-1": "愚人节",
+        "5-1": "劳动节",
+        "6-1": "儿童节",
+        "10-1": "国庆节",
+        "12-25": "圣诞节"
+      };
 
-  let currentYear, currentMonth, selectedDate;
+      let currentYear, currentMonth, selectedDate;
 
-  document.addEventListener("DOMContentLoaded", () => {
-    initTheme();
-    const today = new Date();
-    currentYear = today.getFullYear();
-    currentMonth = today.getMonth();
-    selectedDate = today;
-    render();
-  });
+      document.addEventListener("DOMContentLoaded", () => {
+        initTheme();
+        const today = new Date();
+        currentYear = today.getFullYear();
+        currentMonth = today.getMonth();
+        selectedDate = today;
+        render();
+      });
 
-  function initTheme() {
-    const s = localStorage.getItem("theme");
-    if (s) document.documentElement.setAttribute("data-theme", s);
-  }
-  window.toggleTheme = function () {
-    const c = document.documentElement.getAttribute("data-theme");
-    const n = c === "dark" ? "light" : "dark";
-    document.documentElement.setAttribute("data-theme", n);
-    localStorage.setItem("theme", n);
-  };
-
-  function lYear(y) {
-    let sum = 348;
-    const info = LUNAR_INFO[y - 1900];
-    for (let bit = 0x8000; bit > 0x8; bit >>= 1) {
-      if (info & bit) sum++;
-    }
-    return sum + leapDays(y);
-  }
-  function leapMonth(y) {
-    return LUNAR_INFO[y - 1900] & 0xf;
-  }
-  function leapDays(y) {
-    return leapMonth(y) ? (LUNAR_INFO[y - 1900] & 0x10000 ? 30 : 29) : 0;
-  }
-  function monthDays(y, m) {
-    return LUNAR_INFO[y - 1900] & (0x10000 >> m) ? 30 : 29;
-  }
-
-  function toLunar(date) {
-    let y = date.getFullYear(),
-      m = date.getMonth() + 1,
-      d = date.getDate();
-    let offset = Math.floor((Date.UTC(y, m - 1, d) - Date.UTC(1900, 0, 31)) / 86400000);
-    let ly = 1900,
-      lm = 1,
-      ld,
-      leap = 0,
-      isLeap = false;
-
-    for (; ly < 2101 && offset > 0; ly++) offset -= lYear(ly);
-    if (offset < 0) {
-      offset += lYear(ly);
-      ly--;
-    }
-
-    leap = leapMonth(ly);
-    for (lm = 1; lm < 13 && offset > 0; lm++) {
-      if (leap > 0 && lm === leap + 1 && !isLeap) {
-        lm--;
-        isLeap = true;
-      } else if (isLeap && lm === leap + 1) isLeap = false;
-      offset -= isLeap ? leapDays(ly) : monthDays(ly, lm);
-    }
-    if (offset === 0 && leap > 0 && lm === leap + 1) {
-      if (isLeap) isLeap = false;
-      else {
-        isLeap = true;
-        lm--;
+      function initTheme() {
+        const s = localStorage.getItem("theme");
+        if (s) document.documentElement.setAttribute("data-theme", s);
       }
-    }
-    if (offset < 0) {
-      offset += isLeap ? leapDays(ly) : monthDays(ly, lm);
-      lm--;
-    }
-    ld = offset + 1;
+      window.toggleTheme = function () {
+        const c = document.documentElement.getAttribute("data-theme");
+        const n = c === "dark" ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", n);
+        localStorage.setItem("theme", n);
+      };
 
-    if (lm < 1 || lm > 12 || ld < 1 || ld > 30) {
-      return { year: y, month: 1, day: 1, isLeap: false };
-    }
+      function lYear(y) {
+        let sum = 348;
+        const info = LUNAR_INFO[y - 1900];
+        for (let bit = 0x8000; bit > 0x8; bit >>= 1) {
+          if (info & bit) sum++;
+        }
+        return sum + leapDays(y);
+      }
+      function leapMonth(y) {
+        return LUNAR_INFO[y - 1900] & 0xf;
+      }
+      function leapDays(y) {
+        return leapMonth(y) ? (LUNAR_INFO[y - 1900] & 0x10000 ? 30 : 29) : 0;
+      }
+      function monthDays(y, m) {
+        return LUNAR_INFO[y - 1900] & (0x10000 >> m) ? 30 : 29;
+      }
 
-    return { year: ly, month: lm, day: ld, isLeap: isLeap };
-  }
+      function toLunar(date) {
+        let y = date.getFullYear(),
+          m = date.getMonth() + 1,
+          d = date.getDate();
+        let offset = Math.floor((Date.UTC(y, m - 1, d) - Date.UTC(1900, 0, 31)) / 86400000);
+        let ly = 1900,
+          lm = 1,
+          ld,
+          leap = 0,
+          isLeap = false;
 
-  function getGanZhi(y) {
-    return GAN[(y - 4) % 10] + ZHI[(y - 4) % 12];
-  }
-  function getAnimal(y) {
-    return ANIMALS[(y - 4) % 12];
-  }
+        for (; ly < 2101 && offset > 0; ly++) offset -= lYear(ly);
+        if (offset < 0) {
+          offset += lYear(ly);
+          ly--;
+        }
 
-  function render() {
-    document.getElementById("currentMonth").textContent =
-      currentYear + "年" + (currentMonth + 1) + "月";
+        leap = leapMonth(ly);
+        for (lm = 1; lm < 13 && offset > 0; lm++) {
+          if (leap > 0 && lm === leap + 1 && !isLeap) {
+            lm--;
+            isLeap = true;
+          } else if (isLeap && lm === leap + 1) isLeap = false;
+          offset -= isLeap ? leapDays(ly) : monthDays(ly, lm);
+        }
+        if (offset === 0 && leap > 0 && lm === leap + 1) {
+          if (isLeap) isLeap = false;
+          else {
+            isLeap = true;
+            lm--;
+          }
+        }
+        if (offset < 0) {
+          offset += isLeap ? leapDays(ly) : monthDays(ly, lm);
+          lm--;
+        }
+        ld = offset + 1;
 
-    const firstDay = new Date(currentYear, currentMonth, 1);
-    const lastDay = new Date(currentYear, currentMonth + 1, 0);
-    const startDay = firstDay.getDay();
-    const daysInMonth = lastDay.getDate();
-    const today = new Date();
+        if (lm < 1 || lm > 12 || ld < 1 || ld > 30) {
+          return { year: y, month: 1, day: 1, isLeap: false };
+        }
 
-    let html = "";
-    const prevMonth = new Date(currentYear, currentMonth, 0);
-    for (let i = startDay - 1; i >= 0; i--) {
-      const d = new Date(currentYear, currentMonth - 1, prevMonth.getDate() - i);
-      html += renderDay(d, true, today);
-    }
-    for (let i = 1; i <= daysInMonth; i++) {
-      const d = new Date(currentYear, currentMonth, i);
-      html += renderDay(d, false, today);
-    }
-    const remaining = 42 - (startDay + daysInMonth);
-    for (let i = 1; i <= remaining; i++) {
-      const d = new Date(currentYear, currentMonth + 1, i);
-      html += renderDay(d, true, today);
-    }
+        return { year: ly, month: lm, day: ld, isLeap: isLeap };
+      }
 
-    document.getElementById("daysGrid").innerHTML = html;
-    showDetail(selectedDate);
-  }
+      function getGanZhi(y) {
+        return GAN[(y - 4) % 10] + ZHI[(y - 4) % 12];
+      }
+      function getAnimal(y) {
+        return ANIMALS[(y - 4) % 12];
+      }
 
-  function renderDay(date, isOther, today) {
-    const lunar = toLunar(date);
-    const monthName = LUNAR_MONTH[lunar.month - 1] || "正";
-    const dayName = LUNAR_DAY[lunar.day - 1] || "初一";
-    const lunarText =
-      lunar.day === 1
-        ? (lunar.isLeap ? "闰" : "") + monthName + "月"
-        : dayName;
-    const festival =
-      FESTIVALS[lunar.month + "-" + lunar.day] ||
-      SOLAR_FESTIVALS[date.getMonth() + 1 + "-" + date.getDate()];
-    const isToday = date.toDateString() === today.toDateString();
-    const isSelected = date.toDateString() === selectedDate.toDateString();
+      function render() {
+        document.getElementById("currentMonth").textContent =
+          currentYear + "年" + (currentMonth + 1) + "月";
 
-    let cls = "day";
-    if (isOther) cls += " other-month";
-    if (isToday) cls += " today";
-    if (isSelected) cls += " selected";
-    if (festival) cls += " festival";
+        const firstDay = new Date(currentYear, currentMonth, 1);
+        const lastDay = new Date(currentYear, currentMonth + 1, 0);
+        const startDay = firstDay.getDay();
+        const daysInMonth = lastDay.getDate();
+        const today = new Date();
 
-    return (
-      '<div class="' +
-      cls +
-      '" onclick="selectDate(' +
-      date.getFullYear() +
-      "," +
-      date.getMonth() +
-      "," +
-      date.getDate() +
-      ')">' +
-      "<span>" +
-      date.getDate() +
-      "</span>" +
-      '<span class="lunar">' +
-      (festival || lunarText) +
-      "</span>" +
-      "</div>"
-    );
-  }
+        let html = "";
+        const prevMonth = new Date(currentYear, currentMonth, 0);
+        for (let i = startDay - 1; i >= 0; i--) {
+          const d = new Date(currentYear, currentMonth - 1, prevMonth.getDate() - i);
+          html += renderDay(d, true, today);
+        }
+        for (let i = 1; i <= daysInMonth; i++) {
+          const d = new Date(currentYear, currentMonth, i);
+          html += renderDay(d, false, today);
+        }
+        const remaining = 42 - (startDay + daysInMonth);
+        for (let i = 1; i <= remaining; i++) {
+          const d = new Date(currentYear, currentMonth + 1, i);
+          html += renderDay(d, true, today);
+        }
 
-  window.selectDate = function (y, m, d) {
-    selectedDate = new Date(y, m, d);
-    render();
-  };
+        document.getElementById("daysGrid").innerHTML = html;
+        showDetail(selectedDate);
+      }
 
-  function showDetail(date) {
-    const lunar = toLunar(date);
-    const monthName = LUNAR_MONTH[lunar.month - 1] || "正";
-    const dayName = LUNAR_DAY[lunar.day - 1] || "初一";
-    const festival =
-      FESTIVALS[lunar.month + "-" + lunar.day] ||
-      SOLAR_FESTIVALS[date.getMonth() + 1 + "-" + date.getDate()];
+      function renderDay(date, isOther, today) {
+        const lunar = toLunar(date);
+        const monthName = LUNAR_MONTH[lunar.month - 1] || "正";
+        const dayName = LUNAR_DAY[lunar.day - 1] || "初一";
+        const lunarText = lunar.day === 1 ? (lunar.isLeap ? "闰" : "") + monthName + "月" : dayName;
+        const festival =
+          FESTIVALS[lunar.month + "-" + lunar.day] ||
+          SOLAR_FESTIVALS[date.getMonth() + 1 + "-" + date.getDate()];
+        const isToday = date.toDateString() === today.toDateString();
+        const isSelected = date.toDateString() === selectedDate.toDateString();
 
-    document.getElementById("detail").innerHTML =
-      "<h3>" +
-      date.getFullYear() +
-      "年" +
-      (date.getMonth() + 1) +
-      "月" +
-      date.getDate() +
-      "日</h3>" +
-      '<div class="detail-grid">' +
-      '<span class="label">农历</span><span>' +
-      (lunar.isLeap ? "闰" : "") +
-      monthName +
-      "月" +
-      dayName +
-      "</span>" +
-      '<span class="label">干支年</span><span>' +
-      getGanZhi(lunar.year) +
-      "年 (" +
-      getAnimal(lunar.year) +
-      ")</span>" +
-      '<span class="label">节日</span><span>' +
-      (festival || "-") +
-      "</span>" +
-      '<span class="label">星期</span><span>星期' +
-      "日一二三四五六"[date.getDay()] +
-      "</span>" +
-      "</div>";
-  }
+        let cls = "day";
+        if (isOther) cls += " other-month";
+        if (isToday) cls += " today";
+        if (isSelected) cls += " selected";
+        if (festival) cls += " festival";
 
-  window.changeMonth = function (delta) {
-    currentMonth += delta;
-    if (currentMonth < 0) {
-      currentMonth = 11;
-      currentYear--;
-    }
-    if (currentMonth > 11) {
-      currentMonth = 0;
-      currentYear++;
-    }
-    render();
-  };
-</script>
-    
+        return (
+          '<div class="' +
+          cls +
+          '" onclick="selectDate(' +
+          date.getFullYear() +
+          "," +
+          date.getMonth() +
+          "," +
+          date.getDate() +
+          ')">' +
+          "<span>" +
+          date.getDate() +
+          "</span>" +
+          '<span class="lunar">' +
+          (festival || lunarText) +
+          "</span>" +
+          "</div>"
+        );
+      }
+
+      window.selectDate = function (y, m, d) {
+        selectedDate = new Date(y, m, d);
+        render();
+      };
+
+      function showDetail(date) {
+        const lunar = toLunar(date);
+        const monthName = LUNAR_MONTH[lunar.month - 1] || "正";
+        const dayName = LUNAR_DAY[lunar.day - 1] || "初一";
+        const festival =
+          FESTIVALS[lunar.month + "-" + lunar.day] ||
+          SOLAR_FESTIVALS[date.getMonth() + 1 + "-" + date.getDate()];
+
+        document.getElementById("detail").innerHTML =
+          "<h3>" +
+          date.getFullYear() +
+          "年" +
+          (date.getMonth() + 1) +
+          "月" +
+          date.getDate() +
+          "日</h3>" +
+          '<div class="detail-grid">' +
+          '<span class="label">农历</span><span>' +
+          (lunar.isLeap ? "闰" : "") +
+          monthName +
+          "月" +
+          dayName +
+          "</span>" +
+          '<span class="label">干支年</span><span>' +
+          getGanZhi(lunar.year) +
+          "年 (" +
+          getAnimal(lunar.year) +
+          ")</span>" +
+          '<span class="label">节日</span><span>' +
+          (festival || "-") +
+          "</span>" +
+          '<span class="label">星期</span><span>星期' +
+          "日一二三四五六"[date.getDay()] +
+          "</span>" +
+          "</div>";
+      }
+
+      window.changeMonth = function (delta) {
+        currentMonth += delta;
+        if (currentMonth < 0) {
+          currentMonth = 11;
+          currentYear--;
+        }
+        if (currentMonth > 11) {
+          currentMonth = 0;
+          currentYear++;
+        }
+        render();
+      };
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/time/timestamp.html
+++ b/tools/time/timestamp.html
@@ -41,43 +41,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "时间工具",
-      "item": "https://tools.realtime-ai.chat/tools/time/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "时间戳转换",
-      "item": "https://tools.realtime-ai.chat/tools/time/timestamp.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "时间工具",
+            "item": "https://tools.realtime-ai.chat/tools/time/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "时间戳转换",
+            "item": "https://tools.realtime-ai.chat/tools/time/timestamp.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "时间戳转换 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "时间戳转换 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1203 +88,1214 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-<style>
-  /* ============================================
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================
          Design System - CSS Variables
          ============================================ */
 
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  /* Light Theme */
+      /* Light Theme */
 
-  /* ============================================
+      /* ============================================
          Base Styles
          ============================================ */
-  *,
-  *::before,
-  *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  html {
-    font-size: 16px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+      html {
+        font-size: 16px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    min-height: 100dvh;
-    line-height: 1.5;
-    transition:
-      background-color var(--transition-normal),
-      color var(--transition-normal);
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        min-height: 100dvh;
+        line-height: 1.5;
+        transition:
+          background-color var(--transition-normal),
+          color var(--transition-normal);
+      }
 
-  /* Subtle background gradient */
-  body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
-  }
+      /* Subtle background gradient */
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 212, 170, 0.03) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+      }
 
-  [data-theme="light"] body::before {
-    background:
-      radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
-      radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
-  }
+      [data-theme="light"] body::before {
+        background:
+          radial-gradient(circle at 20% 20%, rgba(0, 184, 148, 0.05) 0%, transparent 50%),
+          radial-gradient(circle at 80% 80%, rgba(124, 58, 237, 0.05) 0%, transparent 50%);
+      }
 
-  /* ============================================
+      /* ============================================
          Navigation Bar
          ============================================ */
-  .nav-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    height: calc(var(--nav-height) + var(--safe-area-top));
-    padding-top: var(--safe-area-top);
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-normal);
-  }
+      .nav-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        height: calc(var(--nav-height) + var(--safe-area-top));
+        padding-top: var(--safe-area-top);
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border-bottom: 1px solid var(--glass-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background var(--transition-normal);
+      }
 
-  .nav-content {
-    width: 100%;
-    max-width: var(--container-max);
-    height: var(--nav-height);
-    padding: 0 var(--space-6);
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: var(--space-4);
-  }
+      .nav-content {
+        width: 100%;
+        max-width: var(--container-max);
+        height: var(--nav-height);
+        padding: 0 var(--space-6);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: var(--space-4);
+      }
 
-  /* Back Button */
-  .nav-back {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    color: var(--color-accent-primary);
-    text-decoration: none;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    padding: var(--space-2) var(--space-1);
-    margin-left: calc(var(--space-2) * -1);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    justify-self: start;
-  }
+      /* Back Button */
+      .nav-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--color-accent-primary);
+        text-decoration: none;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        padding: var(--space-2) var(--space-1);
+        margin-left: calc(var(--space-2) * -1);
+        border-radius: var(--radius-sm);
+        transition: all var(--transition-fast);
+        justify-self: start;
+      }
 
-  .nav-back:hover {
-    background: var(--color-border-subtle);
-  }
+      .nav-back:hover {
+        background: var(--color-border-subtle);
+      }
 
-  .nav-back-icon {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2.5;
-  }
+      .nav-back-icon {
+        width: 20px;
+        height: 20px;
+        stroke-width: 2.5;
+      }
 
-  .nav-back-text {
-    display: inline;
-  }
+      .nav-back-text {
+        display: inline;
+      }
 
-  /* Nav Title */
-  .nav-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+      /* Nav Title */
+      .nav-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-  /* Nav Actions */
-  .nav-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    justify-self: end;
-  }
+      /* Nav Actions */
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        justify-self: end;
+      }
 
-  /* Theme Toggle */
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-  }
+      /* Theme Toggle */
+      .theme-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
 
-  .theme-toggle:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-primary);
-    transform: scale(1.05);
-  }
+      .theme-toggle:hover {
+        background: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: scale(1.05);
+      }
 
-  .theme-toggle svg {
-    width: 18px;
-    height: 18px;
-  }
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
 
-  .theme-icon-dark,
-  .theme-icon-light {
-    display: none;
-  }
+      .theme-icon-dark,
+      .theme-icon-light {
+        display: none;
+      }
 
-  [data-theme="dark"] .theme-icon-light,
-  :root:not([data-theme]) .theme-icon-light {
-    display: block;
-  }
+      [data-theme="dark"] .theme-icon-light,
+      :root:not([data-theme]) .theme-icon-light {
+        display: block;
+      }
 
-  [data-theme="light"] .theme-icon-dark {
-    display: block;
-  }
+      [data-theme="light"] .theme-icon-dark {
+        display: block;
+      }
 
-  /* ============================================
+      /* ============================================
          Main Content
          ============================================ */
-  .main-content {
-    position: relative;
-    z-index: 1;
-    min-height: 100vh;
-    min-height: 100dvh;
-    padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
-    padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+      .main-content {
+        position: relative;
+        z-index: 1;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-6));
+        padding-bottom: calc(var(--space-8) + var(--safe-area-bottom));
+        padding-left: var(--space-6);
+        padding-right: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-  .container {
-    width: 100%;
-    max-width: var(--container-max);
-  }
+      .container {
+        width: 100%;
+        max-width: var(--container-max);
+      }
 
-  /* ============================================
+      /* ============================================
          Current Time Display
          ============================================ */
-  .current-time {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-6);
-    text-align: center;
-    box-shadow: var(--shadow-md);
-  }
+      .current-time {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-6);
+        text-align: center;
+        box-shadow: var(--shadow-md);
+      }
 
-  .current-time .label {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-bottom: var(--space-2);
-    font-weight: 500;
-  }
+      .current-time .label {
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        margin-bottom: var(--space-2);
+        font-weight: 500;
+      }
 
-  .current-time .value {
-    font-size: 2.5rem;
-    font-weight: 700;
-    font-family: var(--font-mono);
-    color: var(--color-accent-primary);
-    letter-spacing: -0.02em;
-  }
+      .current-time .value {
+        font-size: 2.5rem;
+        font-weight: 700;
+        font-family: var(--font-mono);
+        color: var(--color-accent-primary);
+        letter-spacing: -0.02em;
+      }
 
-  .current-time .date {
-    font-size: 1rem;
-    color: var(--color-text-secondary);
-    margin-top: var(--space-2);
-    font-family: var(--font-mono);
-  }
+      .current-time .date {
+        font-size: 1rem;
+        color: var(--color-text-secondary);
+        margin-top: var(--space-2);
+        font-family: var(--font-mono);
+      }
 
-  /* ============================================
+      /* ============================================
          Card Styles
          ============================================ */
-  .card {
-    background: var(--glass-bg);
-    backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    margin-bottom: var(--space-5);
-    box-shadow: var(--shadow-md);
-  }
+      .card {
+        background: var(--glass-bg);
+        backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-5);
+        box-shadow: var(--shadow-md);
+      }
 
-  .card-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: var(--space-5);
-    color: var(--color-text-primary);
-  }
+      .card-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: var(--space-5);
+        color: var(--color-text-primary);
+      }
 
-  /* ============================================
+      /* ============================================
          Form Elements
          ============================================ */
-  .input-group {
-    margin-bottom: var(--space-4);
-  }
+      .input-group {
+        margin-bottom: var(--space-4);
+      }
 
-  .input-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--space-2);
-    font-size: 0.9375rem;
-    color: var(--color-text-secondary);
-  }
+      .input-group label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
 
-  .input-row {
-    display: flex;
-    gap: var(--space-3);
-    flex-wrap: wrap;
-  }
+      .input-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  input[type="datetime-local"],
-  select {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-input);
-    color: var(--color-text-primary);
-    font-family: var(--font-mono);
-    transition: all var(--transition-fast);
-  }
+      input[type="text"],
+      input[type="number"],
+      input[type="datetime-local"],
+      select {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-input);
+        color: var(--color-text-primary);
+        font-family: var(--font-mono);
+        transition: all var(--transition-fast);
+      }
 
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
-  }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--color-accent-primary);
+        box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.1);
+      }
 
-  .timestamp-input {
-    flex: 1;
-    min-width: 200px;
-  }
+      .timestamp-input {
+        flex: 1;
+        min-width: 200px;
+      }
 
-  .unit-select {
-    width: 120px;
-  }
+      .unit-select {
+        width: 120px;
+      }
 
-  /* Buttons */
-  button {
-    padding: var(--space-3) var(--space-4);
-    font-size: 0.9375rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border-default);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: var(--font-sans);
-  }
+      /* Buttons */
+      button {
+        padding: var(--space-3) var(--space-4);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        font-family: var(--font-sans);
+      }
 
-  button:hover {
-    border-color: var(--color-accent-primary);
-    background: var(--color-bg-surface);
-    transform: translateY(-1px);
-  }
+      button:hover {
+        border-color: var(--color-accent-primary);
+        background: var(--color-bg-surface);
+        transform: translateY(-1px);
+      }
 
-  button:active {
-    transform: translateY(0);
-  }
+      button:active {
+        transform: translateY(0);
+      }
 
-  button.primary {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: #fff;
-    font-weight: 600;
-  }
+      button.primary {
+        background: var(--color-accent-primary);
+        border-color: var(--color-accent-primary);
+        color: #fff;
+        font-weight: 600;
+      }
 
-  button.primary:hover {
-    background: #00c299;
-    border-color: #00c299;
-    box-shadow: var(--shadow-glow);
-  }
+      button.primary:hover {
+        background: #00c299;
+        border-color: #00c299;
+        box-shadow: var(--shadow-glow);
+      }
 
-  /* ============================================
+      /* ============================================
          Status Messages
          ============================================ */
-  .status {
-    font-size: 0.875rem;
-    margin-top: var(--space-2);
-    min-height: 20px;
-    font-weight: 500;
-  }
+      .status {
+        font-size: 0.875rem;
+        margin-top: var(--space-2);
+        min-height: 20px;
+        font-weight: 500;
+      }
 
-  .status.success {
-    color: var(--color-success);
-  }
+      .status.success {
+        color: var(--color-success);
+      }
 
-  .status.error {
-    color: var(--color-error);
-  }
+      .status.error {
+        color: var(--color-error);
+      }
 
-  /* ============================================
+      /* ============================================
          Result Table
          ============================================ */
-  .result-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9375rem;
-    margin-top: var(--space-4);
-  }
+      .result-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9375rem;
+        margin-top: var(--space-4);
+      }
 
-  .result-table th,
-  .result-table td {
-    padding: var(--space-3) var(--space-4);
-    text-align: left;
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
+      .result-table th,
+      .result-table td {
+        padding: var(--space-3) var(--space-4);
+        text-align: left;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
 
-  .result-table th {
-    background: var(--color-bg-subtle);
-    font-weight: 600;
-    width: 150px;
-    color: var(--color-text-secondary);
-    font-size: 0.875rem;
-  }
+      .result-table th {
+        background: var(--color-bg-subtle);
+        font-weight: 600;
+        width: 150px;
+        color: var(--color-text-secondary);
+        font-size: 0.875rem;
+      }
 
-  .result-table td {
-    font-family: var(--font-mono);
-    color: var(--color-text-primary);
-  }
+      .result-table td {
+        font-family: var(--font-mono);
+        color: var(--color-text-primary);
+      }
 
-  .result-table tr:last-child th,
-  .result-table tr:last-child td {
-    border-bottom: none;
-  }
+      .result-table tr:last-child th,
+      .result-table tr:last-child td {
+        border-bottom: none;
+      }
 
-  .copy-btn {
-    padding: var(--space-1) var(--space-2);
-    font-size: 0.75rem;
-    margin-left: var(--space-2);
-    background: var(--color-bg-subtle);
-  }
+      .copy-btn {
+        padding: var(--space-1) var(--space-2);
+        font-size: 0.75rem;
+        margin-left: var(--space-2);
+        background: var(--color-bg-subtle);
+      }
 
-  /* ============================================
+      /* ============================================
          Timezone Info
          ============================================ */
-  .timezone-info {
-    background: var(--color-bg-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    margin-top: var(--space-5);
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-  }
+      .timezone-info {
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        margin-top: var(--space-5);
+        font-size: 0.875rem;
+        color: var(--color-text-secondary);
+        line-height: 1.6;
+      }
 
-  .timezone-info strong {
-    color: var(--color-text-primary);
-    font-weight: 600;
-  }
+      .timezone-info strong {
+        color: var(--color-text-primary);
+        font-weight: 600;
+      }
 
-  /* ============================================
+      /* ============================================
          Mobile Responsive
          ============================================ */
-  @media (max-width: 480px) {
-    :root {
-      --nav-height: 52px;
-    }
+      @media (max-width: 480px) {
+        :root {
+          --nav-height: 52px;
+        }
 
-    .nav-content {
-      padding: 0 var(--space-4);
-    }
+        .nav-content {
+          padding: 0 var(--space-4);
+        }
 
-    .nav-back-text {
-      display: none;
-    }
+        .nav-back-text {
+          display: none;
+        }
 
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
-      padding-left: var(--space-4);
-      padding-right: var(--space-4);
-    }
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-4));
+          padding-left: var(--space-4);
+          padding-right: var(--space-4);
+        }
 
-    .current-time .value {
-      font-size: 1.75rem;
-    }
+        .current-time .value {
+          font-size: 1.75rem;
+        }
 
-    .card {
-      padding: var(--space-4);
-    }
+        .card {
+          padding: var(--space-4);
+        }
 
-    .input-row {
-      flex-direction: column;
-    }
+        .input-row {
+          flex-direction: column;
+        }
 
-    .timestamp-input,
-    .unit-select {
-      width: 100%;
-    }
+        .timestamp-input,
+        .unit-select {
+          width: 100%;
+        }
 
-    .result-table th {
-      width: 100px;
-      font-size: 0.8125rem;
-    }
+        .result-table th {
+          width: 100px;
+          font-size: 0.8125rem;
+        }
 
-    .result-table th,
-    .result-table td {
-      padding: var(--space-2) var(--space-3);
-    }
-  }
+        .result-table th,
+        .result-table td {
+          padding: var(--space-2) var(--space-3);
+        }
+      }
 
-  /* Desktop */
-  @media (min-width: 768px) {
-    .nav-back-text {
-      display: inline;
-    }
-  }
+      /* Desktop */
+      @media (min-width: 768px) {
+        .nav-back-text {
+          display: inline;
+        }
+      }
 
-  @media (min-width: 1024px) {
-    .main-content {
-      padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
-    }
-  }
+      @media (min-width: 1024px) {
+        .main-content {
+          padding-top: calc(var(--nav-height) + var(--safe-area-top) + var(--space-8));
+        }
+      }
 
-  /* ============================================
+      /* ============================================
          Accessibility
          ============================================ */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
 
-  :focus-visible {
-    outline: 2px solid var(--color-accent-primary);
-    outline-offset: 2px;
-  }
+      :focus-visible {
+        outline: 2px solid var(--color-accent-primary);
+        outline-offset: 2px;
+      }
 
-  button:focus:not(:focus-visible),
-  a:focus:not(:focus-visible),
-  input:focus:not(:focus-visible) {
-    outline: none;
-  }
-  .faq-section {
-    margin-top: var(--space-5);
-  }
-  .faq-section h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    margin-bottom: var(--space-3);
-  }
-  .faq-item {
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-md);
-    background: var(--color-bg-subtle);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-2);
-  }
-  .faq-item summary {
-    font-weight: 500;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    list-style: none;
-  }
-  .faq-item summary::-webkit-details-marker {
-    display: none;
-  }
-  .faq-item summary::before {
-    content: "+";
-    display: inline-block;
-    width: 1.1em;
-    color: var(--color-accent-primary);
-    font-weight: 700;
-  }
-  .faq-item[open] summary::before {
-    content: "−";
-  }
-  .faq-item p {
-    margin: var(--space-2) 0 0;
-    padding-left: 1.1em;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-</style>
+      button:focus:not(:focus-visible),
+      a:focus:not(:focus-visible),
+      input:focus:not(:focus-visible) {
+        outline: none;
+      }
+      .faq-section {
+        margin-top: var(--space-5);
+      }
+      .faq-section h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        margin-bottom: var(--space-3);
+      }
+      .faq-item {
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .faq-item summary {
+        font-weight: 500;
+        color: var(--color-text-primary);
+        cursor: pointer;
+        list-style: none;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::before {
+        content: "+";
+        display: inline-block;
+        width: 1.1em;
+        color: var(--color-accent-primary);
+        font-weight: 700;
+      }
+      .faq-item[open] summary::before {
+        content: "−";
+      }
+      .faq-item p {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <main class="main-content">
-  <div class="container">
-    <!-- Current Time Display -->
-    <div class="current-time">
-      <div class="label">当前时间戳</div>
-      <div class="value" id="currentTimestamp">0</div>
-      <div class="date" id="currentDate"></div>
-    </div>
+        <div class="container">
+          <!-- Current Time Display -->
+          <div class="current-time">
+            <div class="label">当前时间戳</div>
+            <div class="value" id="currentTimestamp">0</div>
+            <div class="date" id="currentDate"></div>
+          </div>
 
-    <!-- Timestamp to Date Card -->
-    <div class="card">
-      <h2 class="card-title">时间戳 → 日期</h2>
-      <div class="input-group">
-        <label>输入时间戳</label>
-        <div class="input-row">
-          <input type="text" id="tsInput" class="timestamp-input" placeholder="输入时间戳...">
-          <select id="tsUnit" class="unit-select">
-            <option value="s">秒 (s)</option>
-            <option value="ms" selected="">毫秒 (ms)</option>
-          </select>
-          <button id="btnNow">现在</button>
-          <button id="btnConvertTs" class="primary">转换</button>
+          <!-- Timestamp to Date Card -->
+          <div class="card">
+            <h2 class="card-title">时间戳 → 日期</h2>
+            <div class="input-group">
+              <label>输入时间戳</label>
+              <div class="input-row">
+                <input
+                  type="text"
+                  id="tsInput"
+                  class="timestamp-input"
+                  placeholder="输入时间戳..."
+                />
+                <select id="tsUnit" class="unit-select">
+                  <option value="s">秒 (s)</option>
+                  <option value="ms" selected="">毫秒 (ms)</option>
+                </select>
+                <button id="btnNow">现在</button>
+                <button id="btnConvertTs" class="primary">转换</button>
+              </div>
+            </div>
+            <div id="tsStatus" class="status"></div>
+            <table id="tsResult" class="result-table" style="display: none">
+              <tbody>
+                <tr>
+                  <th>本地时间</th>
+                  <td id="resultLocal"></td>
+                </tr>
+                <tr>
+                  <th>UTC 时间</th>
+                  <td id="resultUtc"></td>
+                </tr>
+                <tr>
+                  <th>ISO 8601</th>
+                  <td id="resultIso"></td>
+                </tr>
+                <tr>
+                  <th>相对时间</th>
+                  <td id="resultRelative"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Date to Timestamp Card -->
+          <div class="card">
+            <h2 class="card-title">日期 → 时间戳</h2>
+            <div class="input-group">
+              <label>选择日期时间</label>
+              <div class="input-row">
+                <input type="datetime-local" id="dateInput" step="1" />
+                <button id="btnNowDate">现在</button>
+                <button id="btnConvertDate" class="primary">转换</button>
+              </div>
+            </div>
+            <div id="dateStatus" class="status"></div>
+            <table id="dateResult" class="result-table" style="display: none">
+              <tbody>
+                <tr>
+                  <th>秒 (s)</th>
+                  <td id="resultSeconds"></td>
+                </tr>
+                <tr>
+                  <th>毫秒 (ms)</th>
+                  <td id="resultMillis"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Timezone Info -->
+          <div class="timezone-info">
+            <strong>当前时区:</strong>
+            <span id="timezone"></span>
+            <br />
+            <strong>UTC 偏移:</strong>
+            <span id="utcOffset"></span>
+          </div>
         </div>
-      </div>
-      <div id="tsStatus" class="status"></div>
-      <table id="tsResult" class="result-table" style="display: none">
-        <tbody>
-          <tr>
-            <th>本地时间</th>
-            <td id="resultLocal"></td>
-          </tr>
-          <tr>
-            <th>UTC 时间</th>
-            <td id="resultUtc"></td>
-          </tr>
-          <tr>
-            <th>ISO 8601</th>
-            <td id="resultIso"></td>
-          </tr>
-          <tr>
-            <th>相对时间</th>
-            <td id="resultRelative"></td>
-          </tr>
-        </tbody>
-      </table>
+        <section class="faq-section">
+          <h2>常见问题</h2>
+          <details class="faq-item">
+            <summary>时间戳转换工具安全吗？数据会上传服务器吗？</summary>
+            <p>
+              完全安全。所有时间戳转换都在你的浏览器本地完成，输入的数据不会上传到任何服务器，也不会被记录。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>Unix 时间戳是秒还是毫秒？</summary>
+            <p>
+              Unix 时间戳通常有两种精度：秒级（10 位数字，如 1700000000）和毫秒级（13 位数字，如
+              1700000000000）。本工具支持两种单位，切换「秒 (s)」或「毫秒 (ms)」选项即可正确转换。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>时间戳转换结果和本地时间不一致，是什么原因？</summary>
+            <p>
+              时间戳本身是 UTC
+              时区中立的，显示的本地时间由你浏览器所在时区决定。工具同时提供本地时间和 UTC
+              时间两行结果，页面底部也会显示你当前的时区和 UTC 偏移，方便对比。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>如何把日期时间转换为时间戳？</summary>
+            <p>
+              在「日期 →
+              时间戳」卡片中，选择日期时间后点击「转换」，即可同时获得秒级和毫秒级时间戳。也可以点击「现在」按钮快速填入当前时间。
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>时间戳转换工具可以离线使用吗？</summary>
+            <p>
+              可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。
+            </p>
+          </details>
+        </section>
+      </main>
     </div>
 
-    <!-- Date to Timestamp Card -->
-    <div class="card">
-      <h2 class="card-title">日期 → 时间戳</h2>
-      <div class="input-group">
-        <label>选择日期时间</label>
-        <div class="input-row">
-          <input type="datetime-local" id="dateInput" step="1">
-          <button id="btnNowDate">现在</button>
-          <button id="btnConvertDate" class="primary">转换</button>
-        </div>
-      </div>
-      <div id="dateStatus" class="status"></div>
-      <table id="dateResult" class="result-table" style="display: none">
-        <tbody>
-          <tr>
-            <th>秒 (s)</th>
-            <td id="resultSeconds"></td>
-          </tr>
-          <tr>
-            <th>毫秒 (ms)</th>
-            <td id="resultMillis"></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Timezone Info -->
-    <div class="timezone-info">
-      <strong>当前时区:</strong>
-      <span id="timezone"></span>
-      <br>
-      <strong>UTC 偏移:</strong>
-      <span id="utcOffset"></span>
-    </div>
-  </div>
-  <section class="faq-section">
-    <h2>常见问题</h2>
-    <details class="faq-item">
-      <summary>时间戳转换工具安全吗？数据会上传服务器吗？</summary>
-      <p>
-        完全安全。所有时间戳转换都在你的浏览器本地完成，输入的数据不会上传到任何服务器，也不会被记录。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>Unix 时间戳是秒还是毫秒？</summary>
-      <p>
-        Unix 时间戳通常有两种精度：秒级（10 位数字，如 1700000000）和毫秒级（13 位数字，如
-        1700000000000）。本工具支持两种单位，切换「秒 (s)」或「毫秒 (ms)」选项即可正确转换。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>时间戳转换结果和本地时间不一致，是什么原因？</summary>
-      <p>
-        时间戳本身是 UTC 时区中立的，显示的本地时间由你浏览器所在时区决定。工具同时提供本地时间和
-        UTC 时间两行结果，页面底部也会显示你当前的时区和 UTC 偏移，方便对比。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>如何把日期时间转换为时间戳？</summary>
-      <p>
-        在「日期 →
-        时间戳」卡片中，选择日期时间后点击「转换」，即可同时获得秒级和毫秒级时间戳。也可以点击「现在」按钮快速填入当前时间。
-      </p>
-    </details>
-    <details class="faq-item">
-      <summary>时间戳转换工具可以离线使用吗？</summary>
-      <p>可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。</p>
-    </details>
-  </section>
-</main>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "时间工具",
-              "item": "https://tools.realtime-ai.chat/#time"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "时间戳转换",
-              "item": "https://tools.realtime-ai.chat/tools/time/timestamp.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "时间工具",
+            "item": "https://tools.realtime-ai.chat/#time"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "时间戳转换",
+            "item": "https://tools.realtime-ai.chat/tools/time/timestamp.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
-
-  {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "时间戳转换工具安全吗？数据会上传服务器吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "完全安全。所有时间戳转换都在你的浏览器本地完成，输入的数据不会上传到任何服务器，也不会被记录。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Unix 时间戳是秒还是毫秒？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Unix 时间戳通常有两种精度：秒级（10 位数字，如 1700000000）和毫秒级（13 位数字，如 1700000000000）。本工具支持两种单位，切换「秒 (s)」或「毫秒 (ms)」选项即可正确转换。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "时间戳转换结果和本地时间不一致，是什么原因？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "时间戳本身是 UTC 时区中立的，显示的本地时间由你浏览器所在时区决定。工具同时提供本地时间和 UTC 时间两行结果，页面底部也会显示你当前的时区和 UTC 偏移，方便对比。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "如何把日期时间转换为时间戳？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "在「日期 → 时间戳」卡片中，选择日期时间后点击「转换」，即可同时获得秒级和毫秒级时间戳。也可以点击「现在」按钮快速填入当前时间。"
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "时间戳转换工具可以离线使用吗？",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
-              }
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "时间戳转换工具安全吗？数据会上传服务器吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "完全安全。所有时间戳转换都在你的浏览器本地完成，输入的数据不会上传到任何服务器，也不会被记录。"
             }
-          ]
-        }
+          },
+          {
+            "@type": "Question",
+            "name": "Unix 时间戳是秒还是毫秒？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Unix 时间戳通常有两种精度：秒级（10 位数字，如 1700000000）和毫秒级（13 位数字，如 1700000000000）。本工具支持两种单位，切换「秒 (s)」或「毫秒 (ms)」选项即可正确转换。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "时间戳转换结果和本地时间不一致，是什么原因？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "时间戳本身是 UTC 时区中立的，显示的本地时间由你浏览器所在时区决定。工具同时提供本地时间和 UTC 时间两行结果，页面底部也会显示你当前的时区和 UTC 偏移，方便对比。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "如何把日期时间转换为时间戳？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "在「日期 → 时间戳」卡片中，选择日期时间后点击「转换」，即可同时获得秒级和毫秒级时间戳。也可以点击「现在」按钮快速填入当前时间。"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "时间戳转换工具可以离线使用吗？",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "可以。本工具是单文件 HTML，把页面保存到本地后即使断网也能正常使用，无需安装或注册。"
+            }
+          }
+        ]
+      }
     </script>
-<script>
-  // ============================================
-  // Elements
-  // ============================================
-  var tsInputEl = document.getElementById("tsInput");
-  var tsUnitEl = document.getElementById("tsUnit");
-  var tsStatusEl = document.getElementById("tsStatus");
-  var tsResultEl = document.getElementById("tsResult");
-  var dateInputEl = document.getElementById("dateInput");
-  var dateStatusEl = document.getElementById("dateStatus");
-  var dateResultEl = document.getElementById("dateResult");
+    <script>
+      // ============================================
+      // Elements
+      // ============================================
+      var tsInputEl = document.getElementById("tsInput");
+      var tsUnitEl = document.getElementById("tsUnit");
+      var tsStatusEl = document.getElementById("tsStatus");
+      var tsResultEl = document.getElementById("tsResult");
+      var dateInputEl = document.getElementById("dateInput");
+      var dateStatusEl = document.getElementById("dateStatus");
+      var dateResultEl = document.getElementById("dateResult");
 
-  // ============================================
-  // Current Time Update
-  // ============================================
-  function updateCurrentTime() {
-    var now = Date.now();
-    document.getElementById("currentTimestamp").textContent = now;
-    document.getElementById("currentDate").textContent = formatDate(new Date());
-  }
+      // ============================================
+      // Current Time Update
+      // ============================================
+      function updateCurrentTime() {
+        var now = Date.now();
+        document.getElementById("currentTimestamp").textContent = now;
+        document.getElementById("currentDate").textContent = formatDate(new Date());
+      }
 
-  // ============================================
-  // Date Formatters
-  // ============================================
-  function formatDate(date) {
-    return date.toLocaleString("zh-CN", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false
-    });
-  }
+      // ============================================
+      // Date Formatters
+      // ============================================
+      function formatDate(date) {
+        return date.toLocaleString("zh-CN", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false
+        });
+      }
 
-  function formatUtc(date) {
-    return (
-      date.toLocaleString("zh-CN", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: false,
-        timeZone: "UTC"
-      }) + " UTC"
-    );
-  }
+      function formatUtc(date) {
+        return (
+          date.toLocaleString("zh-CN", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hour12: false,
+            timeZone: "UTC"
+          }) + " UTC"
+        );
+      }
 
-  function relativeTime(date) {
-    var now = Date.now();
-    var diff = date.getTime() - now;
-    var absDiff = Math.abs(diff);
-    var isFuture = diff > 0;
+      function relativeTime(date) {
+        var now = Date.now();
+        var diff = date.getTime() - now;
+        var absDiff = Math.abs(diff);
+        var isFuture = diff > 0;
 
-    var seconds = Math.floor(absDiff / 1000);
-    var minutes = Math.floor(seconds / 60);
-    var hours = Math.floor(minutes / 60);
-    var days = Math.floor(hours / 24);
-    var months = Math.floor(days / 30);
-    var years = Math.floor(days / 365);
+        var seconds = Math.floor(absDiff / 1000);
+        var minutes = Math.floor(seconds / 60);
+        var hours = Math.floor(minutes / 60);
+        var days = Math.floor(hours / 24);
+        var months = Math.floor(days / 30);
+        var years = Math.floor(days / 365);
 
-    var result;
-    if (years > 0) {
-      result = years + " 年";
-    } else if (months > 0) {
-      result = months + " 个月";
-    } else if (days > 0) {
-      result = days + " 天";
-    } else if (hours > 0) {
-      result = hours + " 小时";
-    } else if (minutes > 0) {
-      result = minutes + " 分钟";
-    } else {
-      result = seconds + " 秒";
-    }
+        var result;
+        if (years > 0) {
+          result = years + " 年";
+        } else if (months > 0) {
+          result = months + " 个月";
+        } else if (days > 0) {
+          result = days + " 天";
+        } else if (hours > 0) {
+          result = hours + " 小时";
+        } else if (minutes > 0) {
+          result = minutes + " 分钟";
+        } else {
+          result = seconds + " 秒";
+        }
 
-    return isFuture ? result + "后" : result + "前";
-  }
+        return isFuture ? result + "后" : result + "前";
+      }
 
-  // ============================================
-  // Conversion Functions
-  // ============================================
-  function convertTimestamp() {
-    var input = tsInputEl.value.trim();
-    if (!input) {
-      showStatus(tsStatusEl, "请输入时间戳", "error");
-      tsResultEl.style.display = "none";
-      return;
-    }
+      // ============================================
+      // Conversion Functions
+      // ============================================
+      function convertTimestamp() {
+        var input = tsInputEl.value.trim();
+        if (!input) {
+          showStatus(tsStatusEl, "请输入时间戳", "error");
+          tsResultEl.style.display = "none";
+          return;
+        }
 
-    var ts = parseInt(input, 10);
-    if (isNaN(ts)) {
-      showStatus(tsStatusEl, "无效的时间戳", "error");
-      tsResultEl.style.display = "none";
-      return;
-    }
+        var ts = parseInt(input, 10);
+        if (isNaN(ts)) {
+          showStatus(tsStatusEl, "无效的时间戳", "error");
+          tsResultEl.style.display = "none";
+          return;
+        }
 
-    // 转为毫秒
-    if (tsUnitEl.value === "s") {
-      ts = ts * 1000;
-    }
+        // 转为毫秒
+        if (tsUnitEl.value === "s") {
+          ts = ts * 1000;
+        }
 
-    var date = new Date(ts);
-    if (isNaN(date.getTime())) {
-      showStatus(tsStatusEl, "无效的时间戳", "error");
-      tsResultEl.style.display = "none";
-      return;
-    }
+        var date = new Date(ts);
+        if (isNaN(date.getTime())) {
+          showStatus(tsStatusEl, "无效的时间戳", "error");
+          tsResultEl.style.display = "none";
+          return;
+        }
 
-    document.getElementById("resultLocal").textContent = formatDate(date);
-    document.getElementById("resultUtc").textContent = formatUtc(date);
-    document.getElementById("resultIso").textContent = date.toISOString();
-    document.getElementById("resultRelative").textContent = relativeTime(date);
+        document.getElementById("resultLocal").textContent = formatDate(date);
+        document.getElementById("resultUtc").textContent = formatUtc(date);
+        document.getElementById("resultIso").textContent = date.toISOString();
+        document.getElementById("resultRelative").textContent = relativeTime(date);
 
-    tsResultEl.style.display = "table";
-    showStatus(tsStatusEl, "转换成功", "success");
-  }
+        tsResultEl.style.display = "table";
+        showStatus(tsStatusEl, "转换成功", "success");
+      }
 
-  function convertDate() {
-    var input = dateInputEl.value;
-    if (!input) {
-      showStatus(dateStatusEl, "请选择日期时间", "error");
-      dateResultEl.style.display = "none";
-      return;
-    }
+      function convertDate() {
+        var input = dateInputEl.value;
+        if (!input) {
+          showStatus(dateStatusEl, "请选择日期时间", "error");
+          dateResultEl.style.display = "none";
+          return;
+        }
 
-    var date = new Date(input);
-    if (isNaN(date.getTime())) {
-      showStatus(dateStatusEl, "无效的日期", "error");
-      dateResultEl.style.display = "none";
-      return;
-    }
+        var date = new Date(input);
+        if (isNaN(date.getTime())) {
+          showStatus(dateStatusEl, "无效的日期", "error");
+          dateResultEl.style.display = "none";
+          return;
+        }
 
-    var ms = date.getTime();
-    var s = Math.floor(ms / 1000);
+        var ms = date.getTime();
+        var s = Math.floor(ms / 1000);
 
-    document.getElementById("resultSeconds").textContent = s;
-    document.getElementById("resultMillis").textContent = ms;
+        document.getElementById("resultSeconds").textContent = s;
+        document.getElementById("resultMillis").textContent = ms;
 
-    dateResultEl.style.display = "table";
-    showStatus(dateStatusEl, "转换成功", "success");
-  }
+        dateResultEl.style.display = "table";
+        showStatus(dateStatusEl, "转换成功", "success");
+      }
 
-  function showStatus(el, msg, type) {
-    el.textContent = msg;
-    el.className = "status " + (type || "");
-  }
+      function showStatus(el, msg, type) {
+        el.textContent = msg;
+        el.className = "status " + (type || "");
+      }
 
-  // ============================================
-  // Timezone Info
-  // ============================================
-  function showTimezone() {
-    var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    var offset = new Date().getTimezoneOffset();
-    var offsetHours = Math.abs(Math.floor(offset / 60));
-    var offsetMins = Math.abs(offset % 60);
-    var sign = offset <= 0 ? "+" : "-";
-    var offsetStr =
-      "UTC" +
-      sign +
-      String(offsetHours).padStart(2, "0") +
-      ":" +
-      String(offsetMins).padStart(2, "0");
+      // ============================================
+      // Timezone Info
+      // ============================================
+      function showTimezone() {
+        var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        var offset = new Date().getTimezoneOffset();
+        var offsetHours = Math.abs(Math.floor(offset / 60));
+        var offsetMins = Math.abs(offset % 60);
+        var sign = offset <= 0 ? "+" : "-";
+        var offsetStr =
+          "UTC" +
+          sign +
+          String(offsetHours).padStart(2, "0") +
+          ":" +
+          String(offsetMins).padStart(2, "0");
 
-    document.getElementById("timezone").textContent = tz;
-    document.getElementById("utcOffset").textContent = offsetStr;
-  }
+        document.getElementById("timezone").textContent = tz;
+        document.getElementById("utcOffset").textContent = offsetStr;
+      }
 
-  function setNowToDateInput() {
-    var now = new Date();
-    var local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
-    dateInputEl.value = local.toISOString().slice(0, 19);
-  }
+      function setNowToDateInput() {
+        var now = new Date();
+        var local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
+        dateInputEl.value = local.toISOString().slice(0, 19);
+      }
 
-  // ============================================
-  // Event Handlers
-  // ============================================
-  document.getElementById("btnNow").onclick = function () {
-    tsInputEl.value = Date.now();
-    tsUnitEl.value = "ms";
-    convertTimestamp();
-  };
+      // ============================================
+      // Event Handlers
+      // ============================================
+      document.getElementById("btnNow").onclick = function () {
+        tsInputEl.value = Date.now();
+        tsUnitEl.value = "ms";
+        convertTimestamp();
+      };
 
-  document.getElementById("btnConvertTs").onclick = convertTimestamp;
+      document.getElementById("btnConvertTs").onclick = convertTimestamp;
 
-  tsInputEl.addEventListener("keypress", function (e) {
-    if (e.key === "Enter") convertTimestamp();
-  });
+      tsInputEl.addEventListener("keypress", function (e) {
+        if (e.key === "Enter") convertTimestamp();
+      });
 
-  document.getElementById("btnNowDate").onclick = function () {
-    setNowToDateInput();
-    convertDate();
-  };
+      document.getElementById("btnNowDate").onclick = function () {
+        setNowToDateInput();
+        convertDate();
+      };
 
-  document.getElementById("btnConvertDate").onclick = convertDate;
+      document.getElementById("btnConvertDate").onclick = convertDate;
 
-  // ============================================
-  // Theme Management
-  // ============================================
-  function toggleTheme() {
-    const html = document.documentElement;
-    const currentTheme = html.getAttribute("data-theme") || "dark";
-    const newTheme = currentTheme === "light" ? "dark" : "light";
+      // ============================================
+      // Theme Management
+      // ============================================
+      function toggleTheme() {
+        const html = document.documentElement;
+        const currentTheme = html.getAttribute("data-theme") || "dark";
+        const newTheme = currentTheme === "light" ? "dark" : "light";
 
-    html.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  }
+        html.setAttribute("data-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+      }
 
-  function initTheme() {
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = savedTheme || (prefersDark ? "dark" : "light");
+      function initTheme() {
+        const savedTheme = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = savedTheme || (prefersDark ? "dark" : "light");
 
-    document.documentElement.setAttribute("data-theme", theme);
-  }
+        document.documentElement.setAttribute("data-theme", theme);
+      }
 
-  // ============================================
-  // Initialize
-  // ============================================
-  initTheme();
-  updateCurrentTime();
-  setInterval(updateCurrentTime, 1000);
-  showTimezone();
-  setNowToDateInput();
-</script>
-    
+      // ============================================
+      // Initialize
+      // ============================================
+      initTheme();
+      updateCurrentTime();
+      setInterval(updateCurrentTime, 1000);
+      showTimezone();
+      setNowToDateInput();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/luggage-calculator.html
+++ b/tools/travel/luggage-calculator.html
@@ -6,17 +6,29 @@
     <title>Luggage Calculator - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="luggage calculator" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="Luggage Calculator - WebUtils" />
-    <meta property="og:description" content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Luggage Calculator - WebUtils" />
-    <meta name="twitter:description" content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Luggage Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Luggage Calculator",
-      "item": "https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Luggage Calculator",
+            "item": "https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Luggage Calculator - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Luggage Calculator - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,999 +103,1022 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --bg-hover: #252532;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --glow-red: rgb(244, 63, 94, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f0f0f0;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .tool-section:last-child {
-    margin-bottom: 0;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  input[type="text"],
-  input[type="number"],
-  select {
-    width: 100%;
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
-
-  .input-row {
-    display: grid;
-    grid-template-columns: 1fr 120px auto;
-    gap: 12px;
-    align-items: end;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    padding: 10px 18px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-  }
-
-  .btn-danger {
-    background: transparent;
-    color: var(--accent-red);
-    border: 1px solid var(--accent-red);
-    padding: 8px 12px;
-  }
-
-  .btn-danger:hover {
-    background: var(--accent-red);
-    color: #fff;
-  }
-
-  .btn-icon {
-    width: 36px;
-    height: 36px;
-    padding: 0;
-    font-size: 1rem;
-  }
-
-  /* Airline selector */
-  .airline-info {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    margin-top: 12px;
-  }
-
-  .airline-info .limit-badge {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
-
-  .airline-info .limit-label {
-    color: var(--color-text-secondary);
-    font-size: 0.85rem;
-  }
-
-  /* Items list */
-  .items-list {
-    margin-top: 16px;
-  }
-
-  .item-row {
-    display: grid;
-    grid-template-columns: 1fr 100px auto;
-    gap: 12px;
-    align-items: center;
-    padding: 12px 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 8px;
-    transition: all 0.2s;
-  }
-
-  .item-row:hover {
-    background: var(--bg-hover);
-    border-color: var(--border-strong);
-  }
-
-  .item-name {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-text-primary);
-    overflow-wrap: anywhere;
-  }
-
-  .item-weight {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-accent-cyan);
-    text-align: right;
-  }
-
-  .empty-state {
-    text-align: center;
-    padding: 32px 16px;
-    color: var(--color-text-muted);
-    font-size: 0.9rem;
-  }
-
-  /* Summary */
-  .summary-card {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 20px;
-  }
-
-  .summary-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .summary-row:last-child {
-    border-bottom: none;
-    padding-top: 16px;
-    margin-top: 8px;
-  }
-
-  .summary-label {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-  }
-
-  .summary-value {
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-  }
-
-  .summary-total {
-    font-size: 1.5rem;
-    color: var(--color-accent-cyan);
-  }
-
-  .remaining-ok {
-    color: var(--accent-green);
-  }
-
-  .remaining-warning {
-    color: var(--accent-yellow);
-  }
-
-  .remaining-over {
-    color: var(--accent-red);
-  }
-
-  /* Warning banner */
-  .warning-banner {
-    display: none;
-    align-items: center;
-    gap: 12px;
-    padding: 14px 18px;
-    background: rgba(244, 63, 94, 0.1);
-    border: 1px solid var(--accent-red);
-    border-radius: var(--radius-md);
-    margin-bottom: 16px;
-    animation: pulse 2s ease-in-out infinite;
-  }
-
-  .warning-banner.show {
-    display: flex;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.7;
-    }
-  }
-
-  .warning-icon {
-    font-size: 1.5rem;
-  }
-
-  .warning-text {
-    flex: 1;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--accent-red);
-  }
-
-  .warning-amount {
-    font-weight: 700;
-  }
-
-  /* Progress bar */
-  .progress-container {
-    margin: 16px 0;
-  }
-
-  .progress-bar {
-    height: 12px;
-    background: var(--border-subtle);
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-  }
-
-  .progress-fill {
-    height: 100%;
-    background: var(--accent-green);
-    border-radius: var(--radius-sm);
-    transition: all 0.3s ease;
-  }
-
-  .progress-fill.warning {
-    background: var(--accent-yellow);
-  }
-
-  .progress-fill.over {
-    background: var(--accent-red);
-  }
-
-  .progress-labels {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  .toast.error {
-    background: var(--accent-red);
-    color: #fff;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .input-row {
-      grid-template-columns: 1fr;
-    }
-
-    .item-row {
-      grid-template-columns: 1fr auto auto;
-      gap: 8px;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .airline-info {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 8px;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --bg-hover: #252532;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --glow-red: rgb(244, 63, 94, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f0f0f0;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .tool-section:last-child {
+        margin-bottom: 0;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select {
+        width: 100%;
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
+
+      .input-row {
+        display: grid;
+        grid-template-columns: 1fr 120px auto;
+        gap: 12px;
+        align-items: end;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        padding: 10px 18px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--accent-green);
+        color: var(--accent-green);
+      }
+
+      .btn-danger {
+        background: transparent;
+        color: var(--accent-red);
+        border: 1px solid var(--accent-red);
+        padding: 8px 12px;
+      }
+
+      .btn-danger:hover {
+        background: var(--accent-red);
+        color: #fff;
+      }
+
+      .btn-icon {
+        width: 36px;
+        height: 36px;
+        padding: 0;
+        font-size: 1rem;
+      }
+
+      /* Airline selector */
+      .airline-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        margin-top: 12px;
+      }
+
+      .airline-info .limit-badge {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
+
+      .airline-info .limit-label {
+        color: var(--color-text-secondary);
+        font-size: 0.85rem;
+      }
+
+      /* Items list */
+      .items-list {
+        margin-top: 16px;
+      }
+
+      .item-row {
+        display: grid;
+        grid-template-columns: 1fr 100px auto;
+        gap: 12px;
+        align-items: center;
+        padding: 12px 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        margin-bottom: 8px;
+        transition: all 0.2s;
+      }
+
+      .item-row:hover {
+        background: var(--bg-hover);
+        border-color: var(--border-strong);
+      }
+
+      .item-name {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-text-primary);
+        overflow-wrap: anywhere;
+      }
+
+      .item-weight {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-accent-cyan);
+        text-align: right;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 32px 16px;
+        color: var(--color-text-muted);
+        font-size: 0.9rem;
+      }
+
+      /* Summary */
+      .summary-card {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 20px;
+      }
+
+      .summary-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .summary-row:last-child {
+        border-bottom: none;
+        padding-top: 16px;
+        margin-top: 8px;
+      }
+
+      .summary-label {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+      }
+
+      .summary-value {
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+      }
+
+      .summary-total {
+        font-size: 1.5rem;
+        color: var(--color-accent-cyan);
+      }
+
+      .remaining-ok {
+        color: var(--accent-green);
+      }
+
+      .remaining-warning {
+        color: var(--accent-yellow);
+      }
+
+      .remaining-over {
+        color: var(--accent-red);
+      }
+
+      /* Warning banner */
+      .warning-banner {
+        display: none;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 18px;
+        background: rgba(244, 63, 94, 0.1);
+        border: 1px solid var(--accent-red);
+        border-radius: var(--radius-md);
+        margin-bottom: 16px;
+        animation: pulse 2s ease-in-out infinite;
+      }
+
+      .warning-banner.show {
+        display: flex;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.7;
+        }
+      }
+
+      .warning-icon {
+        font-size: 1.5rem;
+      }
+
+      .warning-text {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--accent-red);
+      }
+
+      .warning-amount {
+        font-weight: 700;
+      }
+
+      /* Progress bar */
+      .progress-container {
+        margin: 16px 0;
+      }
+
+      .progress-bar {
+        height: 12px;
+        background: var(--border-subtle);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+      }
+
+      .progress-fill {
+        height: 100%;
+        background: var(--accent-green);
+        border-radius: var(--radius-sm);
+        transition: all 0.3s ease;
+      }
+
+      .progress-fill.warning {
+        background: var(--accent-yellow);
+      }
+
+      .progress-fill.over {
+        background: var(--accent-red);
+      }
+
+      .progress-labels {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      .toast.error {
+        background: var(--accent-red);
+        color: #fff;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .input-row {
+          grid-template-columns: 1fr;
+        }
+
+        .item-row {
+          grid-template-columns: 1fr auto auto;
+          gap: 8px;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .airline-info {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 8px;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">行李限额计算</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🧳</span>
-        行李限额计算
-      </h1>
-      <p>航班行李重量计算器，避免超重罚款</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">行李限额计算</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🧳</span>
+              行李限额计算
+            </h1>
+            <p>航班行李重量计算器，避免超重罚款</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <!-- Warning Banner -->
-    <div class="warning-banner" id="warningBanner">
-      <span class="warning-icon">⚠️</span>
-      <span class="warning-text">
-        行李超重
-        <span class="warning-amount" id="overweightAmount">0</span>
-        kg，可能需要支付额外费用！
-      </span>
+        <main class="main-content">
+          <!-- Warning Banner -->
+          <div class="warning-banner" id="warningBanner">
+            <span class="warning-icon">⚠️</span>
+            <span class="warning-text">
+              行李超重
+              <span class="warning-amount" id="overweightAmount">0</span>
+              kg，可能需要支付额外费用！
+            </span>
+          </div>
+
+          <!-- Airline Selection -->
+          <div class="tool-section">
+            <div class="section-title">选择航空公司</div>
+            <div class="input-group">
+              <label class="input-label">航空公司</label>
+              <select id="airlineSelect" onchange="updateAirlineLimit()">
+                <option value="23">中国国航 (CA) - 23kg</option>
+                <option value="23">中国东方航空 (MU) - 23kg</option>
+                <option value="23">中国南方航空 (CZ) - 23kg</option>
+                <option value="20">海南航空 (HU) - 20kg</option>
+                <option value="23">厦门航空 (MF) - 23kg</option>
+                <option value="20">深圳航空 (ZH) - 20kg</option>
+                <option value="20">四川航空 (3U) - 20kg</option>
+                <option value="20">山东航空 (SC) - 20kg</option>
+                <option value="15">春秋航空 (9C) - 15kg</option>
+                <option value="10">吉祥航空 (HO) - 10kg</option>
+                <option value="23">国泰航空 (CX) - 23kg</option>
+                <option value="30">阿联酋航空 (EK) - 30kg</option>
+                <option value="23">新加坡航空 (SQ) - 23kg</option>
+                <option value="23">全日空 (NH) - 23kg</option>
+                <option value="23">日本航空 (JL) - 23kg</option>
+                <option value="23">大韩航空 (KE) - 23kg</option>
+                <option value="23">韩亚航空 (OZ) - 23kg</option>
+                <option value="23">美国航空 (AA) - 23kg</option>
+                <option value="23">美联航 (UA) - 23kg</option>
+                <option value="23">达美航空 (DL) - 23kg</option>
+                <option value="23">英国航空 (BA) - 23kg</option>
+                <option value="23">法国航空 (AF) - 23kg</option>
+                <option value="23">德国汉莎 (LH) - 23kg</option>
+                <option value="30">卡塔尔航空 (QR) - 30kg</option>
+                <option value="30">土耳其航空 (TK) - 30kg</option>
+                <option value="23">澳洲航空 (QF) - 23kg</option>
+                <option value="7">亚航 (AK) - 7kg (仅手提)</option>
+                <option value="custom">自定义限额...</option>
+              </select>
+            </div>
+            <div class="input-group" id="customLimitGroup" style="display: none">
+              <label class="input-label">自定义限额 (kg)</label>
+              <input
+                type="number"
+                id="customLimit"
+                min="1"
+                max="100"
+                value="23"
+                onchange="updateAirlineLimit()"
+              />
+            </div>
+            <div class="airline-info">
+              <span class="limit-badge" id="limitBadge">23 kg</span>
+              <span class="limit-label">托运行李限额</span>
+            </div>
+          </div>
+
+          <!-- Add Item -->
+          <div class="tool-section">
+            <div class="section-title">添加物品</div>
+            <div class="input-row">
+              <div class="input-group" style="margin-bottom: 0">
+                <label class="input-label">物品名称</label>
+                <input
+                  type="text"
+                  id="itemName"
+                  placeholder="例如：衣物、电脑..."
+                  onkeypress="handleEnter(event)"
+                />
+              </div>
+              <div class="input-group" style="margin-bottom: 0">
+                <label class="input-label">重量 (kg)</label>
+                <input
+                  type="number"
+                  id="itemWeight"
+                  min="0.1"
+                  step="0.1"
+                  placeholder="0.0"
+                  onkeypress="handleEnter(event)"
+                />
+              </div>
+              <button class="btn btn-primary btn-icon" onclick="addItem()" title="添加物品">
+                +
+              </button>
+            </div>
+          </div>
+
+          <!-- Items List -->
+          <div class="tool-section">
+            <div class="section-title">
+              物品清单 (
+              <span id="itemCount">0</span>
+              件)
+            </div>
+            <div class="items-list" id="itemsList">
+              <div class="empty-state" id="emptyState">还没有添加物品，开始添加你的行李吧</div>
+            </div>
+            <div class="btn-row" style="margin-top: 16px">
+              <button class="btn btn-secondary" onclick="clearAll()">清空所有</button>
+            </div>
+          </div>
+
+          <!-- Summary -->
+          <div class="tool-section">
+            <div class="section-title">重量统计</div>
+            <div class="progress-container">
+              <div class="progress-bar">
+                <div class="progress-fill" id="progressFill" style="width: 0%"></div>
+              </div>
+              <div class="progress-labels">
+                <span>0 kg</span>
+                <span id="progressLimit">23 kg</span>
+              </div>
+            </div>
+            <div class="summary-card">
+              <div class="summary-row">
+                <span class="summary-label">行李限额</span>
+                <span class="summary-value" id="summaryLimit">23 kg</span>
+              </div>
+              <div class="summary-row">
+                <span class="summary-label">已用重量</span>
+                <span class="summary-value" id="summaryUsed">0 kg</span>
+              </div>
+              <div class="summary-row">
+                <span class="summary-label">剩余额度</span>
+                <span class="summary-value remaining-ok" id="summaryRemaining">23 kg</span>
+              </div>
+              <div class="summary-row">
+                <span class="summary-label">总重量</span>
+                <span class="summary-value summary-total" id="summaryTotal">0 kg</span>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
 
-    <!-- Airline Selection -->
-    <div class="tool-section">
-      <div class="section-title">选择航空公司</div>
-      <div class="input-group">
-        <label class="input-label">航空公司</label>
-        <select id="airlineSelect" onchange="updateAirlineLimit()">
-          <option value="23">中国国航 (CA) - 23kg</option>
-          <option value="23">中国东方航空 (MU) - 23kg</option>
-          <option value="23">中国南方航空 (CZ) - 23kg</option>
-          <option value="20">海南航空 (HU) - 20kg</option>
-          <option value="23">厦门航空 (MF) - 23kg</option>
-          <option value="20">深圳航空 (ZH) - 20kg</option>
-          <option value="20">四川航空 (3U) - 20kg</option>
-          <option value="20">山东航空 (SC) - 20kg</option>
-          <option value="15">春秋航空 (9C) - 15kg</option>
-          <option value="10">吉祥航空 (HO) - 10kg</option>
-          <option value="23">国泰航空 (CX) - 23kg</option>
-          <option value="30">阿联酋航空 (EK) - 30kg</option>
-          <option value="23">新加坡航空 (SQ) - 23kg</option>
-          <option value="23">全日空 (NH) - 23kg</option>
-          <option value="23">日本航空 (JL) - 23kg</option>
-          <option value="23">大韩航空 (KE) - 23kg</option>
-          <option value="23">韩亚航空 (OZ) - 23kg</option>
-          <option value="23">美国航空 (AA) - 23kg</option>
-          <option value="23">美联航 (UA) - 23kg</option>
-          <option value="23">达美航空 (DL) - 23kg</option>
-          <option value="23">英国航空 (BA) - 23kg</option>
-          <option value="23">法国航空 (AF) - 23kg</option>
-          <option value="23">德国汉莎 (LH) - 23kg</option>
-          <option value="30">卡塔尔航空 (QR) - 30kg</option>
-          <option value="30">土耳其航空 (TK) - 30kg</option>
-          <option value="23">澳洲航空 (QF) - 23kg</option>
-          <option value="7">亚航 (AK) - 7kg (仅手提)</option>
-          <option value="custom">自定义限额...</option>
-        </select>
-      </div>
-      <div class="input-group" id="customLimitGroup" style="display: none">
-        <label class="input-label">自定义限额 (kg)</label>
-        <input type="number" id="customLimit" min="1" max="100" value="23" onchange="updateAirlineLimit()">
-      </div>
-      <div class="airline-info">
-        <span class="limit-badge" id="limitBadge">23 kg</span>
-        <span class="limit-label">托运行李限额</span>
-      </div>
-    </div>
-
-    <!-- Add Item -->
-    <div class="tool-section">
-      <div class="section-title">添加物品</div>
-      <div class="input-row">
-        <div class="input-group" style="margin-bottom: 0">
-          <label class="input-label">物品名称</label>
-          <input type="text" id="itemName" placeholder="例如：衣物、电脑..." onkeypress="handleEnter(event)">
-        </div>
-        <div class="input-group" style="margin-bottom: 0">
-          <label class="input-label">重量 (kg)</label>
-          <input type="number" id="itemWeight" min="0.1" step="0.1" placeholder="0.0" onkeypress="handleEnter(event)">
-        </div>
-        <button class="btn btn-primary btn-icon" onclick="addItem()" title="添加物品">+</button>
-      </div>
-    </div>
-
-    <!-- Items List -->
-    <div class="tool-section">
-      <div class="section-title">
-        物品清单 (
-        <span id="itemCount">0</span>
-        件)
-      </div>
-      <div class="items-list" id="itemsList">
-        <div class="empty-state" id="emptyState">还没有添加物品，开始添加你的行李吧</div>
-      </div>
-      <div class="btn-row" style="margin-top: 16px">
-        <button class="btn btn-secondary" onclick="clearAll()">清空所有</button>
-      </div>
-    </div>
-
-    <!-- Summary -->
-    <div class="tool-section">
-      <div class="section-title">重量统计</div>
-      <div class="progress-container">
-        <div class="progress-bar">
-          <div class="progress-fill" id="progressFill" style="width: 0%"></div>
-        </div>
-        <div class="progress-labels">
-          <span>0 kg</span>
-          <span id="progressLimit">23 kg</span>
-        </div>
-      </div>
-      <div class="summary-card">
-        <div class="summary-row">
-          <span class="summary-label">行李限额</span>
-          <span class="summary-value" id="summaryLimit">23 kg</span>
-        </div>
-        <div class="summary-row">
-          <span class="summary-label">已用重量</span>
-          <span class="summary-value" id="summaryUsed">0 kg</span>
-        </div>
-        <div class="summary-row">
-          <span class="summary-label">剩余额度</span>
-          <span class="summary-value remaining-ok" id="summaryRemaining">23 kg</span>
-        </div>
-        <div class="summary-row">
-          <span class="summary-label">总重量</span>
-          <span class="summary-value summary-total" id="summaryTotal">0 kg</span>
-        </div>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "行李限额计算",
-              "item": "https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "行李限额计算",
+            "item": "https://tools.realtime-ai.chat/tools/travel/luggage-calculator.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      var LS_KEY = "luggage_calculator_v1";
 
-        var LS_KEY = "luggage_calculator_v1";
+      // State
+      var items = [];
+      var limit = 23;
 
-        // State
-        var items = [];
-        var limit = 23;
+      // DOM Elements
+      var airlineSelect = document.getElementById("airlineSelect");
+      var customLimitGroup = document.getElementById("customLimitGroup");
+      var customLimitInput = document.getElementById("customLimit");
+      var limitBadge = document.getElementById("limitBadge");
+      var itemNameInput = document.getElementById("itemName");
+      var itemWeightInput = document.getElementById("itemWeight");
+      var itemsList = document.getElementById("itemsList");
+      var itemCount = document.getElementById("itemCount");
+      var warningBanner = document.getElementById("warningBanner");
+      var overweightAmount = document.getElementById("overweightAmount");
+      var progressFill = document.getElementById("progressFill");
+      var progressLimit = document.getElementById("progressLimit");
+      var summaryLimit = document.getElementById("summaryLimit");
+      var summaryUsed = document.getElementById("summaryUsed");
+      var summaryRemaining = document.getElementById("summaryRemaining");
+      var summaryTotal = document.getElementById("summaryTotal");
 
-        // DOM Elements
-        var airlineSelect = document.getElementById("airlineSelect");
-        var customLimitGroup = document.getElementById("customLimitGroup");
-        var customLimitInput = document.getElementById("customLimit");
-        var limitBadge = document.getElementById("limitBadge");
-        var itemNameInput = document.getElementById("itemName");
-        var itemWeightInput = document.getElementById("itemWeight");
-        var itemsList = document.getElementById("itemsList");
-        var itemCount = document.getElementById("itemCount");
-        var warningBanner = document.getElementById("warningBanner");
-        var overweightAmount = document.getElementById("overweightAmount");
-        var progressFill = document.getElementById("progressFill");
-        var progressLimit = document.getElementById("progressLimit");
-        var summaryLimit = document.getElementById("summaryLimit");
-        var summaryUsed = document.getElementById("summaryUsed");
-        var summaryRemaining = document.getElementById("summaryRemaining");
-        var summaryTotal = document.getElementById("summaryTotal");
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // Load theme
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // Update airline limit
+      function updateAirlineLimit() {
+        var value = airlineSelect.value;
+
+        if (value === "custom") {
+          customLimitGroup.style.display = "block";
+          limit = parseFloat(customLimitInput.value) || 23;
+        } else {
+          customLimitGroup.style.display = "none";
+          limit = parseInt(value, 10);
         }
 
-        // Load theme
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+        limitBadge.textContent = limit + " kg";
+        saveToStorage();
+        updateSummary();
+      }
 
-        // Update airline limit
-        function updateAirlineLimit() {
-          var value = airlineSelect.value;
-
-          if (value === "custom") {
-            customLimitGroup.style.display = "block";
-            limit = parseFloat(customLimitInput.value) || 23;
-          } else {
-            customLimitGroup.style.display = "none";
-            limit = parseInt(value, 10);
-          }
-
-          limitBadge.textContent = limit + " kg";
-          saveToStorage();
-          updateSummary();
+      // Handle enter key
+      function handleEnter(event) {
+        if (event.key === "Enter") {
+          addItem();
         }
+      }
 
-        // Handle enter key
-        function handleEnter(event) {
-          if (event.key === "Enter") {
-            addItem();
-          }
-        }
+      // Add item
+      function addItem() {
+        var name = itemNameInput.value.trim();
+        var weight = parseFloat(itemWeightInput.value);
 
-        // Add item
-        function addItem() {
-          var name = itemNameInput.value.trim();
-          var weight = parseFloat(itemWeightInput.value);
-
-          if (!name) {
-            showToast("请输入物品名称", "error");
-            itemNameInput.focus();
-            return;
-          }
-
-          if (!weight || weight <= 0) {
-            showToast("请输入有效的重量", "error");
-            itemWeightInput.focus();
-            return;
-          }
-
-          items.push({
-            id: Date.now(),
-            name: name,
-            weight: weight
-          });
-
-          itemNameInput.value = "";
-          itemWeightInput.value = "";
+        if (!name) {
+          showToast("请输入物品名称", "error");
           itemNameInput.focus();
+          return;
+        }
 
+        if (!weight || weight <= 0) {
+          showToast("请输入有效的重量", "error");
+          itemWeightInput.focus();
+          return;
+        }
+
+        items.push({
+          id: Date.now(),
+          name: name,
+          weight: weight
+        });
+
+        itemNameInput.value = "";
+        itemWeightInput.value = "";
+        itemNameInput.focus();
+
+        saveToStorage();
+        renderItems();
+        updateSummary();
+        showToast("已添加: " + name);
+      }
+
+      // Delete item
+      function deleteItem(id) {
+        var item = items.find(function (i) {
+          return i.id === id;
+        });
+        items = items.filter(function (i) {
+          return i.id !== id;
+        });
+        saveToStorage();
+        renderItems();
+        updateSummary();
+        if (item) {
+          showToast("已删除: " + item.name);
+        }
+      }
+
+      // Clear all items
+      function clearAll() {
+        if (items.length === 0) {
+          showToast("清单已经是空的", "error");
+          return;
+        }
+
+        if (confirm("确定要清空所有物品吗？")) {
+          items = [];
           saveToStorage();
           renderItems();
           updateSummary();
-          showToast("已添加: " + name);
+          showToast("已清空所有物品");
+        }
+      }
+
+      // Create item row element
+      function createItemRow(item) {
+        var row = document.createElement("div");
+        row.className = "item-row";
+
+        var nameSpan = document.createElement("span");
+        nameSpan.className = "item-name";
+        nameSpan.textContent = item.name;
+
+        var weightSpan = document.createElement("span");
+        weightSpan.className = "item-weight";
+        weightSpan.textContent = item.weight.toFixed(1) + " kg";
+
+        var deleteBtn = document.createElement("button");
+        deleteBtn.className = "btn btn-danger btn-icon";
+        deleteBtn.textContent = "×";
+        deleteBtn.title = "删除";
+        deleteBtn.onclick = function () {
+          deleteItem(item.id);
+        };
+
+        row.appendChild(nameSpan);
+        row.appendChild(weightSpan);
+        row.appendChild(deleteBtn);
+
+        return row;
+      }
+
+      // Render items list
+      function renderItems() {
+        // Clear the list
+        while (itemsList.firstChild) {
+          itemsList.removeChild(itemsList.firstChild);
         }
 
-        // Delete item
-        function deleteItem(id) {
-          var item = items.find(function (i) {
-            return i.id === id;
-          });
-          items = items.filter(function (i) {
-            return i.id !== id;
-          });
-          saveToStorage();
-          renderItems();
-          updateSummary();
-          if (item) {
-            showToast("已删除: " + item.name);
-          }
+        if (items.length === 0) {
+          var emptyDiv = document.createElement("div");
+          emptyDiv.className = "empty-state";
+          emptyDiv.id = "emptyState";
+          emptyDiv.textContent = "还没有添加物品，开始添加你的行李吧";
+          itemsList.appendChild(emptyDiv);
+          itemCount.textContent = "0";
+          return;
         }
 
-        // Clear all items
-        function clearAll() {
-          if (items.length === 0) {
-            showToast("清单已经是空的", "error");
-            return;
-          }
+        itemCount.textContent = items.length;
 
-          if (confirm("确定要清空所有物品吗？")) {
-            items = [];
-            saveToStorage();
+        items.forEach(function (item) {
+          itemsList.appendChild(createItemRow(item));
+        });
+      }
+
+      // Update summary
+      function updateSummary() {
+        var totalWeight = items.reduce(function (sum, item) {
+          return sum + item.weight;
+        }, 0);
+        var remaining = limit - totalWeight;
+        var percentage = (totalWeight / limit) * 100;
+
+        // Update progress bar
+        progressFill.style.width = Math.min(percentage, 100) + "%";
+        progressFill.classList.remove("warning", "over");
+        if (percentage > 100) {
+          progressFill.classList.add("over");
+        } else if (percentage > 80) {
+          progressFill.classList.add("warning");
+        }
+
+        progressLimit.textContent = limit + " kg";
+
+        // Update summary card
+        summaryLimit.textContent = limit + " kg";
+        summaryUsed.textContent = totalWeight.toFixed(1) + " kg";
+        summaryTotal.textContent = totalWeight.toFixed(1) + " kg";
+
+        // Update remaining with color
+        summaryRemaining.textContent = remaining.toFixed(1) + " kg";
+        summaryRemaining.classList.remove("remaining-ok", "remaining-warning", "remaining-over");
+
+        if (remaining < 0) {
+          summaryRemaining.classList.add("remaining-over");
+          summaryRemaining.textContent = remaining.toFixed(1) + " kg (超重!)";
+        } else if (remaining < limit * 0.2) {
+          summaryRemaining.classList.add("remaining-warning");
+        } else {
+          summaryRemaining.classList.add("remaining-ok");
+        }
+
+        // Show/hide warning banner
+        if (remaining < 0) {
+          warningBanner.classList.add("show");
+          overweightAmount.textContent = Math.abs(remaining).toFixed(1);
+        } else {
+          warningBanner.classList.remove("show");
+        }
+      }
+
+      // Save to localStorage
+      function saveToStorage() {
+        var data = {
+          items: items,
+          limit: limit,
+          airlineValue: airlineSelect.value,
+          customLimit: customLimitInput.value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from localStorage
+      function loadFromStorage() {
+        try {
+          var saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            var data = JSON.parse(saved);
+            items = data.items || [];
+            limit = data.limit || 23;
+
+            if (data.airlineValue) {
+              airlineSelect.value = data.airlineValue;
+              if (data.airlineValue === "custom") {
+                customLimitGroup.style.display = "block";
+                customLimitInput.value = data.customLimit || 23;
+              }
+            }
+
+            limitBadge.textContent = limit + " kg";
             renderItems();
             updateSummary();
-            showToast("已清空所有物品");
           }
+        } catch (e) {
+          console.error("Failed to load from storage:", e);
         }
+      }
 
-        // Create item row element
-        function createItemRow(item) {
-          var row = document.createElement("div");
-          row.className = "item-row";
-
-          var nameSpan = document.createElement("span");
-          nameSpan.className = "item-name";
-          nameSpan.textContent = item.name;
-
-          var weightSpan = document.createElement("span");
-          weightSpan.className = "item-weight";
-          weightSpan.textContent = item.weight.toFixed(1) + " kg";
-
-          var deleteBtn = document.createElement("button");
-          deleteBtn.className = "btn btn-danger btn-icon";
-          deleteBtn.textContent = "×";
-          deleteBtn.title = "删除";
-          deleteBtn.onclick = function () {
-            deleteItem(item.id);
-          };
-
-          row.appendChild(nameSpan);
-          row.appendChild(weightSpan);
-          row.appendChild(deleteBtn);
-
-          return row;
+      // Show toast
+      function showToast(msg, type) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.remove("error");
+        if (type === "error") {
+          toast.classList.add("error");
         }
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
 
-        // Render items list
-        function renderItems() {
-          // Clear the list
-          while (itemsList.firstChild) {
-            itemsList.removeChild(itemsList.firstChild);
-          }
+      // Initialize
+      loadFromStorage();
+    </script>
 
-          if (items.length === 0) {
-            var emptyDiv = document.createElement("div");
-            emptyDiv.className = "empty-state";
-            emptyDiv.id = "emptyState";
-            emptyDiv.textContent = "还没有添加物品，开始添加你的行李吧";
-            itemsList.appendChild(emptyDiv);
-            itemCount.textContent = "0";
-            return;
-          }
-
-          itemCount.textContent = items.length;
-
-          items.forEach(function (item) {
-            itemsList.appendChild(createItemRow(item));
-          });
-        }
-
-        // Update summary
-        function updateSummary() {
-          var totalWeight = items.reduce(function (sum, item) {
-            return sum + item.weight;
-          }, 0);
-          var remaining = limit - totalWeight;
-          var percentage = (totalWeight / limit) * 100;
-
-          // Update progress bar
-          progressFill.style.width = Math.min(percentage, 100) + "%";
-          progressFill.classList.remove("warning", "over");
-          if (percentage > 100) {
-            progressFill.classList.add("over");
-          } else if (percentage > 80) {
-            progressFill.classList.add("warning");
-          }
-
-          progressLimit.textContent = limit + " kg";
-
-          // Update summary card
-          summaryLimit.textContent = limit + " kg";
-          summaryUsed.textContent = totalWeight.toFixed(1) + " kg";
-          summaryTotal.textContent = totalWeight.toFixed(1) + " kg";
-
-          // Update remaining with color
-          summaryRemaining.textContent = remaining.toFixed(1) + " kg";
-          summaryRemaining.classList.remove("remaining-ok", "remaining-warning", "remaining-over");
-
-          if (remaining < 0) {
-            summaryRemaining.classList.add("remaining-over");
-            summaryRemaining.textContent = remaining.toFixed(1) + " kg (超重!)";
-          } else if (remaining < limit * 0.2) {
-            summaryRemaining.classList.add("remaining-warning");
-          } else {
-            summaryRemaining.classList.add("remaining-ok");
-          }
-
-          // Show/hide warning banner
-          if (remaining < 0) {
-            warningBanner.classList.add("show");
-            overweightAmount.textContent = Math.abs(remaining).toFixed(1);
-          } else {
-            warningBanner.classList.remove("show");
-          }
-        }
-
-        // Save to localStorage
-        function saveToStorage() {
-          var data = {
-            items: items,
-            limit: limit,
-            airlineValue: airlineSelect.value,
-            customLimit: customLimitInput.value
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
-        }
-
-        // Load from localStorage
-        function loadFromStorage() {
-          try {
-            var saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              var data = JSON.parse(saved);
-              items = data.items || [];
-              limit = data.limit || 23;
-
-              if (data.airlineValue) {
-                airlineSelect.value = data.airlineValue;
-                if (data.airlineValue === "custom") {
-                  customLimitGroup.style.display = "block";
-                  customLimitInput.value = data.customLimit || 23;
-                }
-              }
-
-              limitBadge.textContent = limit + " kg";
-              renderItems();
-              updateSummary();
-            }
-          } catch (e) {
-            console.error("Failed to load from storage:", e);
-          }
-        }
-
-        // Show toast
-        function showToast(msg, type) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.remove("error");
-          if (type === "error") {
-            toast.classList.add("error");
-          }
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // Initialize
-        loadFromStorage();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/packing-list.html
+++ b/tools/travel/packing-list.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="旅行打包清单 - WebUtils" />
     <meta property="og:description" content="智能旅行打包清单，按目的地和天数生成" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/packing-list.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/packing-list.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "旅行打包清单",
-      "item": "https://tools.realtime-ai.chat/tools/travel/packing-list.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "旅行打包清单",
+            "item": "https://tools.realtime-ai.chat/tools/travel/packing-list.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "旅行打包清单 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "旅行打包清单 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,899 +91,909 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&amp;family=Space+Grotesk:wght@400;500;600&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&amp;family=Space+Grotesk:wght@400;500;600&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(77, 159, 255, 0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(77, 159, 255, 0.03) 1px, transparent 1px);
-    background-size: 50px 50px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    border-color: var(--color-accent-cyan);
-    transform: scale(1.1);
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s;
-  }
-  .breadcrumb a:hover {
-    color: var(--color-accent-cyan);
-  }
-  .breadcrumb-separator {
-    color: var(--text-muted);
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  h1 {
-    font-size: 2rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    background: linear-gradient(135deg, var(--color-text-primary), var(--accent-blue));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-  .subtitle {
-    color: var(--color-text-secondary);
-    margin-bottom: 2rem;
-  }
-  .card {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .card-title {
-    font-size: 1rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    margin-bottom: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  .form-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    margin-bottom: 1rem;
-  }
-  .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  .form-group label {
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-  }
-  .form-group select,
-  .form-group input {
-    padding: 0.75rem 1rem;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    font-family: inherit;
-    font-size: 1rem;
-  }
-  .form-group select:focus,
-  .form-group input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
-  }
-  .btn {
-    padding: 0.75rem 1.5rem;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    font-family: inherit;
-    font-size: 0.95rem;
-    font-weight: 500;
-    transition: all 0.2s;
-  }
-  .btn-primary {
-    background: linear-gradient(135deg, var(--accent-blue), var(--color-accent-cyan));
-    color: #000;
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-glow);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--color-accent-cyan);
-  }
-  .btn-group {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-top: 1rem;
-  }
-  .checklist {
-    display: grid;
-    gap: 0.5rem;
-  }
-  .checklist-category {
-    margin-top: 1rem;
-  }
-  .checklist-category:first-child {
-    margin-top: 0;
-  }
-  .category-title {
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
-  }
-  .checklist-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
-    background: var(--color-bg-surface);
-    border-radius: var(--radius-sm);
-    transition: all 0.2s;
-  }
-  .checklist-item:hover {
-    background: var(--bg-hover);
-  }
-  .checklist-item.checked {
-    opacity: 0.6;
-    text-decoration: line-through;
-  }
-  .checklist-item input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--color-accent-cyan);
-    cursor: pointer;
-  }
-  .checklist-item span {
-    flex: 1;
-  }
-  .checklist-item .delete-btn {
-    opacity: 0;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    padding: 4px;
-    font-size: 1rem;
-    transition: all 0.2s;
-  }
-  .checklist-item:hover .delete-btn {
-    opacity: 1;
-  }
-  .checklist-item .delete-btn:hover {
-    color: #ff6b6b;
-  }
-  .add-item {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 1rem;
-  }
-  .add-item input {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    font-family: inherit;
-  }
-  .add-item button {
-    padding: 0.5rem 1rem;
-    background: var(--color-accent-cyan);
-    color: #000;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    font-weight: 500;
-  }
-  .stats {
-    display: flex;
-    gap: 2rem;
-    padding: 1rem;
-    background: var(--color-bg-surface);
-    border-radius: var(--radius-sm);
-    margin-bottom: 1rem;
-  }
-  .stat {
-    text-align: center;
-  }
-  .stat-value {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-accent-cyan);
-  }
-  .stat-label {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-  }
-  .hidden {
-    display: none;
-  }
-  footer {
-    margin-top: 3rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--border-subtle);
-    text-align: center;
-    color: var(--text-muted);
-    font-size: 0.85rem;
-  }
-  footer a {
-    color: var(--accent-blue);
-    text-decoration: none;
-  }
-  @media (max-width: 600px) {
-    .stats {
-      flex-direction: column;
-      gap: 1rem;
-    }
-    .form-row {
-      grid-template-columns: 1fr;
-    }
-  }
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-</style>
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(77, 159, 255, 0.03) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(77, 159, 255, 0.03) 1px, transparent 1px);
+        background-size: 50px 50px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        border-color: var(--color-accent-cyan);
+        transform: scale(1.1);
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+      .breadcrumb a:hover {
+        color: var(--color-accent-cyan);
+      }
+      .breadcrumb-separator {
+        color: var(--text-muted);
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      h1 {
+        font-size: 2rem;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(135deg, var(--color-text-primary), var(--accent-blue));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+      .subtitle {
+        color: var(--color-text-secondary);
+        margin-bottom: 2rem;
+      }
+      .card {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+      .card-title {
+        font-size: 1rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .form-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .form-group label {
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+      }
+      .form-group select,
+      .form-group input {
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        font-family: inherit;
+        font-size: 1rem;
+      }
+      .form-group select:focus,
+      .form-group input:focus {
+        outline: none;
+        border-color: var(--accent-blue);
+      }
+      .btn {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: all 0.2s;
+      }
+      .btn-primary {
+        background: linear-gradient(135deg, var(--accent-blue), var(--color-accent-cyan));
+        color: #000;
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-glow);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--color-accent-cyan);
+      }
+      .btn-group {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+      }
+      .checklist {
+        display: grid;
+        gap: 0.5rem;
+      }
+      .checklist-category {
+        margin-top: 1rem;
+      }
+      .checklist-category:first-child {
+        margin-top: 0;
+      }
+      .category-title {
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+        margin-bottom: 0.5rem;
+        font-size: 0.95rem;
+      }
+      .checklist-item {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.5rem 0.75rem;
+        background: var(--color-bg-surface);
+        border-radius: var(--radius-sm);
+        transition: all 0.2s;
+      }
+      .checklist-item:hover {
+        background: var(--bg-hover);
+      }
+      .checklist-item.checked {
+        opacity: 0.6;
+        text-decoration: line-through;
+      }
+      .checklist-item input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--color-accent-cyan);
+        cursor: pointer;
+      }
+      .checklist-item span {
+        flex: 1;
+      }
+      .checklist-item .delete-btn {
+        opacity: 0;
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        cursor: pointer;
+        padding: 4px;
+        font-size: 1rem;
+        transition: all 0.2s;
+      }
+      .checklist-item:hover .delete-btn {
+        opacity: 1;
+      }
+      .checklist-item .delete-btn:hover {
+        color: #ff6b6b;
+      }
+      .add-item {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 1rem;
+      }
+      .add-item input {
+        flex: 1;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        font-family: inherit;
+      }
+      .add-item button {
+        padding: 0.5rem 1rem;
+        background: var(--color-accent-cyan);
+        color: #000;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        font-weight: 500;
+      }
+      .stats {
+        display: flex;
+        gap: 2rem;
+        padding: 1rem;
+        background: var(--color-bg-surface);
+        border-radius: var(--radius-sm);
+        margin-bottom: 1rem;
+      }
+      .stat {
+        text-align: center;
+      }
+      .stat-value {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--color-accent-cyan);
+      }
+      .stat-label {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
+      .hidden {
+        display: none;
+      }
+      footer {
+        margin-top: 3rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--border-subtle);
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+      footer a {
+        color: var(--accent-blue);
+        text-decoration: none;
+      }
+      @media (max-width: 600px) {
+        .stats {
+          flex-direction: column;
+          gap: 1rem;
+        }
+        .form-row {
+          grid-template-columns: 1fr;
+        }
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <button class="theme-toggle" onclick="toggleTheme()" title="切换主题" aria-label="🌙">🌙</button>
+        <button class="theme-toggle" onclick="toggleTheme()" title="切换主题" aria-label="🌙">
+          🌙
+        </button>
 
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="../../index.html">首页</a>
-    <span class="breadcrumb-separator">/</span>
-    <span class="breadcrumb-current">行李清单生成器</span>
-  </nav>
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../../index.html">首页</a>
+          <span class="breadcrumb-separator">/</span>
+          <span class="breadcrumb-current">行李清单生成器</span>
+        </nav>
 
-  <h1>行李清单生成器</h1>
-  <p class="subtitle">根据旅行类型和天数智能生成行李清单</p>
+        <h1>行李清单生成器</h1>
+        <p class="subtitle">根据旅行类型和天数智能生成行李清单</p>
 
-  <div class="card">
-    <div class="card-title">🧳 旅行信息</div>
-    <div class="form-row">
-      <div class="form-group">
-        <label>旅行类型</label>
-        <select id="tripType">
-          <option value="business">商务出差</option>
-          <option value="leisure" selected="">休闲度假</option>
-          <option value="beach">海滩度假</option>
-          <option value="hiking">徒步露营</option>
-          <option value="winter">冬季滑雪</option>
-          <option value="city">城市观光</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>旅行天数</label>
-        <select id="tripDays">
-          <option value="1-3">1-3天</option>
-          <option value="4-7" selected="">4-7天</option>
-          <option value="8-14">8-14天</option>
-          <option value="15+">15天以上</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>目的地气候</label>
-        <select id="climate">
-          <option value="hot">炎热</option>
-          <option value="warm" selected="">温暖</option>
-          <option value="cool">凉爽</option>
-          <option value="cold">寒冷</option>
-        </select>
-      </div>
-    </div>
-    <div class="btn-group">
-      <button class="btn btn-primary" onclick="generateList()" aria-label="生成清单">
-        生成清单
-      </button>
-      <button class="btn btn-secondary" onclick="clearAll()" aria-label="清空">清空</button>
-    </div>
-  </div>
-
-  <div id="resultSection" class="hidden">
-    <div class="card">
-      <div class="card-title">📋 行李清单</div>
-      <div class="stats">
-        <div class="stat">
-          <div class="stat-value" id="totalItems">0</div>
-          <div class="stat-label">总物品</div>
+        <div class="card">
+          <div class="card-title">🧳 旅行信息</div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>旅行类型</label>
+              <select id="tripType">
+                <option value="business">商务出差</option>
+                <option value="leisure" selected="">休闲度假</option>
+                <option value="beach">海滩度假</option>
+                <option value="hiking">徒步露营</option>
+                <option value="winter">冬季滑雪</option>
+                <option value="city">城市观光</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>旅行天数</label>
+              <select id="tripDays">
+                <option value="1-3">1-3天</option>
+                <option value="4-7" selected="">4-7天</option>
+                <option value="8-14">8-14天</option>
+                <option value="15+">15天以上</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>目的地气候</label>
+              <select id="climate">
+                <option value="hot">炎热</option>
+                <option value="warm" selected="">温暖</option>
+                <option value="cool">凉爽</option>
+                <option value="cold">寒冷</option>
+              </select>
+            </div>
+          </div>
+          <div class="btn-group">
+            <button class="btn btn-primary" onclick="generateList()" aria-label="生成清单">
+              生成清单
+            </button>
+            <button class="btn btn-secondary" onclick="clearAll()" aria-label="清空">清空</button>
+          </div>
         </div>
-        <div class="stat">
-          <div class="stat-value" id="packedItems">0</div>
-          <div class="stat-label">已打包</div>
+
+        <div id="resultSection" class="hidden">
+          <div class="card">
+            <div class="card-title">📋 行李清单</div>
+            <div class="stats">
+              <div class="stat">
+                <div class="stat-value" id="totalItems">0</div>
+                <div class="stat-label">总物品</div>
+              </div>
+              <div class="stat">
+                <div class="stat-value" id="packedItems">0</div>
+                <div class="stat-label">已打包</div>
+              </div>
+              <div class="stat">
+                <div class="stat-value" id="progressPercent">0%</div>
+                <div class="stat-label">进度</div>
+              </div>
+            </div>
+            <div id="checklist" class="checklist"></div>
+            <div class="add-item">
+              <input
+                type="text"
+                id="newItem"
+                placeholder="添加自定义物品..."
+                onkeypress="if (event.key === 'Enter') addCustomItem();"
+                aria-label="文本输入框"
+              />
+              <button onclick="addCustomItem()" aria-label="添加">添加</button>
+            </div>
+          </div>
+
+          <div class="btn-group">
+            <button class="btn btn-secondary" onclick="exportList()" aria-label="导出清单">
+              导出清单
+            </button>
+            <button class="btn btn-secondary" onclick="copyList()" aria-label="复制到剪贴板">
+              复制到剪贴板
+            </button>
+          </div>
         </div>
-        <div class="stat">
-          <div class="stat-value" id="progressPercent">0%</div>
-          <div class="stat-label">进度</div>
-        </div>
-      </div>
-      <div id="checklist" class="checklist"></div>
-      <div class="add-item">
-        <input type="text" id="newItem" placeholder="添加自定义物品..." onkeypress="if (event.key === 'Enter') addCustomItem();" aria-label="文本输入框">
-        <button onclick="addCustomItem()" aria-label="添加">添加</button>
+
+        <footer>
+          <a href="https://github.com/chicogong/html-tools" target="_blank">GitHub</a>
+        </footer>
       </div>
     </div>
 
-    <div class="btn-group">
-      <button class="btn btn-secondary" onclick="exportList()" aria-label="导出清单">
-        导出清单
-      </button>
-      <button class="btn btn-secondary" onclick="copyList()" aria-label="复制到剪贴板">
-        复制到剪贴板
-      </button>
-    </div>
-  </div>
-
-  <footer>
-    <a href="https://github.com/chicogong/html-tools" target="_blank">GitHub</a>
-  </footer>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "行李清单生成器",
-              "item": "https://tools.realtime-ai.chat/tools/travel/packing-list.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "行李清单生成器",
+            "item": "https://tools.realtime-ai.chat/tools/travel/packing-list.html"
+          }
+        ]
+      }
+    </script>
     <script>
-
-  const packingData = {
-          essentials: {
-            name: "必备物品",
-            items: ["身份证/护照", "手机及充电器", "钱包/信用卡", "钥匙", "旅行保险单"]
-          },
-          toiletries: {
-            name: "洗漱用品",
-            items: [
-              "牙刷牙膏",
-              "洗面奶",
-              "洗发水/护发素",
-              "沐浴露",
-              "毛巾",
-              "梳子",
-              "护肤品",
-              "防晒霜"
-            ]
-          },
-          electronics: {
-            name: "电子产品",
-            items: ["充电宝", "数据线", "耳机", "相机", "转换插头"]
-          },
-          medicine: {
-            name: "药品",
-            items: ["感冒药", "肠胃药", "创可贴", "常用药物"]
-          },
-          clothing: {
-            business: ["正装", "衬衫", "西裤/西裙", "皮鞋", "领带/丝巾", "内衣裤", "袜子", "睡衣"],
-            leisure: ["T恤", "休闲裤", "短裤", "内衣裤", "袜子", "运动鞋", "拖鞋", "睡衣"],
-            beach: ["泳衣", "沙滩裤", "防晒衣", "T恤", "短裤", "人字拖", "太阳帽", "墨镜"],
-            hiking: ["速干衣", "冲锋衣", "登山裤", "登山鞋", "袜子", "帽子", "手套", "围巾"],
-            winter: ["羽绒服", "毛衣", "保暖内衣", "厚裤子", "雪地靴", "帽子", "围巾", "手套"],
-            city: ["休闲上衣", "牛仔裤", "外套", "舒适的鞋", "内衣裤", "袜子", "太阳镜"]
-          },
-          accessories: {
-            business: ["笔记本电脑", "文件资料", "名片", "笔", "笔记本"],
-            leisure: ["太阳镜", "帽子", "背包", "水壶"],
-            beach: ["防水袋", "浮潜装备", "沙滩垫", "遮阳伞"],
-            hiking: ["登山杖", "背包", "水壶", "头灯", "指南针", "帐篷", "睡袋"],
-            winter: ["滑雪装备", "护目镜", "暖宝宝", "保温杯"],
-            city: ["背包", "相机", "地图/导航", "雨伞"]
-          }
-        };
-
-        let currentList = [];
-        let checkedItems = new Set();
-
-        function generateList() {
-          const tripType = document.getElementById("tripType").value;
-          const tripDays = document.getElementById("tripDays").value;
-          const climate = document.getElementById("climate").value;
-
-          currentList = [];
-          checkedItems.clear();
-
-          // Add essentials
-          currentList.push({
-            category: packingData.essentials.name,
-            items: [...packingData.essentials.items]
-          });
-
-          // Add toiletries
-          currentList.push({
-            category: packingData.toiletries.name,
-            items: [...packingData.toiletries.items]
-          });
-
-          // Add electronics
-          currentList.push({
-            category: packingData.electronics.name,
-            items: [...packingData.electronics.items]
-          });
-
-          // Add medicine
-          currentList.push({
-            category: packingData.medicine.name,
-            items: [...packingData.medicine.items]
-          });
-
-          // Add clothing based on trip type
-          const clothingItems = [...packingData.clothing[tripType]];
-          // Adjust quantity based on days
-          if (tripDays === "8-14" || tripDays === "15+") {
-            clothingItems.push("备用衣物");
-          }
-          // Add climate-specific items
-          if (climate === "hot") {
-            clothingItems.push("防晒衣", "凉鞋");
-          } else if (climate === "cold") {
-            clothingItems.push("保暖内衣", "厚外套");
-          }
-          currentList.push({ category: "衣物", items: clothingItems });
-
-          // Add accessories based on trip type
-          currentList.push({ category: "配件装备", items: [...packingData.accessories[tripType]] });
-
-          // Add custom category
-          currentList.push({ category: "自定义物品", items: [] });
-
-          renderChecklist();
-          document.getElementById("resultSection").classList.remove("hidden");
-          updateStats();
+      const packingData = {
+        essentials: {
+          name: "必备物品",
+          items: ["身份证/护照", "手机及充电器", "钱包/信用卡", "钥匙", "旅行保险单"]
+        },
+        toiletries: {
+          name: "洗漱用品",
+          items: [
+            "牙刷牙膏",
+            "洗面奶",
+            "洗发水/护发素",
+            "沐浴露",
+            "毛巾",
+            "梳子",
+            "护肤品",
+            "防晒霜"
+          ]
+        },
+        electronics: {
+          name: "电子产品",
+          items: ["充电宝", "数据线", "耳机", "相机", "转换插头"]
+        },
+        medicine: {
+          name: "药品",
+          items: ["感冒药", "肠胃药", "创可贴", "常用药物"]
+        },
+        clothing: {
+          business: ["正装", "衬衫", "西裤/西裙", "皮鞋", "领带/丝巾", "内衣裤", "袜子", "睡衣"],
+          leisure: ["T恤", "休闲裤", "短裤", "内衣裤", "袜子", "运动鞋", "拖鞋", "睡衣"],
+          beach: ["泳衣", "沙滩裤", "防晒衣", "T恤", "短裤", "人字拖", "太阳帽", "墨镜"],
+          hiking: ["速干衣", "冲锋衣", "登山裤", "登山鞋", "袜子", "帽子", "手套", "围巾"],
+          winter: ["羽绒服", "毛衣", "保暖内衣", "厚裤子", "雪地靴", "帽子", "围巾", "手套"],
+          city: ["休闲上衣", "牛仔裤", "外套", "舒适的鞋", "内衣裤", "袜子", "太阳镜"]
+        },
+        accessories: {
+          business: ["笔记本电脑", "文件资料", "名片", "笔", "笔记本"],
+          leisure: ["太阳镜", "帽子", "背包", "水壶"],
+          beach: ["防水袋", "浮潜装备", "沙滩垫", "遮阳伞"],
+          hiking: ["登山杖", "背包", "水壶", "头灯", "指南针", "帐篷", "睡袋"],
+          winter: ["滑雪装备", "护目镜", "暖宝宝", "保温杯"],
+          city: ["背包", "相机", "地图/导航", "雨伞"]
         }
+      };
 
-        function renderChecklist() {
-          const container = document.getElementById("checklist");
-          container.innerHTML = "";
+      let currentList = [];
+      let checkedItems = new Set();
 
-          currentList.forEach((category, catIndex) => {
-            if (category.items.length === 0 && category.category !== "自定义物品") return;
+      function generateList() {
+        const tripType = document.getElementById("tripType").value;
+        const tripDays = document.getElementById("tripDays").value;
+        const climate = document.getElementById("climate").value;
 
-            const catDiv = document.createElement("div");
-            catDiv.className = "checklist-category";
-            catDiv.innerHTML = `<div class="category-title">${category.category}</div>`;
+        currentList = [];
+        checkedItems.clear();
 
-            category.items.forEach((item, itemIndex) => {
-              const itemId = `${catIndex}-${itemIndex}`;
-              const isChecked = checkedItems.has(itemId);
+        // Add essentials
+        currentList.push({
+          category: packingData.essentials.name,
+          items: [...packingData.essentials.items]
+        });
 
-              const itemDiv = document.createElement("div");
-              itemDiv.className = `checklist-item${isChecked ? " checked" : ""}`;
-              itemDiv.innerHTML = `
+        // Add toiletries
+        currentList.push({
+          category: packingData.toiletries.name,
+          items: [...packingData.toiletries.items]
+        });
+
+        // Add electronics
+        currentList.push({
+          category: packingData.electronics.name,
+          items: [...packingData.electronics.items]
+        });
+
+        // Add medicine
+        currentList.push({
+          category: packingData.medicine.name,
+          items: [...packingData.medicine.items]
+        });
+
+        // Add clothing based on trip type
+        const clothingItems = [...packingData.clothing[tripType]];
+        // Adjust quantity based on days
+        if (tripDays === "8-14" || tripDays === "15+") {
+          clothingItems.push("备用衣物");
+        }
+        // Add climate-specific items
+        if (climate === "hot") {
+          clothingItems.push("防晒衣", "凉鞋");
+        } else if (climate === "cold") {
+          clothingItems.push("保暖内衣", "厚外套");
+        }
+        currentList.push({ category: "衣物", items: clothingItems });
+
+        // Add accessories based on trip type
+        currentList.push({ category: "配件装备", items: [...packingData.accessories[tripType]] });
+
+        // Add custom category
+        currentList.push({ category: "自定义物品", items: [] });
+
+        renderChecklist();
+        document.getElementById("resultSection").classList.remove("hidden");
+        updateStats();
+      }
+
+      function renderChecklist() {
+        const container = document.getElementById("checklist");
+        container.innerHTML = "";
+
+        currentList.forEach((category, catIndex) => {
+          if (category.items.length === 0 && category.category !== "自定义物品") return;
+
+          const catDiv = document.createElement("div");
+          catDiv.className = "checklist-category";
+          catDiv.innerHTML = `<div class="category-title">${category.category}</div>`;
+
+          category.items.forEach((item, itemIndex) => {
+            const itemId = `${catIndex}-${itemIndex}`;
+            const isChecked = checkedItems.has(itemId);
+
+            const itemDiv = document.createElement("div");
+            itemDiv.className = `checklist-item${isChecked ? " checked" : ""}`;
+            itemDiv.innerHTML = `
               <input type="checkbox" ${isChecked ? "checked" : ""} onchange="toggleItem('${itemId}')">
               <span>${item}</span>
               <button class="delete-btn" onclick="deleteItem(${catIndex}, ${itemIndex})" title="删除" aria-label="×">×</button>
             `;
-              catDiv.appendChild(itemDiv);
-            });
-
-            container.appendChild(catDiv);
-          });
-        }
-
-        function toggleItem(itemId) {
-          if (checkedItems.has(itemId)) {
-            checkedItems.delete(itemId);
-          } else {
-            checkedItems.add(itemId);
-          }
-          renderChecklist();
-          updateStats();
-        }
-
-        function deleteItem(catIndex, itemIndex) {
-          currentList[catIndex].items.splice(itemIndex, 1);
-          checkedItems.clear(); // Reset checked items to avoid index issues
-          renderChecklist();
-          updateStats();
-        }
-
-        function addCustomItem() {
-          const input = document.getElementById("newItem");
-          const value = input.value.trim();
-          if (!value) return;
-
-          // Find or create custom category
-          let customCat = currentList.find((c) => c.category === "自定义物品");
-          if (!customCat) {
-            customCat = { category: "自定义物品", items: [] };
-            currentList.push(customCat);
-          }
-          customCat.items.push(value);
-
-          input.value = "";
-          renderChecklist();
-          updateStats();
-        }
-
-        function updateStats() {
-          const totalItems = currentList.reduce((sum, cat) => sum + cat.items.length, 0);
-          const packedCount = checkedItems.size;
-          const percent = totalItems > 0 ? Math.round((packedCount / totalItems) * 100) : 0;
-
-          document.getElementById("totalItems").textContent = totalItems;
-          document.getElementById("packedItems").textContent = packedCount;
-          document.getElementById("progressPercent").textContent = percent + "%";
-        }
-
-        function clearAll() {
-          currentList = [];
-          checkedItems.clear();
-          document.getElementById("resultSection").classList.add("hidden");
-        }
-
-        function exportList() {
-          let text = "行李清单\n" + "=".repeat(30) + "\n\n";
-          currentList.forEach((category) => {
-            if (category.items.length === 0) return;
-            text += `【${category.category}】\n`;
-            category.items.forEach((item, index) => {
-              const itemId = `${currentList.indexOf(category)}-${index}`;
-              const checked = checkedItems.has(itemId) ? "✓" : "○";
-              text += `${checked} ${item}\n`;
-            });
-            text += "\n";
+            catDiv.appendChild(itemDiv);
           });
 
-          const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "行李清单.txt";
-          a.click();
-          URL.revokeObjectURL(url);
+          container.appendChild(catDiv);
+        });
+      }
+
+      function toggleItem(itemId) {
+        if (checkedItems.has(itemId)) {
+          checkedItems.delete(itemId);
+        } else {
+          checkedItems.add(itemId);
         }
+        renderChecklist();
+        updateStats();
+      }
 
-        function copyList() {
-          let text = "行李清单\n\n";
-          currentList.forEach((category) => {
-            if (category.items.length === 0) return;
-            text += `【${category.category}】\n`;
-            category.items.forEach((item, index) => {
-              const itemId = `${currentList.indexOf(category)}-${index}`;
-              const checked = checkedItems.has(itemId) ? "✓" : "○";
-              text += `${checked} ${item}\n`;
-            });
-            text += "\n";
-          });
+      function deleteItem(catIndex, itemIndex) {
+        currentList[catIndex].items.splice(itemIndex, 1);
+        checkedItems.clear(); // Reset checked items to avoid index issues
+        renderChecklist();
+        updateStats();
+      }
 
-          navigator.clipboard.writeText(text).then(() => {
-            alert("清单已复制到剪贴板！");
-          });
+      function addCustomItem() {
+        const input = document.getElementById("newItem");
+        const value = input.value.trim();
+        if (!value) return;
+
+        // Find or create custom category
+        let customCat = currentList.find((c) => c.category === "自定义物品");
+        if (!customCat) {
+          customCat = { category: "自定义物品", items: [] };
+          currentList.push(customCat);
         }
+        customCat.items.push(value);
 
-        window.toggleTheme = function () {
-          const html = document.documentElement;
-          const btn = document.querySelector(".theme-toggle");
-          const current = html.getAttribute("data-theme");
-          const next = current === "light" ? "dark" : "light";
-          html.setAttribute("data-theme", next);
-          btn.textContent = next === "light" ? "☀️" : "🌙";
-          localStorage.setItem("theme", next);
-        };
+        input.value = "";
+        renderChecklist();
+        updateStats();
+      }
 
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved) {
-            document.documentElement.setAttribute("data-theme", saved);
-            document.querySelector(".theme-toggle").textContent = saved === "light" ? "☀️" : "🌙";
-          }
-        })();
-</script>
-    
+      function updateStats() {
+        const totalItems = currentList.reduce((sum, cat) => sum + cat.items.length, 0);
+        const packedCount = checkedItems.size;
+        const percent = totalItems > 0 ? Math.round((packedCount / totalItems) * 100) : 0;
+
+        document.getElementById("totalItems").textContent = totalItems;
+        document.getElementById("packedItems").textContent = packedCount;
+        document.getElementById("progressPercent").textContent = percent + "%";
+      }
+
+      function clearAll() {
+        currentList = [];
+        checkedItems.clear();
+        document.getElementById("resultSection").classList.add("hidden");
+      }
+
+      function exportList() {
+        let text = "行李清单\n" + "=".repeat(30) + "\n\n";
+        currentList.forEach((category) => {
+          if (category.items.length === 0) return;
+          text += `【${category.category}】\n`;
+          category.items.forEach((item, index) => {
+            const itemId = `${currentList.indexOf(category)}-${index}`;
+            const checked = checkedItems.has(itemId) ? "✓" : "○";
+            text += `${checked} ${item}\n`;
+          });
+          text += "\n";
+        });
+
+        const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "行李清单.txt";
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      function copyList() {
+        let text = "行李清单\n\n";
+        currentList.forEach((category) => {
+          if (category.items.length === 0) return;
+          text += `【${category.category}】\n`;
+          category.items.forEach((item, index) => {
+            const itemId = `${currentList.indexOf(category)}-${index}`;
+            const checked = checkedItems.has(itemId) ? "✓" : "○";
+            text += `${checked} ${item}\n`;
+          });
+          text += "\n";
+        });
+
+        navigator.clipboard.writeText(text).then(() => {
+          alert("清单已复制到剪贴板！");
+        });
+      }
+
+      window.toggleTheme = function () {
+        const html = document.documentElement;
+        const btn = document.querySelector(".theme-toggle");
+        const current = html.getAttribute("data-theme");
+        const next = current === "light" ? "dark" : "light";
+        html.setAttribute("data-theme", next);
+        btn.textContent = next === "light" ? "☀️" : "🌙";
+        localStorage.setItem("theme", next);
+      };
+
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved) {
+          document.documentElement.setAttribute("data-theme", saved);
+          document.querySelector(".theme-toggle").textContent = saved === "light" ? "☀️" : "🌙";
+        }
+      })();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/power-adapter.html
+++ b/tools/travel/power-adapter.html
@@ -16,7 +16,10 @@
     <meta property="og:title" content="电源插座指南 - WebUtils" />
     <meta property="og:description" content="各国电源插座类型" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/power-adapter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -41,43 +44,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "电源插座指南",
-      "item": "https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "电源插座指南",
+            "item": "https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "电源插座指南 - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "电源插座指南 - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1373 +91,1375 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --accent-green: #10b981;
-    --accent-blue: #3b82f6;
-    --accent-yellow: #fbbf24;
-    --accent-red: #f43f5e;
-    --accent-purple: #a855f7;
-    --accent-cyan: #06b6d4;
-    --glow-green: rgba(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, sans-serif;
-    --font-mono: "JetBrains Mono", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: transform 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(16, 185, 129, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(16, 185, 129, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 24px;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-  }
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: 16px;
-    color: var(--color-text-primary);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .section-title::before {
-    content: "";
-    width: 4px;
-    height: 1em;
-    background: var(--accent-green);
-    border-radius: 2px;
-  }
 
-  /* Quick Buttons */
-  .quick-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 24px;
-  }
-  .quick-btn {
-    padding: 8px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-  .quick-btn:hover {
-    border-color: var(--accent-green);
-    background: rgba(16, 185, 129, 0.1);
-  }
-  .quick-btn.active {
-    border-color: var(--accent-green);
-    background: rgba(16, 185, 129, 0.15);
-    color: var(--accent-green);
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --accent-green: #10b981;
+        --accent-blue: #3b82f6;
+        --accent-yellow: #fbbf24;
+        --accent-red: #f43f5e;
+        --accent-purple: #a855f7;
+        --accent-cyan: #06b6d4;
+        --glow-green: rgba(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, sans-serif;
+        --font-mono: "JetBrains Mono", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: transform 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(16, 185, 129, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(16, 185, 129, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+      }
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        font-weight: 600;
+        margin-bottom: 16px;
+        color: var(--color-text-primary);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .section-title::before {
+        content: "";
+        width: 4px;
+        height: 1em;
+        background: var(--accent-green);
+        border-radius: 2px;
+      }
 
-  /* Selector */
-  .selector-row {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .selector-group {
-    flex: 1;
-    min-width: 250px;
-  }
-  .selector-label {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    margin-bottom: 8px;
-    text-transform: uppercase;
-  }
-  select {
-    width: 100%;
-    padding: 14px 18px;
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--color-text-primary);
-    cursor: pointer;
-    appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%238888a0' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10l-5 5z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 14px center;
-  }
-  select:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
+      /* Quick Buttons */
+      .quick-buttons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 24px;
+      }
+      .quick-btn {
+        padding: 8px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .quick-btn:hover {
+        border-color: var(--accent-green);
+        background: rgba(16, 185, 129, 0.1);
+      }
+      .quick-btn.active {
+        border-color: var(--accent-green);
+        background: rgba(16, 185, 129, 0.15);
+        color: var(--accent-green);
+      }
 
-  /* Plug Types Legend */
-  .plug-types-legend {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-    gap: 12px;
-    margin-bottom: 24px;
-    padding: 16px;
-    background: var(--bg-input);
-    border-radius: var(--radius-md);
-  }
-  .plug-type {
-    text-align: center;
-    padding: 12px 8px;
-    border-radius: var(--radius-sm);
-    transition: all 0.2s;
-    cursor: pointer;
-  }
-  .plug-type:hover {
-    background: rgba(16, 185, 129, 0.1);
-  }
-  .plug-type.highlight {
-    background: rgba(16, 185, 129, 0.2);
-    border: 1px solid var(--accent-green);
-  }
-  .plug-visual {
-    width: 50px;
-    height: 50px;
-    margin: 0 auto 8px;
-    position: relative;
-  }
-  .plug-name {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--accent-green);
-  }
-  .plug-desc {
-    font-size: 0.7rem;
-    color: var(--color-text-muted);
-    margin-top: 2px;
-  }
+      /* Selector */
+      .selector-row {
+        display: flex;
+        gap: 16px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .selector-group {
+        flex: 1;
+        min-width: 250px;
+      }
+      .selector-label {
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+      }
+      select {
+        width: 100%;
+        padding: 14px 18px;
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        cursor: pointer;
+        appearance: none;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%238888a0' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10l-5 5z'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: right 14px center;
+      }
+      select:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
 
-  /* CSS Plug Shapes */
-  .plug-shape {
-    width: 100%;
-    height: 100%;
-    background: var(--color-bg-card);
-    border: 2px solid var(--border-subtle);
-    border-radius: 8px;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-  }
-  .pin {
-    background: var(--color-text-secondary);
-    border-radius: 2px;
-  }
+      /* Plug Types Legend */
+      .plug-types-legend {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        gap: 12px;
+        margin-bottom: 24px;
+        padding: 16px;
+        background: var(--bg-input);
+        border-radius: var(--radius-md);
+      }
+      .plug-type {
+        text-align: center;
+        padding: 12px 8px;
+        border-radius: var(--radius-sm);
+        transition: all 0.2s;
+        cursor: pointer;
+      }
+      .plug-type:hover {
+        background: rgba(16, 185, 129, 0.1);
+      }
+      .plug-type.highlight {
+        background: rgba(16, 185, 129, 0.2);
+        border: 1px solid var(--accent-green);
+      }
+      .plug-visual {
+        width: 50px;
+        height: 50px;
+        margin: 0 auto 8px;
+        position: relative;
+      }
+      .plug-name {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--accent-green);
+      }
+      .plug-desc {
+        font-size: 0.7rem;
+        color: var(--color-text-muted);
+        margin-top: 2px;
+      }
 
-  /* Type A - Two flat parallel pins */
-  .plug-a .pin {
-    width: 3px;
-    height: 16px;
-  }
+      /* CSS Plug Shapes */
+      .plug-shape {
+        width: 100%;
+        height: 100%;
+        background: var(--color-bg-card);
+        border: 2px solid var(--border-subtle);
+        border-radius: 8px;
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+      }
+      .pin {
+        background: var(--color-text-secondary);
+        border-radius: 2px;
+      }
 
-  /* Type B - Two flat + round ground */
-  .plug-b .pin {
-    width: 3px;
-    height: 14px;
-  }
-  .plug-b .ground {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    position: absolute;
-    bottom: 8px;
-  }
+      /* Type A - Two flat parallel pins */
+      .plug-a .pin {
+        width: 3px;
+        height: 16px;
+      }
 
-  /* Type C - Two round pins */
-  .plug-c .pin {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-  }
+      /* Type B - Two flat + round ground */
+      .plug-b .pin {
+        width: 3px;
+        height: 14px;
+      }
+      .plug-b .ground {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        position: absolute;
+        bottom: 8px;
+      }
 
-  /* Type G - Three rectangular pins */
-  .plug-g {
-    flex-direction: column;
-    gap: 3px;
-  }
-  .plug-g .top-pin {
-    width: 6px;
-    height: 10px;
-  }
-  .plug-g .bottom-pins {
-    display: flex;
-    gap: 8px;
-  }
-  .plug-g .bottom-pins .pin {
-    width: 4px;
-    height: 8px;
-  }
+      /* Type C - Two round pins */
+      .plug-c .pin {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+      }
 
-  /* Type I - Angled pins */
-  .plug-i .pin {
-    width: 3px;
-    height: 14px;
-  }
-  .plug-i .pin:first-child {
-    transform: rotate(-15deg);
-  }
-  .plug-i .pin:last-child {
-    transform: rotate(15deg);
-  }
+      /* Type G - Three rectangular pins */
+      .plug-g {
+        flex-direction: column;
+        gap: 3px;
+      }
+      .plug-g .top-pin {
+        width: 6px;
+        height: 10px;
+      }
+      .plug-g .bottom-pins {
+        display: flex;
+        gap: 8px;
+      }
+      .plug-g .bottom-pins .pin {
+        width: 4px;
+        height: 8px;
+      }
 
-  /* Type F - Two round + side grounds */
-  .plug-f .pin {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-  }
-  .plug-f::before,
-  .plug-f::after {
-    content: "";
-    position: absolute;
-    width: 3px;
-    height: 12px;
-    background: var(--color-text-muted);
-    border-radius: 1px;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-  .plug-f::before {
-    left: 4px;
-  }
-  .plug-f::after {
-    right: 4px;
-  }
+      /* Type I - Angled pins */
+      .plug-i .pin {
+        width: 3px;
+        height: 14px;
+      }
+      .plug-i .pin:first-child {
+        transform: rotate(-15deg);
+      }
+      .plug-i .pin:last-child {
+        transform: rotate(15deg);
+      }
 
-  /* Result Display */
-  .result-card {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    margin-bottom: 24px;
-  }
-  .result-header {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 20px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .country-flag {
-    font-size: 3rem;
-  }
-  .country-info h2 {
-    font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 600;
-  }
-  .country-info .name-en {
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
-  }
-  .specs-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 16px;
-    margin-bottom: 20px;
-  }
-  .spec-item {
-    padding: 16px;
-    background: var(--bg-input);
-    border-radius: var(--radius-md);
-    text-align: center;
-  }
-  .spec-label {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .spec-value {
-    font-family: var(--font-mono);
-    font-size: 1.3rem;
-    font-weight: 700;
-  }
-  .spec-value.voltage {
-    color: var(--accent-yellow);
-  }
-  .spec-value.frequency {
-    color: var(--accent-blue);
-  }
-  .spec-value.plugs {
-    color: var(--accent-green);
-  }
+      /* Type F - Two round + side grounds */
+      .plug-f .pin {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+      }
+      .plug-f::before,
+      .plug-f::after {
+        content: "";
+        position: absolute;
+        width: 3px;
+        height: 12px;
+        background: var(--color-text-muted);
+        border-radius: 1px;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      .plug-f::before {
+        left: 4px;
+      }
+      .plug-f::after {
+        right: 4px;
+      }
 
-  /* Adapter Needed Status */
-  .adapter-status {
-    padding: 16px 20px;
-    border-radius: var(--radius-md);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-family: var(--font-mono);
-  }
-  .adapter-status.needed {
-    background: rgba(244, 63, 94, 0.1);
-    border: 1px solid var(--accent-red);
-    color: var(--accent-red);
-  }
-  .adapter-status.not-needed {
-    background: rgba(16, 185, 129, 0.1);
-    border: 1px solid var(--accent-green);
-    color: var(--accent-green);
-  }
-  .adapter-status.partial {
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid var(--accent-yellow);
-    color: var(--accent-yellow);
-  }
-  .status-icon {
-    font-size: 1.5rem;
-  }
-  .status-text {
-    flex: 1;
-  }
-  .status-title {
-    font-weight: 600;
-    font-size: 1rem;
-  }
-  .status-detail {
-    font-size: 0.85rem;
-    opacity: 0.9;
-    margin-top: 4px;
-  }
+      /* Result Display */
+      .result-card {
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        margin-bottom: 24px;
+      }
+      .result-header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 20px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .country-flag {
+        font-size: 3rem;
+      }
+      .country-info h2 {
+        font-family: var(--font-mono);
+        font-size: 1.4rem;
+        font-weight: 600;
+      }
+      .country-info .name-en {
+        font-size: 0.9rem;
+        color: var(--color-text-muted);
+      }
+      .specs-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 16px;
+        margin-bottom: 20px;
+      }
+      .spec-item {
+        padding: 16px;
+        background: var(--bg-input);
+        border-radius: var(--radius-md);
+        text-align: center;
+      }
+      .spec-label {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+        margin-bottom: 6px;
+      }
+      .spec-value {
+        font-family: var(--font-mono);
+        font-size: 1.3rem;
+        font-weight: 700;
+      }
+      .spec-value.voltage {
+        color: var(--accent-yellow);
+      }
+      .spec-value.frequency {
+        color: var(--accent-blue);
+      }
+      .spec-value.plugs {
+        color: var(--accent-green);
+      }
 
-  /* Notes */
-  .adapter-note {
-    padding: 14px 18px;
-    background: rgba(168, 85, 247, 0.1);
-    border: 1px solid var(--accent-purple);
-    border-radius: var(--radius-md);
-    font-size: 0.85rem;
-    color: var(--accent-purple);
-    margin-top: 16px;
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-  }
-  .adapter-note .note-icon {
-    font-size: 1.1rem;
-  }
+      /* Adapter Needed Status */
+      .adapter-status {
+        padding: 16px 20px;
+        border-radius: var(--radius-md);
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-family: var(--font-mono);
+      }
+      .adapter-status.needed {
+        background: rgba(244, 63, 94, 0.1);
+        border: 1px solid var(--accent-red);
+        color: var(--accent-red);
+      }
+      .adapter-status.not-needed {
+        background: rgba(16, 185, 129, 0.1);
+        border: 1px solid var(--accent-green);
+        color: var(--accent-green);
+      }
+      .adapter-status.partial {
+        background: rgba(251, 191, 36, 0.1);
+        border: 1px solid var(--accent-yellow);
+        color: var(--accent-yellow);
+      }
+      .status-icon {
+        font-size: 1.5rem;
+      }
+      .status-text {
+        flex: 1;
+      }
+      .status-title {
+        font-weight: 600;
+        font-size: 1rem;
+      }
+      .status-detail {
+        font-size: 0.85rem;
+        opacity: 0.9;
+        margin-top: 4px;
+      }
 
-  /* Toast */
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    opacity: 0;
-    transition: all 0.3s;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      /* Notes */
+      .adapter-note {
+        padding: 14px 18px;
+        background: rgba(168, 85, 247, 0.1);
+        border: 1px solid var(--accent-purple);
+        border-radius: var(--radius-md);
+        font-size: 0.85rem;
+        color: var(--accent-purple);
+        margin-top: 16px;
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+      }
+      .adapter-note .note-icon {
+        font-size: 1.1rem;
+      }
 
-  /* Reference Section */
-  .reference-section {
-    margin-top: 24px;
-    padding-top: 24px;
-    border-top: 1px solid var(--border-subtle);
-  }
-  .china-ref {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 16px;
-    background: rgba(6, 182, 212, 0.1);
-    border: 1px solid var(--accent-cyan);
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--accent-cyan);
-  }
+      /* Toast */
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        opacity: 0;
+        transition: all 0.3s;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-    .selector-row {
-      flex-direction: column;
-    }
-    .selector-group {
-      min-width: 100%;
-    }
-    .specs-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-    .plug-types-legend {
-      grid-template-columns: repeat(3, 1fr);
-    }
-    .result-header {
-      flex-direction: column;
-      text-align: center;
-    }
-  }
-</style>
+      /* Reference Section */
+      .reference-section {
+        margin-top: 24px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border-subtle);
+      }
+      .china-ref {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 16px;
+        background: rgba(6, 182, 212, 0.1);
+        border: 1px solid var(--accent-cyan);
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--accent-cyan);
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+        .selector-row {
+          flex-direction: column;
+        }
+        .selector-group {
+          min-width: 100%;
+        }
+        .specs-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .plug-types-legend {
+          grid-template-columns: repeat(3, 1fr);
+        }
+        .result-header {
+          flex-direction: column;
+          text-align: center;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">电源插座指南</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🔌</span>
-        电源插座指南
-      </h1>
-      <p>查询各国电源插座类型和电压标准，判断从中国出发是否需要转换器</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">电源插座指南</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🔌</span>
+              电源插座指南
+            </h1>
+            <p>查询各国电源插座类型和电压标准，判断从中国出发是否需要转换器</p>
+          </div>
+        </header>
 
-  <main class="main-content">
-    <div class="section-title">热门目的地</div>
-    <div class="quick-buttons" id="quickButtons">
-      <button class="quick-btn" data-country="JP">🇯🇵 日本</button>
-      <button class="quick-btn" data-country="US">🇺🇸 美国</button>
-      <button class="quick-btn" data-country="GB">🇬🇧 英国</button>
-      <button class="quick-btn" data-country="TH">🇹🇭 泰国</button>
-      <button class="quick-btn" data-country="KR">🇰🇷 韩国</button>
-      <button class="quick-btn" data-country="SG">🇸🇬 新加坡</button>
-      <button class="quick-btn" data-country="AU">🇦🇺 澳大利亚</button>
-      <button class="quick-btn" data-country="DE">🇩🇪 德国</button>
-      <button class="quick-btn" data-country="FR">🇫🇷 法国</button>
-      <button class="quick-btn" data-country="AE">🇦🇪 阿联酋</button>
-    </div>
+        <main class="main-content">
+          <div class="section-title">热门目的地</div>
+          <div class="quick-buttons" id="quickButtons">
+            <button class="quick-btn" data-country="JP">🇯🇵 日本</button>
+            <button class="quick-btn" data-country="US">🇺🇸 美国</button>
+            <button class="quick-btn" data-country="GB">🇬🇧 英国</button>
+            <button class="quick-btn" data-country="TH">🇹🇭 泰国</button>
+            <button class="quick-btn" data-country="KR">🇰🇷 韩国</button>
+            <button class="quick-btn" data-country="SG">🇸🇬 新加坡</button>
+            <button class="quick-btn" data-country="AU">🇦🇺 澳大利亚</button>
+            <button class="quick-btn" data-country="DE">🇩🇪 德国</button>
+            <button class="quick-btn" data-country="FR">🇫🇷 法国</button>
+            <button class="quick-btn" data-country="AE">🇦🇪 阿联酋</button>
+          </div>
 
-    <div class="section-title">选择目的地国家</div>
-    <div class="selector-row">
-      <div class="selector-group">
-        <div class="selector-label">目的地</div>
-        <select id="countrySelect">
-          <option value="">-- 请选择国家/地区 --</option>
-        </select>
-      </div>
-    </div>
-
-    <div id="resultArea" style="display: none">
-      <div class="result-card">
-        <div class="result-header">
-          <div class="country-flag" id="resultFlag"></div>
-          <div class="country-info">
-            <h2 id="resultName"></h2>
-            <div class="name-en" id="resultNameEn"></div>
-          </div>
-        </div>
-
-        <div class="specs-grid">
-          <div class="spec-item">
-            <div class="spec-label">电压</div>
-            <div class="spec-value voltage" id="resultVoltage"></div>
-          </div>
-          <div class="spec-item">
-            <div class="spec-label">频率</div>
-            <div class="spec-value frequency" id="resultFrequency"></div>
-          </div>
-          <div class="spec-item">
-            <div class="spec-label">插座类型</div>
-            <div class="spec-value plugs" id="resultPlugs"></div>
-          </div>
-        </div>
-
-        <div class="adapter-status" id="adapterStatus">
-          <div class="status-icon" id="statusIcon"></div>
-          <div class="status-text">
-            <div class="status-title" id="statusTitle"></div>
-            <div class="status-detail" id="statusDetail"></div>
-          </div>
-        </div>
-
-        <div class="adapter-note" id="resultNote" style="display: none">
-          <span class="note-icon">💡</span>
-          <span id="noteText"></span>
-        </div>
-      </div>
-    </div>
-
-    <div class="section-title">插座类型图示</div>
-    <div class="plug-types-legend" id="plugLegend">
-      <div class="plug-type" data-type="A">
-        <div class="plug-visual">
-          <div class="plug-shape plug-a">
-            <div class="pin"></div>
-            <div class="pin"></div>
-          </div>
-        </div>
-        <div class="plug-name">A型</div>
-        <div class="plug-desc">美标两扁</div>
-      </div>
-      <div class="plug-type" data-type="B">
-        <div class="plug-visual">
-          <div class="plug-shape plug-b">
-            <div class="pin"></div>
-            <div class="pin"></div>
-            <div class="pin ground"></div>
-          </div>
-        </div>
-        <div class="plug-name">B型</div>
-        <div class="plug-desc">美标三扁</div>
-      </div>
-      <div class="plug-type" data-type="C">
-        <div class="plug-visual">
-          <div class="plug-shape plug-c">
-            <div class="pin"></div>
-            <div class="pin"></div>
-          </div>
-        </div>
-        <div class="plug-name">C型</div>
-        <div class="plug-desc">欧标两圆</div>
-      </div>
-      <div class="plug-type" data-type="F">
-        <div class="plug-visual">
-          <div class="plug-shape plug-f">
-            <div class="pin"></div>
-            <div class="pin"></div>
-          </div>
-        </div>
-        <div class="plug-name">F型</div>
-        <div class="plug-desc">德标接地</div>
-      </div>
-      <div class="plug-type" data-type="G">
-        <div class="plug-visual">
-          <div class="plug-shape plug-g">
-            <div class="pin top-pin"></div>
-            <div class="bottom-pins">
-              <div class="pin"></div>
-              <div class="pin"></div>
+          <div class="section-title">选择目的地国家</div>
+          <div class="selector-row">
+            <div class="selector-group">
+              <div class="selector-label">目的地</div>
+              <select id="countrySelect">
+                <option value="">-- 请选择国家/地区 --</option>
+              </select>
             </div>
           </div>
-        </div>
-        <div class="plug-name">G型</div>
-        <div class="plug-desc">英标三方</div>
-      </div>
-      <div class="plug-type" data-type="I">
-        <div class="plug-visual">
-          <div class="plug-shape plug-i">
-            <div class="pin"></div>
-            <div class="pin"></div>
+
+          <div id="resultArea" style="display: none">
+            <div class="result-card">
+              <div class="result-header">
+                <div class="country-flag" id="resultFlag"></div>
+                <div class="country-info">
+                  <h2 id="resultName"></h2>
+                  <div class="name-en" id="resultNameEn"></div>
+                </div>
+              </div>
+
+              <div class="specs-grid">
+                <div class="spec-item">
+                  <div class="spec-label">电压</div>
+                  <div class="spec-value voltage" id="resultVoltage"></div>
+                </div>
+                <div class="spec-item">
+                  <div class="spec-label">频率</div>
+                  <div class="spec-value frequency" id="resultFrequency"></div>
+                </div>
+                <div class="spec-item">
+                  <div class="spec-label">插座类型</div>
+                  <div class="spec-value plugs" id="resultPlugs"></div>
+                </div>
+              </div>
+
+              <div class="adapter-status" id="adapterStatus">
+                <div class="status-icon" id="statusIcon"></div>
+                <div class="status-text">
+                  <div class="status-title" id="statusTitle"></div>
+                  <div class="status-detail" id="statusDetail"></div>
+                </div>
+              </div>
+
+              <div class="adapter-note" id="resultNote" style="display: none">
+                <span class="note-icon">💡</span>
+                <span id="noteText"></span>
+              </div>
+            </div>
           </div>
-        </div>
-        <div class="plug-name">I型</div>
-        <div class="plug-desc">澳标斜扁</div>
+
+          <div class="section-title">插座类型图示</div>
+          <div class="plug-types-legend" id="plugLegend">
+            <div class="plug-type" data-type="A">
+              <div class="plug-visual">
+                <div class="plug-shape plug-a">
+                  <div class="pin"></div>
+                  <div class="pin"></div>
+                </div>
+              </div>
+              <div class="plug-name">A型</div>
+              <div class="plug-desc">美标两扁</div>
+            </div>
+            <div class="plug-type" data-type="B">
+              <div class="plug-visual">
+                <div class="plug-shape plug-b">
+                  <div class="pin"></div>
+                  <div class="pin"></div>
+                  <div class="pin ground"></div>
+                </div>
+              </div>
+              <div class="plug-name">B型</div>
+              <div class="plug-desc">美标三扁</div>
+            </div>
+            <div class="plug-type" data-type="C">
+              <div class="plug-visual">
+                <div class="plug-shape plug-c">
+                  <div class="pin"></div>
+                  <div class="pin"></div>
+                </div>
+              </div>
+              <div class="plug-name">C型</div>
+              <div class="plug-desc">欧标两圆</div>
+            </div>
+            <div class="plug-type" data-type="F">
+              <div class="plug-visual">
+                <div class="plug-shape plug-f">
+                  <div class="pin"></div>
+                  <div class="pin"></div>
+                </div>
+              </div>
+              <div class="plug-name">F型</div>
+              <div class="plug-desc">德标接地</div>
+            </div>
+            <div class="plug-type" data-type="G">
+              <div class="plug-visual">
+                <div class="plug-shape plug-g">
+                  <div class="pin top-pin"></div>
+                  <div class="bottom-pins">
+                    <div class="pin"></div>
+                    <div class="pin"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="plug-name">G型</div>
+              <div class="plug-desc">英标三方</div>
+            </div>
+            <div class="plug-type" data-type="I">
+              <div class="plug-visual">
+                <div class="plug-shape plug-i">
+                  <div class="pin"></div>
+                  <div class="pin"></div>
+                </div>
+              </div>
+              <div class="plug-name">I型</div>
+              <div class="plug-desc">澳标斜扁</div>
+            </div>
+          </div>
+
+          <div class="reference-section">
+            <div class="section-title">出发地参考</div>
+            <div class="china-ref">🇨🇳 中国：A / I 型插座 | 220V | 50Hz</div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <div class="reference-section">
-      <div class="section-title">出发地参考</div>
-      <div class="china-ref">🇨🇳 中国：A / I 型插座 | 220V | 50Hz</div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "电源插座指南",
-              "item": "https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "电源插座指南",
+            "item": "https://tools.realtime-ai.chat/tools/travel/power-adapter.html"
+          }
+        ]
+      }
     </script>
     <script>
+      // China reference: Type A/I, 220V, 50Hz
+      var CHINA_PLUGS = ["A", "I"];
+      var CHINA_VOLTAGE = 220;
+      var CHINA_FREQUENCY = 50;
 
-  // China reference: Type A/I, 220V, 50Hz
-        var CHINA_PLUGS = ["A", "I"];
-        var CHINA_VOLTAGE = 220;
-        var CHINA_FREQUENCY = 50;
+      var countries = [
+        {
+          code: "CN",
+          name: "中国",
+          nameEn: "China",
+          flag: "🇨🇳",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["A", "C", "I"],
+          note: "中国使用扁平两脚(A型)和斜角三脚(I型)插座"
+        },
+        {
+          code: "US",
+          name: "美国",
+          nameEn: "United States",
+          flag: "🇺🇸",
+          voltage: "120V",
+          frequency: "60Hz",
+          plugs: ["A", "B"],
+          note: "电压仅120V，部分电器可能需要变压器"
+        },
+        {
+          code: "GB",
+          name: "英国",
+          nameEn: "United Kingdom",
+          flag: "🇬🇧",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插，必须使用G型转换器"
+        },
+        {
+          code: "JP",
+          name: "日本",
+          nameEn: "Japan",
+          flag: "🇯🇵",
+          voltage: "100V",
+          frequency: "50/60Hz",
+          plugs: ["A", "B"],
+          note: "电压仅100V，为全球最低，电热设备效率降低"
+        },
+        {
+          code: "DE",
+          name: "德国",
+          nameEn: "Germany",
+          flag: "🇩🇪",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆孔插座，需要C/F型转换器"
+        },
+        {
+          code: "FR",
+          name: "法国",
+          nameEn: "France",
+          flag: "🇫🇷",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "E"],
+          note: "E型带接地针，C型欧标也可使用"
+        },
+        {
+          code: "AU",
+          name: "澳大利亚",
+          nameEn: "Australia",
+          flag: "🇦🇺",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["I"],
+          note: "斜角扁平插头，与中国I型兼容"
+        },
+        {
+          code: "CA",
+          name: "加拿大",
+          nameEn: "Canada",
+          flag: "🇨🇦",
+          voltage: "120V",
+          frequency: "60Hz",
+          plugs: ["A", "B"],
+          note: "与美国标准相同，低电压"
+        },
+        {
+          code: "KR",
+          name: "韩国",
+          nameEn: "South Korea",
+          flag: "🇰🇷",
+          voltage: "220V",
+          frequency: "60Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头，频率为60Hz"
+        },
+        {
+          code: "IN",
+          name: "印度",
+          nameEn: "India",
+          flag: "🇮🇳",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "D", "M"],
+          note: "多种插座类型并存，建议携带万能转换器"
+        },
+        {
+          code: "SG",
+          name: "新加坡",
+          nameEn: "Singapore",
+          flag: "🇸🇬",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插，必须使用G型转换器"
+        },
+        {
+          code: "MY",
+          name: "马来西亚",
+          nameEn: "Malaysia",
+          flag: "🇲🇾",
+          voltage: "240V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插"
+        },
+        {
+          code: "TH",
+          name: "泰国",
+          nameEn: "Thailand",
+          flag: "🇹🇭",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["A", "B", "C", "O"],
+          note: "多种插座混用，A型中国插头可直接使用"
+        },
+        {
+          code: "ID",
+          name: "印度尼西亚",
+          nameEn: "Indonesia",
+          flag: "🇮🇩",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "VN",
+          name: "越南",
+          nameEn: "Vietnam",
+          flag: "🇻🇳",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["A", "C", "G"],
+          note: "多种插座类型，A型较常见"
+        },
+        {
+          code: "PH",
+          name: "菲律宾",
+          nameEn: "Philippines",
+          flag: "🇵🇭",
+          voltage: "220V",
+          frequency: "60Hz",
+          plugs: ["A", "B", "C"],
+          note: "美标和欧标混用，A型常见"
+        },
+        {
+          code: "NZ",
+          name: "新西兰",
+          nameEn: "New Zealand",
+          flag: "🇳🇿",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["I"],
+          note: "与澳大利亚相同，I型兼容"
+        },
+        {
+          code: "IT",
+          name: "意大利",
+          nameEn: "Italy",
+          flag: "🇮🇹",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F", "L"],
+          note: "L型为意大利特有三圆孔"
+        },
+        {
+          code: "ES",
+          name: "西班牙",
+          nameEn: "Spain",
+          flag: "🇪🇸",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "NL",
+          name: "荷兰",
+          nameEn: "Netherlands",
+          flag: "🇳🇱",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "CH",
+          name: "瑞士",
+          nameEn: "Switzerland",
+          flag: "🇨🇭",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "J"],
+          note: "J型为瑞士特有，C型也可使用"
+        },
+        {
+          code: "RU",
+          name: "俄罗斯",
+          nameEn: "Russia",
+          flag: "🇷🇺",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "TR",
+          name: "土耳其",
+          nameEn: "Turkey",
+          flag: "🇹🇷",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "BR",
+          name: "巴西",
+          nameEn: "Brazil",
+          flag: "🇧🇷",
+          voltage: "127/220V",
+          frequency: "60Hz",
+          plugs: ["C", "N"],
+          note: "N型为巴西特有，注意确认当地电压"
+        },
+        {
+          code: "AR",
+          name: "阿根廷",
+          nameEn: "Argentina",
+          flag: "🇦🇷",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["C", "I"],
+          note: "I型斜角插头，与中国部分兼容"
+        },
+        {
+          code: "MX",
+          name: "墨西哥",
+          nameEn: "Mexico",
+          flag: "🇲🇽",
+          voltage: "127V",
+          frequency: "60Hz",
+          plugs: ["A", "B"],
+          note: "与美国相同，低电压"
+        },
+        {
+          code: "ZA",
+          name: "南非",
+          nameEn: "South Africa",
+          flag: "🇿🇦",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "D", "M", "N"],
+          note: "多种插座类型，建议万能转换器"
+        },
+        {
+          code: "EG",
+          name: "埃及",
+          nameEn: "Egypt",
+          flag: "🇪🇬",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "AE",
+          name: "阿联酋",
+          nameEn: "United Arab Emirates",
+          flag: "🇦🇪",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["C", "D", "G"],
+          note: "G型英标为主，部分场所有欧标"
+        },
+        {
+          code: "IL",
+          name: "以色列",
+          nameEn: "Israel",
+          flag: "🇮🇱",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "H"],
+          note: "H型为以色列特有，C型也可使用"
+        },
+        {
+          code: "HK",
+          name: "香港",
+          nameEn: "Hong Kong",
+          flag: "🇭🇰",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插，必须使用G型转换器"
+        },
+        {
+          code: "MO",
+          name: "澳门",
+          nameEn: "Macau",
+          flag: "🇲🇴",
+          voltage: "220V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插"
+        },
+        {
+          code: "TW",
+          name: "台湾",
+          nameEn: "Taiwan",
+          flag: "🇹🇼",
+          voltage: "110V",
+          frequency: "60Hz",
+          plugs: ["A", "B"],
+          note: "与美国日本类似，低电压"
+        },
+        {
+          code: "GR",
+          name: "希腊",
+          nameEn: "Greece",
+          flag: "🇬🇷",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "PT",
+          name: "葡萄牙",
+          nameEn: "Portugal",
+          flag: "🇵🇹",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "SE",
+          name: "瑞典",
+          nameEn: "Sweden",
+          flag: "🇸🇪",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "NO",
+          name: "挪威",
+          nameEn: "Norway",
+          flag: "🇳🇴",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "DK",
+          name: "丹麦",
+          nameEn: "Denmark",
+          flag: "🇩🇰",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "E", "F", "K"],
+          note: "K型为丹麦特有，C/F型也可使用"
+        },
+        {
+          code: "FI",
+          name: "芬兰",
+          nameEn: "Finland",
+          flag: "🇫🇮",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "AT",
+          name: "奥地利",
+          nameEn: "Austria",
+          flag: "🇦🇹",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "BE",
+          name: "比利时",
+          nameEn: "Belgium",
+          flag: "🇧🇪",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "E"],
+          note: "E型带接地针，C型也可使用"
+        },
+        {
+          code: "PL",
+          name: "波兰",
+          nameEn: "Poland",
+          flag: "🇵🇱",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "E"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "CZ",
+          name: "捷克",
+          nameEn: "Czech Republic",
+          flag: "🇨🇿",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "E"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "HU",
+          name: "匈牙利",
+          nameEn: "Hungary",
+          flag: "🇭🇺",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["C", "F"],
+          note: "欧标圆插头"
+        },
+        {
+          code: "IE",
+          name: "爱尔兰",
+          nameEn: "Ireland",
+          flag: "🇮🇪",
+          voltage: "230V",
+          frequency: "50Hz",
+          plugs: ["G"],
+          note: "英标三脚方插"
+        },
+        {
+          code: "SA",
+          name: "沙特阿拉伯",
+          nameEn: "Saudi Arabia",
+          flag: "🇸🇦",
+          voltage: "220V",
+          frequency: "60Hz",
+          plugs: ["A", "B", "G"],
+          note: "多种插座类型，A型和G型常见"
+        }
+      ];
 
-        var countries = [
-          {
-            code: "CN",
-            name: "中国",
-            nameEn: "China",
-            flag: "🇨🇳",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["A", "C", "I"],
-            note: "中国使用扁平两脚(A型)和斜角三脚(I型)插座"
-          },
-          {
-            code: "US",
-            name: "美国",
-            nameEn: "United States",
-            flag: "🇺🇸",
-            voltage: "120V",
-            frequency: "60Hz",
-            plugs: ["A", "B"],
-            note: "电压仅120V，部分电器可能需要变压器"
-          },
-          {
-            code: "GB",
-            name: "英国",
-            nameEn: "United Kingdom",
-            flag: "🇬🇧",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插，必须使用G型转换器"
-          },
-          {
-            code: "JP",
-            name: "日本",
-            nameEn: "Japan",
-            flag: "🇯🇵",
-            voltage: "100V",
-            frequency: "50/60Hz",
-            plugs: ["A", "B"],
-            note: "电压仅100V，为全球最低，电热设备效率降低"
-          },
-          {
-            code: "DE",
-            name: "德国",
-            nameEn: "Germany",
-            flag: "🇩🇪",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆孔插座，需要C/F型转换器"
-          },
-          {
-            code: "FR",
-            name: "法国",
-            nameEn: "France",
-            flag: "🇫🇷",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "E"],
-            note: "E型带接地针，C型欧标也可使用"
-          },
-          {
-            code: "AU",
-            name: "澳大利亚",
-            nameEn: "Australia",
-            flag: "🇦🇺",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["I"],
-            note: "斜角扁平插头，与中国I型兼容"
-          },
-          {
-            code: "CA",
-            name: "加拿大",
-            nameEn: "Canada",
-            flag: "🇨🇦",
-            voltage: "120V",
-            frequency: "60Hz",
-            plugs: ["A", "B"],
-            note: "与美国标准相同，低电压"
-          },
-          {
-            code: "KR",
-            name: "韩国",
-            nameEn: "South Korea",
-            flag: "🇰🇷",
-            voltage: "220V",
-            frequency: "60Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头，频率为60Hz"
-          },
-          {
-            code: "IN",
-            name: "印度",
-            nameEn: "India",
-            flag: "🇮🇳",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "D", "M"],
-            note: "多种插座类型并存，建议携带万能转换器"
-          },
-          {
-            code: "SG",
-            name: "新加坡",
-            nameEn: "Singapore",
-            flag: "🇸🇬",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插，必须使用G型转换器"
-          },
-          {
-            code: "MY",
-            name: "马来西亚",
-            nameEn: "Malaysia",
-            flag: "🇲🇾",
-            voltage: "240V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插"
-          },
-          {
-            code: "TH",
-            name: "泰国",
-            nameEn: "Thailand",
-            flag: "🇹🇭",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["A", "B", "C", "O"],
-            note: "多种插座混用，A型中国插头可直接使用"
-          },
-          {
-            code: "ID",
-            name: "印度尼西亚",
-            nameEn: "Indonesia",
-            flag: "🇮🇩",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "VN",
-            name: "越南",
-            nameEn: "Vietnam",
-            flag: "🇻🇳",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["A", "C", "G"],
-            note: "多种插座类型，A型较常见"
-          },
-          {
-            code: "PH",
-            name: "菲律宾",
-            nameEn: "Philippines",
-            flag: "🇵🇭",
-            voltage: "220V",
-            frequency: "60Hz",
-            plugs: ["A", "B", "C"],
-            note: "美标和欧标混用，A型常见"
-          },
-          {
-            code: "NZ",
-            name: "新西兰",
-            nameEn: "New Zealand",
-            flag: "🇳🇿",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["I"],
-            note: "与澳大利亚相同，I型兼容"
-          },
-          {
-            code: "IT",
-            name: "意大利",
-            nameEn: "Italy",
-            flag: "🇮🇹",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F", "L"],
-            note: "L型为意大利特有三圆孔"
-          },
-          {
-            code: "ES",
-            name: "西班牙",
-            nameEn: "Spain",
-            flag: "🇪🇸",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "NL",
-            name: "荷兰",
-            nameEn: "Netherlands",
-            flag: "🇳🇱",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "CH",
-            name: "瑞士",
-            nameEn: "Switzerland",
-            flag: "🇨🇭",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "J"],
-            note: "J型为瑞士特有，C型也可使用"
-          },
-          {
-            code: "RU",
-            name: "俄罗斯",
-            nameEn: "Russia",
-            flag: "🇷🇺",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "TR",
-            name: "土耳其",
-            nameEn: "Turkey",
-            flag: "🇹🇷",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "BR",
-            name: "巴西",
-            nameEn: "Brazil",
-            flag: "🇧🇷",
-            voltage: "127/220V",
-            frequency: "60Hz",
-            plugs: ["C", "N"],
-            note: "N型为巴西特有，注意确认当地电压"
-          },
-          {
-            code: "AR",
-            name: "阿根廷",
-            nameEn: "Argentina",
-            flag: "🇦🇷",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["C", "I"],
-            note: "I型斜角插头，与中国部分兼容"
-          },
-          {
-            code: "MX",
-            name: "墨西哥",
-            nameEn: "Mexico",
-            flag: "🇲🇽",
-            voltage: "127V",
-            frequency: "60Hz",
-            plugs: ["A", "B"],
-            note: "与美国相同，低电压"
-          },
-          {
-            code: "ZA",
-            name: "南非",
-            nameEn: "South Africa",
-            flag: "🇿🇦",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "D", "M", "N"],
-            note: "多种插座类型，建议万能转换器"
-          },
-          {
-            code: "EG",
-            name: "埃及",
-            nameEn: "Egypt",
-            flag: "🇪🇬",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "AE",
-            name: "阿联酋",
-            nameEn: "United Arab Emirates",
-            flag: "🇦🇪",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["C", "D", "G"],
-            note: "G型英标为主，部分场所有欧标"
-          },
-          {
-            code: "IL",
-            name: "以色列",
-            nameEn: "Israel",
-            flag: "🇮🇱",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "H"],
-            note: "H型为以色列特有，C型也可使用"
-          },
-          {
-            code: "HK",
-            name: "香港",
-            nameEn: "Hong Kong",
-            flag: "🇭🇰",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插，必须使用G型转换器"
-          },
-          {
-            code: "MO",
-            name: "澳门",
-            nameEn: "Macau",
-            flag: "🇲🇴",
-            voltage: "220V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插"
-          },
-          {
-            code: "TW",
-            name: "台湾",
-            nameEn: "Taiwan",
-            flag: "🇹🇼",
-            voltage: "110V",
-            frequency: "60Hz",
-            plugs: ["A", "B"],
-            note: "与美国日本类似，低电压"
-          },
-          {
-            code: "GR",
-            name: "希腊",
-            nameEn: "Greece",
-            flag: "🇬🇷",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "PT",
-            name: "葡萄牙",
-            nameEn: "Portugal",
-            flag: "🇵🇹",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "SE",
-            name: "瑞典",
-            nameEn: "Sweden",
-            flag: "🇸🇪",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "NO",
-            name: "挪威",
-            nameEn: "Norway",
-            flag: "🇳🇴",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "DK",
-            name: "丹麦",
-            nameEn: "Denmark",
-            flag: "🇩🇰",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "E", "F", "K"],
-            note: "K型为丹麦特有，C/F型也可使用"
-          },
-          {
-            code: "FI",
-            name: "芬兰",
-            nameEn: "Finland",
-            flag: "🇫🇮",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "AT",
-            name: "奥地利",
-            nameEn: "Austria",
-            flag: "🇦🇹",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "BE",
-            name: "比利时",
-            nameEn: "Belgium",
-            flag: "🇧🇪",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "E"],
-            note: "E型带接地针，C型也可使用"
-          },
-          {
-            code: "PL",
-            name: "波兰",
-            nameEn: "Poland",
-            flag: "🇵🇱",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "E"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "CZ",
-            name: "捷克",
-            nameEn: "Czech Republic",
-            flag: "🇨🇿",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "E"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "HU",
-            name: "匈牙利",
-            nameEn: "Hungary",
-            flag: "🇭🇺",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["C", "F"],
-            note: "欧标圆插头"
-          },
-          {
-            code: "IE",
-            name: "爱尔兰",
-            nameEn: "Ireland",
-            flag: "🇮🇪",
-            voltage: "230V",
-            frequency: "50Hz",
-            plugs: ["G"],
-            note: "英标三脚方插"
-          },
-          {
-            code: "SA",
-            name: "沙特阿拉伯",
-            nameEn: "Saudi Arabia",
-            flag: "🇸🇦",
-            voltage: "220V",
-            frequency: "60Hz",
-            plugs: ["A", "B", "G"],
-            note: "多种插座类型，A型和G型常见"
-          }
-        ];
+      // Sort countries by name
+      countries.sort(function (a, b) {
+        return a.name.localeCompare(b.name, "zh-CN");
+      });
 
-        // Sort countries by name
-        countries.sort(function (a, b) {
-          return a.name.localeCompare(b.name, "zh-CN");
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      function initCountrySelect() {
+        var select = document.getElementById("countrySelect");
+        countries.forEach(function (country) {
+          var option = document.createElement("option");
+          option.value = country.code;
+          option.textContent = country.flag + " " + country.name + " (" + country.nameEn + ")";
+          select.appendChild(option);
+        });
+      }
+
+      function checkAdapterNeeded(country) {
+        var plugsCompatible = country.plugs.some(function (plug) {
+          return CHINA_PLUGS.indexOf(plug) !== -1;
         });
 
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
+        var voltageNum = parseInt(country.voltage);
+        var voltageCompatible = voltageNum >= 200 && voltageNum <= 240;
 
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
-
-        function initCountrySelect() {
-          var select = document.getElementById("countrySelect");
-          countries.forEach(function (country) {
-            var option = document.createElement("option");
-            option.value = country.code;
-            option.textContent = country.flag + " " + country.name + " (" + country.nameEn + ")";
-            select.appendChild(option);
+        if (country.voltage.indexOf("/") !== -1) {
+          // Mixed voltage like Brazil
+          var voltages = country.voltage.split("/").map(function (v) {
+            return parseInt(v);
+          });
+          voltageCompatible = voltages.some(function (v) {
+            return v >= 200 && v <= 240;
           });
         }
 
-        function checkAdapterNeeded(country) {
-          var plugsCompatible = country.plugs.some(function (plug) {
-            return CHINA_PLUGS.indexOf(plug) !== -1;
-          });
+        return {
+          plugsCompatible: plugsCompatible,
+          voltageCompatible: voltageCompatible,
+          needsAdapter: !plugsCompatible,
+          needsTransformer: !voltageCompatible
+        };
+      }
 
-          var voltageNum = parseInt(country.voltage);
-          var voltageCompatible = voltageNum >= 200 && voltageNum <= 240;
-
-          if (country.voltage.indexOf("/") !== -1) {
-            // Mixed voltage like Brazil
-            var voltages = country.voltage.split("/").map(function (v) {
-              return parseInt(v);
-            });
-            voltageCompatible = voltages.some(function (v) {
-              return v >= 200 && v <= 240;
-            });
-          }
-
-          return {
-            plugsCompatible: plugsCompatible,
-            voltageCompatible: voltageCompatible,
-            needsAdapter: !plugsCompatible,
-            needsTransformer: !voltageCompatible
-          };
+      function displayResult(countryCode) {
+        var country = countries.find(function (c) {
+          return c.code === countryCode;
+        });
+        if (!country) {
+          document.getElementById("resultArea").style.display = "none";
+          return;
         }
 
-        function displayResult(countryCode) {
-          var country = countries.find(function (c) {
-            return c.code === countryCode;
-          });
-          if (!country) {
-            document.getElementById("resultArea").style.display = "none";
-            return;
-          }
+        document.getElementById("resultArea").style.display = "block";
+        document.getElementById("resultFlag").textContent = country.flag;
+        document.getElementById("resultName").textContent = country.name;
+        document.getElementById("resultNameEn").textContent = country.nameEn;
+        document.getElementById("resultVoltage").textContent = country.voltage;
+        document.getElementById("resultFrequency").textContent = country.frequency;
+        document.getElementById("resultPlugs").textContent = country.plugs.join(" / ");
 
-          document.getElementById("resultArea").style.display = "block";
-          document.getElementById("resultFlag").textContent = country.flag;
-          document.getElementById("resultName").textContent = country.name;
-          document.getElementById("resultNameEn").textContent = country.nameEn;
-          document.getElementById("resultVoltage").textContent = country.voltage;
-          document.getElementById("resultFrequency").textContent = country.frequency;
-          document.getElementById("resultPlugs").textContent = country.plugs.join(" / ");
+        var check = checkAdapterNeeded(country);
+        var statusEl = document.getElementById("adapterStatus");
+        var iconEl = document.getElementById("statusIcon");
+        var titleEl = document.getElementById("statusTitle");
+        var detailEl = document.getElementById("statusDetail");
 
-          var check = checkAdapterNeeded(country);
-          var statusEl = document.getElementById("adapterStatus");
-          var iconEl = document.getElementById("statusIcon");
-          var titleEl = document.getElementById("statusTitle");
-          var detailEl = document.getElementById("statusDetail");
+        statusEl.className = "adapter-status";
 
-          statusEl.className = "adapter-status";
+        if (!check.needsAdapter && !check.needsTransformer) {
+          statusEl.classList.add("not-needed");
+          iconEl.textContent = "✅";
+          titleEl.textContent = "无需转换器";
+          detailEl.textContent = "中国插头可直接使用，电压兼容";
+        } else if (check.needsAdapter && check.needsTransformer) {
+          statusEl.classList.add("needed");
+          iconEl.textContent = "⚠️";
+          titleEl.textContent = "需要转换器 + 变压器";
+          detailEl.textContent = "插座类型不兼容，且电压差异大，建议使用支持宽电压的设备";
+        } else if (check.needsAdapter) {
+          statusEl.classList.add("needed");
+          iconEl.textContent = "🔌";
+          titleEl.textContent = "需要转换器";
+          detailEl.textContent = "插座类型不兼容，需要 " + country.plugs.join("/") + " 型转换器";
+        } else {
+          statusEl.classList.add("partial");
+          iconEl.textContent = "⚡";
+          titleEl.textContent = "需要变压器";
+          detailEl.textContent =
+            "插头兼容但电压不同（" + country.voltage + "），电热设备可能功率不足";
+        }
 
-          if (!check.needsAdapter && !check.needsTransformer) {
-            statusEl.classList.add("not-needed");
-            iconEl.textContent = "✅";
-            titleEl.textContent = "无需转换器";
-            detailEl.textContent = "中国插头可直接使用，电压兼容";
-          } else if (check.needsAdapter && check.needsTransformer) {
-            statusEl.classList.add("needed");
-            iconEl.textContent = "⚠️";
-            titleEl.textContent = "需要转换器 + 变压器";
-            detailEl.textContent = "插座类型不兼容，且电压差异大，建议使用支持宽电压的设备";
-          } else if (check.needsAdapter) {
-            statusEl.classList.add("needed");
-            iconEl.textContent = "🔌";
-            titleEl.textContent = "需要转换器";
-            detailEl.textContent = "插座类型不兼容，需要 " + country.plugs.join("/") + " 型转换器";
+        // Highlight compatible plug types
+        var plugTypes = document.querySelectorAll(".plug-type");
+        plugTypes.forEach(function (el) {
+          var type = el.getAttribute("data-type");
+          if (country.plugs.indexOf(type) !== -1) {
+            el.classList.add("highlight");
           } else {
-            statusEl.classList.add("partial");
-            iconEl.textContent = "⚡";
-            titleEl.textContent = "需要变压器";
-            detailEl.textContent =
-              "插头兼容但电压不同（" + country.voltage + "），电热设备可能功率不足";
+            el.classList.remove("highlight");
           }
+        });
 
-          // Highlight compatible plug types
-          var plugTypes = document.querySelectorAll(".plug-type");
-          plugTypes.forEach(function (el) {
-            var type = el.getAttribute("data-type");
-            if (country.plugs.indexOf(type) !== -1) {
-              el.classList.add("highlight");
-            } else {
-              el.classList.remove("highlight");
-            }
-          });
+        // Show note
+        var noteEl = document.getElementById("resultNote");
+        var noteText = document.getElementById("noteText");
+        if (country.note) {
+          noteEl.style.display = "flex";
+          noteText.textContent = country.note;
+        } else {
+          noteEl.style.display = "none";
+        }
 
-          // Show note
-          var noteEl = document.getElementById("resultNote");
-          var noteText = document.getElementById("noteText");
-          if (country.note) {
-            noteEl.style.display = "flex";
-            noteText.textContent = country.note;
+        // Update quick button active state
+        var quickBtns = document.querySelectorAll(".quick-btn");
+        quickBtns.forEach(function (btn) {
+          if (btn.getAttribute("data-country") === countryCode) {
+            btn.classList.add("active");
           } else {
-            noteEl.style.display = "none";
-          }
-
-          // Update quick button active state
-          var quickBtns = document.querySelectorAll(".quick-btn");
-          quickBtns.forEach(function (btn) {
-            if (btn.getAttribute("data-country") === countryCode) {
-              btn.classList.add("active");
-            } else {
-              btn.classList.remove("active");
-            }
-          });
-
-          // Update select
-          document.getElementById("countrySelect").value = countryCode;
-
-          // Save to localStorage
-          localStorage.setItem("powerAdapter_country", countryCode);
-        }
-
-        function showToast(msg) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        // Event listeners
-        document.getElementById("countrySelect").addEventListener("change", function () {
-          displayResult(this.value);
-        });
-
-        document.getElementById("quickButtons").addEventListener("click", function (e) {
-          var btn = e.target.closest(".quick-btn");
-          if (btn) {
-            var code = btn.getAttribute("data-country");
-            displayResult(code);
+            btn.classList.remove("active");
           }
         });
 
-        // Initialize
-        initCountrySelect();
+        // Update select
+        document.getElementById("countrySelect").value = countryCode;
 
-        // Restore from localStorage
-        var savedCountry = localStorage.getItem("powerAdapter_country");
-        if (savedCountry) {
-          displayResult(savedCountry);
+        // Save to localStorage
+        localStorage.setItem("powerAdapter_country", countryCode);
+      }
+
+      function showToast(msg) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Event listeners
+      document.getElementById("countrySelect").addEventListener("change", function () {
+        displayResult(this.value);
+      });
+
+      document.getElementById("quickButtons").addEventListener("click", function (e) {
+        var btn = e.target.closest(".quick-btn");
+        if (btn) {
+          var code = btn.getAttribute("data-country");
+          displayResult(code);
         }
-</script>
-    
+      });
+
+      // Initialize
+      initCountrySelect();
+
+      // Restore from localStorage
+      var savedCountry = localStorage.getItem("powerAdapter_country");
+      if (savedCountry) {
+        displayResult(savedCountry);
+      }
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/timezone-converter.html
+++ b/tools/travel/timezone-converter.html
@@ -6,17 +6,29 @@
     <title>Timezone Converter - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="timezone converter" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/travel/timezone-converter.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="Timezone Converter - WebUtils" />
-    <meta property="og:description" content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/timezone-converter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Timezone Converter - WebUtils" />
-    <meta name="twitter:description" content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Timezone Converter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Timezone Converter",
-      "item": "https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Timezone Converter",
+            "item": "https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Timezone Converter - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Timezone Converter - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,575 +103,578 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
-  :root {
-    /* color-* 家族 → 新设计系统 */
-    --color-bg-deep: var(--bg-deep, #0a0a0f);
-    --color-bg-surface: var(--bg-surface, #12121a);
-    --color-bg-subtle: var(--bg-card, #1a1a24);
-    --color-bg-card: var(--bg-card, #1a1a24);
-    --color-bg-input: var(--bg-input, #0e0e14);
-    --color-text-primary: var(--text-primary, #e8e8ed);
-    --color-text-secondary: var(--text-secondary, #8888a0);
-    --color-text-muted: var(--text-muted, #55556a);
-    --color-border-default: var(--border-subtle, #2a2a3a);
-    --color-border-subtle: var(--border-subtle, #2a2a3a);
-    --color-border-strong: var(--border-strong, #3a3a4a);
-    --color-accent-primary: var(--accent-cyan, #00f5d4);
-    --color-accent-secondary: var(--accent-magenta, #f72585);
-    --color-accent-tertiary: var(--accent-blue, #4cc9f0);
-    --color-accent-cyan: var(--accent-cyan, #00f5d4);
-    --color-accent-purple: var(--accent-purple, #8b5cf6);
-    --color-accent-pink: var(--accent-magenta, #f72585);
-    --color-accent-orange: #ff9f1c;
-    --color-success: var(--accent-green, #10b981);
-    --color-warning: var(--accent-yellow, #fbbf24);
-    --color-error: var(--accent-red, #f43f5e);
-    --color-danger: var(--accent-red, #f43f5e);
-    --color-info: var(--accent-blue, #4cc9f0);
-    --color-safe: var(--accent-green, #10b981);
 
-    /* 玻璃拟态 */
-    --glass-bg: rgba(26, 26, 36, 0.72);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-blur: 24px;
-    --glass-saturate: 180%;
-    --glass-radius: 16px;
-    --glass-border-width: 1px;
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
+      :root {
+        /* color-* 家族 → 新设计系统 */
+        --color-bg-deep: var(--bg-deep, #0a0a0f);
+        --color-bg-surface: var(--bg-surface, #12121a);
+        --color-bg-subtle: var(--bg-card, #1a1a24);
+        --color-bg-card: var(--bg-card, #1a1a24);
+        --color-bg-input: var(--bg-input, #0e0e14);
+        --color-text-primary: var(--text-primary, #e8e8ed);
+        --color-text-secondary: var(--text-secondary, #8888a0);
+        --color-text-muted: var(--text-muted, #55556a);
+        --color-border-default: var(--border-subtle, #2a2a3a);
+        --color-border-subtle: var(--border-subtle, #2a2a3a);
+        --color-border-strong: var(--border-strong, #3a3a4a);
+        --color-accent-primary: var(--accent-cyan, #00f5d4);
+        --color-accent-secondary: var(--accent-magenta, #f72585);
+        --color-accent-tertiary: var(--accent-blue, #4cc9f0);
+        --color-accent-cyan: var(--accent-cyan, #00f5d4);
+        --color-accent-purple: var(--accent-purple, #8b5cf6);
+        --color-accent-pink: var(--accent-magenta, #f72585);
+        --color-accent-orange: #ff9f1c;
+        --color-success: var(--accent-green, #10b981);
+        --color-warning: var(--accent-yellow, #fbbf24);
+        --color-error: var(--accent-red, #f43f5e);
+        --color-danger: var(--accent-red, #f43f5e);
+        --color-info: var(--accent-blue, #4cc9f0);
+        --color-safe: var(--accent-green, #10b981);
 
-    /* 间距尺度 */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 20px;
-    --space-6: 24px;
-    --space-8: 32px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-card: 16px;
+        /* 玻璃拟态 */
+        --glass-bg: rgba(26, 26, 36, 0.72);
+        --glass-border: rgba(255, 255, 255, 0.08);
+        --glass-blur: 24px;
+        --glass-saturate: 180%;
+        --glass-radius: 16px;
+        --glass-border-width: 1px;
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* 阴影 */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-    --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        /* 间距尺度 */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --spacing-sm: 8px;
+        --spacing-md: 16px;
+        --spacing-lg: 24px;
+        --spacing-card: 16px;
 
-    /* 辉光 */
-    --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
-    --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
-    --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
-    --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
-    --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
-    --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
+        /* 阴影 */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+        --shadow-glow: 0 0 20px rgba(0, 245, 212, 0.15);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
-    /* 过渡 */
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
-    --transition: 200ms ease;
+        /* 辉光 */
+        --glow-cyan: 0 0 20px rgba(0, 245, 212, 0.4);
+        --glow-purple: 0 0 20px rgba(139, 92, 246, 0.4);
+        --glow-green: 0 0 20px rgba(16, 185, 129, 0.4);
+        --glow-red: 0 0 20px rgba(244, 63, 94, 0.4);
+        --glow-magenta: 0 0 20px rgba(247, 37, 133, 0.4);
+        --accent-glow: 0 0 20px rgba(0, 245, 212, 0.4);
 
-    /* 圆角 */
-    --radius-full: 9999px;
-    --radius-xl: 24px;
-    --border-radius: 8px;
+        /* 过渡 */
+        --transition-fast: 150ms ease;
+        --transition-normal: 250ms ease;
+        --transition: 200ms ease;
 
-    /* 布局 */
-    --nav-height: 56px;
-    --container-max: 1400px;
-    --container-bg: var(--bg-card, #1a1a24);
-    --safe-area-top: env(safe-area-inset-top, 0px);
-    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        /* 圆角 */
+        --radius-full: 9999px;
+        --radius-xl: 24px;
+        --border-radius: 8px;
 
-    /* 单名旧约定 */
-    --bg-color: var(--bg-deep, #0a0a0f);
-    --bg-secondary: var(--bg-surface, #12121a);
-    --bg-tertiary: var(--bg-card, #1a1a24);
-    --bg-elevated: var(--bg-card-hover, #22222e);
-    --bg-hover: var(--bg-card-hover, #22222e);
-    --bg-card-hover: #22222e;
-    --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
-    --text-color: var(--text-primary, #e8e8ed);
-    --primary-color: var(--accent-cyan, #00f5d4);
-    --primary-focus: rgba(0, 245, 212, 0.25);
-    --secondary-color: var(--accent-magenta, #f72585);
-    --tertiary-color: var(--text-muted, #55556a);
-    --accent-color: var(--accent-cyan, #00f5d4);
-    --accent-hover: #2dffe2;
-    --accent-light: rgba(0, 245, 212, 0.15);
-    --accent-pink: var(--accent-magenta, #f72585);
-    --accent-orange: #ff9f1c;
-    --accent-gold: #ffd166;
-    --accent-brown: #a0522d;
-    --success-color: var(--accent-green, #10b981);
-    --good-color: var(--accent-green, #10b981);
-    --warning-color: var(--accent-yellow, #fbbf24);
-    --error-color: var(--accent-red, #f43f5e);
-    --danger-color: var(--accent-red, #f43f5e);
-    --info-color: var(--accent-blue, #4cc9f0);
-    --muted-color: var(--text-muted, #55556a);
-    --muted-border-color: var(--border-subtle, #2a2a3a);
-    --hover-color: var(--accent-cyan, #00f5d4);
-    --border-default: var(--border-subtle, #2a2a3a);
-    --border-focus: var(--accent-cyan, #00f5d4);
-    --border-accent: var(--accent-cyan, #00f5d4);
-    --card-background-color: var(--bg-card, #1a1a24);
-    --code-background-color: var(--bg-input, #0e0e14);
+        /* 布局 */
+        --nav-height: 56px;
+        --container-max: 1400px;
+        --container-bg: var(--bg-card, #1a1a24);
+        --safe-area-top: env(safe-area-inset-top, 0px);
+        --safe-area-bottom: env(safe-area-inset-bottom, 0px);
 
-    /* Pico CSS 框架默认 */
-    --pico-background-color: var(--bg-deep, #0a0a0f);
-    --pico-color: var(--text-primary, #e8e8ed);
-    --pico-muted-color: var(--text-muted, #55556a);
-    --pico-muted-border-color: var(--border-subtle, #2a2a3a);
-    --pico-muted-background: var(--bg-surface, #12121a);
-    --pico-card-background-color: var(--bg-card, #1a1a24);
-    --pico-code-background-color: var(--bg-input, #0e0e14);
-    --pico-primary: var(--accent-cyan, #00f5d4);
-    --pico-primary-background: var(--accent-cyan, #00f5d4);
-    --pico-primary-inverse: #0a0a0f;
-    --pico-primary-focus: rgba(0, 245, 212, 0.25);
-    --pico-primary-rgb: 0, 245, 212;
-    --pico-secondary: var(--text-secondary, #8888a0);
-    --pico-secondary-background: var(--bg-card, #1a1a24);
-    --pico-border-radius: 8px;
-    --pico-contrast: var(--text-primary, #e8e8ed);
-    --pico-contrast-background: var(--bg-card-hover, #22222e);
-    --pico-del-color: var(--accent-red, #f43f5e);
-    --pico-ins-color: var(--accent-green, #10b981);
-    --pico-form-element-border-color: var(--border-strong, #3a3a4a);
-    --pico-form-element-background-color: var(--bg-input, #0e0e14);
-  }
+        /* 单名旧约定 */
+        --bg-color: var(--bg-deep, #0a0a0f);
+        --bg-secondary: var(--bg-surface, #12121a);
+        --bg-tertiary: var(--bg-card, #1a1a24);
+        --bg-elevated: var(--bg-card-hover, #22222e);
+        --bg-hover: var(--bg-card-hover, #22222e);
+        --bg-card-hover: #22222e;
+        --bg-gradient: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
+        --primary-gradient: linear-gradient(135deg, #00f5d4 0%, #4cc9f0 100%);
+        --text-color: var(--text-primary, #e8e8ed);
+        --primary-color: var(--accent-cyan, #00f5d4);
+        --primary-focus: rgba(0, 245, 212, 0.25);
+        --secondary-color: var(--accent-magenta, #f72585);
+        --tertiary-color: var(--text-muted, #55556a);
+        --accent-color: var(--accent-cyan, #00f5d4);
+        --accent-hover: #2dffe2;
+        --accent-light: rgba(0, 245, 212, 0.15);
+        --accent-pink: var(--accent-magenta, #f72585);
+        --accent-orange: #ff9f1c;
+        --accent-gold: #ffd166;
+        --accent-brown: #a0522d;
+        --success-color: var(--accent-green, #10b981);
+        --good-color: var(--accent-green, #10b981);
+        --warning-color: var(--accent-yellow, #fbbf24);
+        --error-color: var(--accent-red, #f43f5e);
+        --danger-color: var(--accent-red, #f43f5e);
+        --info-color: var(--accent-blue, #4cc9f0);
+        --muted-color: var(--text-muted, #55556a);
+        --muted-border-color: var(--border-subtle, #2a2a3a);
+        --hover-color: var(--accent-cyan, #00f5d4);
+        --border-default: var(--border-subtle, #2a2a3a);
+        --border-focus: var(--accent-cyan, #00f5d4);
+        --border-accent: var(--accent-cyan, #00f5d4);
+        --card-background-color: var(--bg-card, #1a1a24);
+        --code-background-color: var(--bg-input, #0e0e14);
 
-  /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
-  [data-theme="light"] {
-    /* 玻璃拟态 — 浅色版（半透明白） */
-    --glass-bg: rgba(255, 255, 255, 0.78);
-    --glass-border: rgba(0, 0, 0, 0.06);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+        /* Pico CSS 框架默认 */
+        --pico-background-color: var(--bg-deep, #0a0a0f);
+        --pico-color: var(--text-primary, #e8e8ed);
+        --pico-muted-color: var(--text-muted, #55556a);
+        --pico-muted-border-color: var(--border-subtle, #2a2a3a);
+        --pico-muted-background: var(--bg-surface, #12121a);
+        --pico-card-background-color: var(--bg-card, #1a1a24);
+        --pico-code-background-color: var(--bg-input, #0e0e14);
+        --pico-primary: var(--accent-cyan, #00f5d4);
+        --pico-primary-background: var(--accent-cyan, #00f5d4);
+        --pico-primary-inverse: #0a0a0f;
+        --pico-primary-focus: rgba(0, 245, 212, 0.25);
+        --pico-primary-rgb: 0, 245, 212;
+        --pico-secondary: var(--text-secondary, #8888a0);
+        --pico-secondary-background: var(--bg-card, #1a1a24);
+        --pico-border-radius: 8px;
+        --pico-contrast: var(--text-primary, #e8e8ed);
+        --pico-contrast-background: var(--bg-card-hover, #22222e);
+        --pico-del-color: var(--accent-red, #f43f5e);
+        --pico-ins-color: var(--accent-green, #10b981);
+        --pico-form-element-border-color: var(--border-strong, #3a3a4a);
+        --pico-form-element-background-color: var(--bg-input, #0e0e14);
+      }
 
-    /* 阴影 — 浅色版（更淡） */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
-    --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      /* 浅色主题覆盖：glass/shadow/glow 等主题敏感变量 */
+      [data-theme="light"] {
+        /* 玻璃拟态 — 浅色版（半透明白） */
+        --glass-bg: rgba(255, 255, 255, 0.78);
+        --glass-border: rgba(0, 0, 0, 0.06);
+        --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 
-    /* 辉光 — 浅色版（透明度降低） */
-    --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
-    --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
-    --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
-    --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
-    --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
-    --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
+        /* 阴影 — 浅色版（更淡） */
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+        --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+        --shadow-glow: 0 0 20px rgba(0, 184, 148, 0.12);
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-    /* 渐变 — 浅色版 */
-    --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
+        /* 辉光 — 浅色版（透明度降低） */
+        --glow-cyan: 0 0 16px rgba(0, 184, 148, 0.18);
+        --glow-purple: 0 0 16px rgba(139, 92, 246, 0.18);
+        --glow-green: 0 0 16px rgba(16, 185, 129, 0.18);
+        --glow-red: 0 0 16px rgba(244, 63, 94, 0.18);
+        --glow-magenta: 0 0 16px rgba(247, 37, 133, 0.18);
+        --accent-glow: 0 0 16px rgba(0, 184, 148, 0.18);
 
-    /* hover/elevated 替换为浅色调 */
-    --bg-card-hover: #f1f5f9;
-    --bg-elevated: #fff;
-    --bg-hover: #f1f5f9;
-    --accent-light: rgba(0, 184, 148, 0.12);
-    --accent-hover: #00d4aa;
+        /* 渐变 — 浅色版 */
+        --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #fff 100%);
 
-    /* Pico 浅色覆盖（默认 Pico 行为） */
-    --pico-primary-inverse: #fff;
-    --pico-contrast-background: #f1f5f9;
-  }
+        /* hover/elevated 替换为浅色调 */
+        --bg-card-hover: #f1f5f9;
+        --bg-elevated: #fff;
+        --bg-hover: #f1f5f9;
+        --accent-light: rgba(0, 184, 148, 0.12);
+        --accent-hover: #00d4aa;
 
-  :root {
-    --bg-deep: #0a0a0f;
-    --bg-surface: #12121a;
-    --bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --text-primary: #e8e8ed;
-    --text-secondary: #8888a0;
-    --text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-magenta: #f72585;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #4cc9f0;
-    --accent-purple: #7b2cbf;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
+        /* Pico 浅色覆盖（默认 Pico 行为） */
+        --pico-primary-inverse: #fff;
+        --pico-contrast-background: #f1f5f9;
+      }
 
-  [data-theme="light"] {
-    --bg-deep: #fafafa;
-    --bg-surface: #fff;
-    --bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --text-primary: #1a1a1a;
-    --text-secondary: #666;
-    --text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-    --accent-cyan: #00d4b8;
-    --accent-magenta: #e63975;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  }
+      :root {
+        --bg-deep: #0a0a0f;
+        --bg-surface: #12121a;
+        --bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --text-primary: #e8e8ed;
+        --text-secondary: #8888a0;
+        --text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-magenta: #f72585;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #4cc9f0;
+        --accent-purple: #7b2cbf;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      }
 
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
+      [data-theme="light"] {
+        --bg-deep: #fafafa;
+        --bg-surface: #fff;
+        --bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666;
+        --text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+        --accent-cyan: #00d4b8;
+        --accent-magenta: #e63975;
+        --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    font-size: 16px;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(16, 185, 129, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(16, 185, 129, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-  }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s;
-  }
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
-  .breadcrumb-separator {
-    color: var(--text-muted);
-    user-select: none;
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        font-size: 16px;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgb(16, 185, 129, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(16, 185, 129, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+      }
 
-  .timezone-card {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    margin-bottom: 24px;
-  }
-  .timezone-card.current {
-    border-color: var(--accent-green);
-  }
-  .timezone-label {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-  .timezone-time {
-    font-family: var(--font-mono);
-    font-size: 3rem;
-    font-weight: 700;
-    color: var(--accent-green);
-    margin-bottom: 8px;
-  }
-  .timezone-date {
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    color: var(--color-text-secondary);
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
+      .breadcrumb-separator {
+        color: var(--text-muted);
+        user-select: none;
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  select,
-  input[type="datetime-local"] {
-    width: 100%;
-    padding: 12px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    margin-bottom: 16px;
-  }
-  select:focus,
-  input:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
+      .timezone-card {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        margin-bottom: 24px;
+      }
+      .timezone-card.current {
+        border-color: var(--accent-green);
+      }
+      .timezone-label {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+      .timezone-time {
+        font-family: var(--font-mono);
+        font-size: 3rem;
+        font-weight: 700;
+        color: var(--accent-green);
+        margin-bottom: 8px;
+      }
+      .timezone-date {
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        color: var(--color-text-secondary);
+      }
 
-  .grid-2 {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
-  @media (max-width: 768px) {
-    .grid-2 {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
+      select,
+      input[type="datetime-local"] {
+        width: 100%;
+        padding: 12px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        margin-bottom: 16px;
+      }
+      select:focus,
+      input:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
+
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 768px) {
+        .grid-2 {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">时区转换器</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🌍</span>
-        时区转换器
-      </h1>
-      <p>全球时区时间转换</p>
-    </div>
-  </header>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">时区转换器</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🌍</span>
+              时区转换器
+            </h1>
+            <p>全球时区时间转换</p>
+          </div>
+        </header>
 
-  <main>
-    <div class="timezone-card current">
-      <div class="timezone-label">本地时间</div>
-      <div class="timezone-time" id="localTime">--:--:--</div>
-      <div class="timezone-date" id="localDate">----年--月--日</div>
-    </div>
+        <main>
+          <div class="timezone-card current">
+            <div class="timezone-label">本地时间</div>
+            <div class="timezone-time" id="localTime">--:--:--</div>
+            <div class="timezone-date" id="localDate">----年--月--日</div>
+          </div>
 
-    <div class="grid-2">
-      <div class="timezone-card">
-        <div class="timezone-label">源时区</div>
-        <select id="fromTz">
-          <option value="Asia/Shanghai">中国 (UTC+8)</option>
-          <option value="America/New_York">纽约 (UTC-5)</option>
-          <option value="America/Los_Angeles">洛杉矶 (UTC-8)</option>
-          <option value="Europe/London">伦敦 (UTC+0)</option>
-          <option value="Europe/Paris">巴黎 (UTC+1)</option>
-          <option value="Asia/Tokyo">东京 (UTC+9)</option>
-          <option value="Asia/Seoul">首尔 (UTC+9)</option>
-          <option value="Asia/Dubai">迪拜 (UTC+4)</option>
-          <option value="Australia/Sydney">悉尼 (UTC+11)</option>
-        </select>
-        <input type="datetime-local" id="fromTime">
+          <div class="grid-2">
+            <div class="timezone-card">
+              <div class="timezone-label">源时区</div>
+              <select id="fromTz">
+                <option value="Asia/Shanghai">中国 (UTC+8)</option>
+                <option value="America/New_York">纽约 (UTC-5)</option>
+                <option value="America/Los_Angeles">洛杉矶 (UTC-8)</option>
+                <option value="Europe/London">伦敦 (UTC+0)</option>
+                <option value="Europe/Paris">巴黎 (UTC+1)</option>
+                <option value="Asia/Tokyo">东京 (UTC+9)</option>
+                <option value="Asia/Seoul">首尔 (UTC+9)</option>
+                <option value="Asia/Dubai">迪拜 (UTC+4)</option>
+                <option value="Australia/Sydney">悉尼 (UTC+11)</option>
+              </select>
+              <input type="datetime-local" id="fromTime" />
+            </div>
+
+            <div class="timezone-card">
+              <div class="timezone-label">目标时区</div>
+              <select id="toTz">
+                <option value="America/New_York">纽约 (UTC-5)</option>
+                <option value="America/Los_Angeles">洛杉矶 (UTC-8)</option>
+                <option value="Europe/London">伦敦 (UTC+0)</option>
+                <option value="Europe/Paris">巴黎 (UTC+1)</option>
+                <option value="Asia/Tokyo">东京 (UTC+9)</option>
+                <option value="Asia/Seoul">首尔 (UTC+9)</option>
+                <option value="Asia/Shanghai">中国 (UTC+8)</option>
+                <option value="Asia/Dubai">迪拜 (UTC+4)</option>
+                <option value="Australia/Sydney">悉尼 (UTC+11)</option>
+              </select>
+              <div class="timezone-time" id="toTime" style="font-size: 2rem">--:--:--</div>
+              <div class="timezone-date" id="toDate">----年--月--日</div>
+            </div>
+          </div>
+        </main>
       </div>
+    </div>
 
-      <div class="timezone-card">
-        <div class="timezone-label">目标时区</div>
-        <select id="toTz">
-          <option value="America/New_York">纽约 (UTC-5)</option>
-          <option value="America/Los_Angeles">洛杉矶 (UTC-8)</option>
-          <option value="Europe/London">伦敦 (UTC+0)</option>
-          <option value="Europe/Paris">巴黎 (UTC+1)</option>
-          <option value="Asia/Tokyo">东京 (UTC+9)</option>
-          <option value="Asia/Seoul">首尔 (UTC+9)</option>
-          <option value="Asia/Shanghai">中国 (UTC+8)</option>
-          <option value="Asia/Dubai">迪拜 (UTC+4)</option>
-          <option value="Australia/Sydney">悉尼 (UTC+11)</option>
-        </select>
-        <div class="timezone-time" id="toTime" style="font-size: 2rem">--:--:--</div>
-        <div class="timezone-date" id="toDate">----年--月--日</div>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "时区转换器",
-              "item": "https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "时区转换器",
+            "item": "https://tools.realtime-ai.chat/tools/travel/timezone-converter.html"
+          }
+        ]
+      }
     </script>
     <script>
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") document.body.setAttribute("data-theme", "light");
+      })();
 
-  function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") document.body.setAttribute("data-theme", "light");
-        })();
-
-        function updateLocalTime() {
-          const now = new Date();
-          document.getElementById("localTime").textContent = now.toLocaleTimeString("zh-CN", {
-            hour12: false
-          });
-          document.getElementById("localDate").textContent = now.toLocaleDateString("zh-CN", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            weekday: "long"
-          });
-        }
-
-        function convertTime() {
-          const fromTime = document.getElementById("fromTime").value;
-          if (!fromTime) return;
-
-          const fromTz = document.getElementById("fromTz").value;
-          const toTz = document.getElementById("toTz").value;
-
-          // 将输入时间解析为源时区的时间，然后转换到目标时区
-          // 使用 Intl.DateTimeFormat 获取源时区的当前偏移量来正确解析输入时间
-          const inputDate = new Date(fromTime);
-
-          // 获取源时区和本地时区的偏移差
-          const localFormatter = new Intl.DateTimeFormat("en-US", {
-            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            timeZoneName: "shortOffset"
-          });
-          const fromFormatter = new Intl.DateTimeFormat("en-US", {
-            timeZone: fromTz,
-            timeZoneName: "shortOffset"
-          });
-
-          // 通过格式化同一时间点获取偏移信息
-          const localParts = localFormatter.formatToParts(inputDate);
-          const fromParts = fromFormatter.formatToParts(inputDate);
-
-          const getOffset = (parts) => {
-            const tzPart = parts.find((p) => p.type === "timeZoneName");
-            if (!tzPart) return 0;
-            const match = tzPart.value.match(/GMT([+-]?)(\d+)?:?(\d+)?/);
-            if (!match) return 0;
-            const sign = match[1] === "-" ? -1 : 1;
-            const hours = parseInt(match[2] || "0", 10);
-            const mins = parseInt(match[3] || "0", 10);
-            return sign * (hours * 60 + mins);
-          };
-
-          const localOffset = getOffset(localParts);
-          const fromOffset = getOffset(fromParts);
-          const offsetDiff = (fromOffset - localOffset) * 60 * 1000;
-
-          // 调整时间：将本地时区解析的时间调整为源时区的时间
-          const adjustedDate = new Date(inputDate.getTime() - offsetDiff);
-
-          const toTime = adjustedDate.toLocaleTimeString("zh-CN", { timeZone: toTz, hour12: false });
-          const toDate = adjustedDate.toLocaleDateString("zh-CN", {
-            timeZone: toTz,
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            weekday: "long"
-          });
-
-          document.getElementById("toTime").textContent = toTime;
-          document.getElementById("toDate").textContent = toDate;
-        }
-
-        document.getElementById("fromTime").addEventListener("change", convertTime);
-        document.getElementById("fromTz").addEventListener("change", convertTime);
-        document.getElementById("toTz").addEventListener("change", convertTime);
-
-        setInterval(updateLocalTime, 1000);
-        updateLocalTime();
-
+      function updateLocalTime() {
         const now = new Date();
-        document.getElementById("fromTime").value = now.toISOString().slice(0, 16);
-        convertTime();
-</script>
-    
+        document.getElementById("localTime").textContent = now.toLocaleTimeString("zh-CN", {
+          hour12: false
+        });
+        document.getElementById("localDate").textContent = now.toLocaleDateString("zh-CN", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          weekday: "long"
+        });
+      }
+
+      function convertTime() {
+        const fromTime = document.getElementById("fromTime").value;
+        if (!fromTime) return;
+
+        const fromTz = document.getElementById("fromTz").value;
+        const toTz = document.getElementById("toTz").value;
+
+        // 将输入时间解析为源时区的时间，然后转换到目标时区
+        // 使用 Intl.DateTimeFormat 获取源时区的当前偏移量来正确解析输入时间
+        const inputDate = new Date(fromTime);
+
+        // 获取源时区和本地时区的偏移差
+        const localFormatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          timeZoneName: "shortOffset"
+        });
+        const fromFormatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: fromTz,
+          timeZoneName: "shortOffset"
+        });
+
+        // 通过格式化同一时间点获取偏移信息
+        const localParts = localFormatter.formatToParts(inputDate);
+        const fromParts = fromFormatter.formatToParts(inputDate);
+
+        const getOffset = (parts) => {
+          const tzPart = parts.find((p) => p.type === "timeZoneName");
+          if (!tzPart) return 0;
+          const match = tzPart.value.match(/GMT([+-]?)(\d+)?:?(\d+)?/);
+          if (!match) return 0;
+          const sign = match[1] === "-" ? -1 : 1;
+          const hours = parseInt(match[2] || "0", 10);
+          const mins = parseInt(match[3] || "0", 10);
+          return sign * (hours * 60 + mins);
+        };
+
+        const localOffset = getOffset(localParts);
+        const fromOffset = getOffset(fromParts);
+        const offsetDiff = (fromOffset - localOffset) * 60 * 1000;
+
+        // 调整时间：将本地时区解析的时间调整为源时区的时间
+        const adjustedDate = new Date(inputDate.getTime() - offsetDiff);
+
+        const toTime = adjustedDate.toLocaleTimeString("zh-CN", { timeZone: toTz, hour12: false });
+        const toDate = adjustedDate.toLocaleDateString("zh-CN", {
+          timeZone: toTz,
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          weekday: "long"
+        });
+
+        document.getElementById("toTime").textContent = toTime;
+        document.getElementById("toDate").textContent = toDate;
+      }
+
+      document.getElementById("fromTime").addEventListener("change", convertTime);
+      document.getElementById("fromTz").addEventListener("change", convertTime);
+      document.getElementById("toTz").addEventListener("change", convertTime);
+
+      setInterval(updateLocalTime, 1000);
+      updateLocalTime();
+
+      const now = new Date();
+      document.getElementById("fromTime").value = now.toISOString().slice(0, 16);
+      convertTime();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/toll-calculator.html
+++ b/tools/travel/toll-calculator.html
@@ -6,7 +6,10 @@
     <title>Toll Calculator - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="toll calculator" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
@@ -14,9 +17,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Toll Calculator - WebUtils" />
-    <meta property="og:description" content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/toll-calculator.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +36,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Toll Calculator - WebUtils" />
-    <meta name="twitter:description" content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Toll Calculator，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +53,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Toll Calculator",
-      "item": "https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Toll Calculator",
+            "item": "https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Toll Calculator - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Toll Calculator - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,803 +100,805 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgb(0, 245, 212, 0.15);
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f5f5f5;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
 
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgb(0, 245, 212, 0.15);
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f5f5f5;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
 
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
 
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
 
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
 
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
 
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
 
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
 
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
 
-  .title-section {
-    flex: 1;
-  }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
 
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
+      .title-section {
+        flex: 1;
+      }
 
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
 
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
 
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
 
-  .tool-section {
-    margin-bottom: 24px;
-  }
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
 
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
+      .tool-section {
+        margin-bottom: 24px;
+      }
 
-  .input-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-    margin-bottom: 16px;
-  }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
 
-  .input-group {
-    margin-bottom: 16px;
-  }
+      .input-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-bottom: 16px;
+      }
 
-  .input-group.full-width {
-    grid-column: 1 / -1;
-  }
+      .input-group {
+        margin-bottom: 16px;
+      }
 
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
+      .input-group.full-width {
+        grid-column: 1 / -1;
+      }
 
-  input[type="text"],
-  input[type="number"],
-  select {
-    width: 100%;
-    padding: 12px 14px;
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
 
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
+      input[type="text"],
+      input[type="number"],
+      select {
+        width: 100%;
+        padding: 12px 14px;
+        font-family: var(--font-mono);
+        font-size: 1rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
 
-  input[type="number"] {
-    -moz-appearance: textfield;
-  }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
 
-  input[type="number"]::-webkit-outer-spin-button,
-  input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
+      input[type="number"] {
+        -moz-appearance: textfield;
+      }
 
-  .vehicle-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 12px;
-    margin-bottom: 16px;
-  }
+      input[type="number"]::-webkit-outer-spin-button,
+      input[type="number"]::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
 
-  .vehicle-card {
-    background: var(--bg-input);
-    border: 2px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px 12px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    text-align: center;
-  }
+      .vehicle-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 12px;
+        margin-bottom: 16px;
+      }
 
-  .vehicle-card:hover {
-    border-color: var(--accent-green);
-    transform: translateY(-2px);
-  }
+      .vehicle-card {
+        background: var(--bg-input);
+        border: 2px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px 12px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        text-align: center;
+      }
 
-  .vehicle-card.selected {
-    border-color: var(--accent-green);
-    background: rgba(16, 185, 129, 0.1);
-  }
+      .vehicle-card:hover {
+        border-color: var(--accent-green);
+        transform: translateY(-2px);
+      }
 
-  .vehicle-card .icon {
-    font-size: 2rem;
-    margin-bottom: 8px;
-  }
+      .vehicle-card.selected {
+        border-color: var(--accent-green);
+        background: rgba(16, 185, 129, 0.1);
+      }
 
-  .vehicle-card .name {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    margin-bottom: 4px;
-  }
+      .vehicle-card .icon {
+        font-size: 2rem;
+        margin-bottom: 8px;
+      }
 
-  .vehicle-card .rate {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-  }
+      .vehicle-card .name {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: var(--color-text-primary);
+        margin-bottom: 4px;
+      }
 
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
+      .vehicle-card .rate {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
 
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 14px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
 
-  .btn-primary {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-  }
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 14px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
 
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
+      .btn-primary {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+      }
 
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
 
-  .btn-secondary:hover {
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-  }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
 
-  .result-box {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 24px;
-    text-align: center;
-  }
+      .btn-secondary:hover {
+        border-color: var(--accent-green);
+        color: var(--accent-green);
+      }
 
-  .result-amount {
-    font-family: var(--font-mono);
-    font-size: 3rem;
-    font-weight: 700;
-    color: var(--accent-green);
-    margin-bottom: 8px;
-  }
+      .result-box {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 24px;
+        text-align: center;
+      }
 
-  .result-amount .currency {
-    font-size: 1.5rem;
-    vertical-align: top;
-    margin-right: 4px;
-  }
+      .result-amount {
+        font-family: var(--font-mono);
+        font-size: 3rem;
+        font-weight: 700;
+        color: var(--accent-green);
+        margin-bottom: 8px;
+      }
 
-  .result-label {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 16px;
-  }
+      .result-amount .currency {
+        font-size: 1.5rem;
+        vertical-align: top;
+        margin-right: 4px;
+      }
 
-  .result-details {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-    padding-top: 16px;
-    border-top: 1px solid var(--border-subtle);
-  }
+      .result-label {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 16px;
+      }
 
-  .detail-item {
-    text-align: center;
-  }
+      .result-details {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        padding-top: 16px;
+        border-top: 1px solid var(--border-subtle);
+      }
 
-  .detail-item .value {
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-  }
+      .detail-item {
+        text-align: center;
+      }
 
-  .detail-item .label {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    margin-top: 4px;
-  }
+      .detail-item .value {
+        font-family: var(--font-mono);
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+      }
 
-  .note-box {
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid rgba(251, 191, 36, 0.3);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    margin-top: 24px;
-  }
+      .detail-item .label {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 4px;
+      }
 
-  .note-box .note-title {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--accent-yellow);
-    margin-bottom: 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
+      .note-box {
+        background: rgba(251, 191, 36, 0.1);
+        border: 1px solid rgba(251, 191, 36, 0.3);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        margin-top: 24px;
+      }
 
-  .note-box ul {
-    list-style: none;
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-  }
+      .note-box .note-title {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--accent-yellow);
+        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
 
-  .note-box ul li {
-    padding: 4px 0;
-    padding-left: 16px;
-    position: relative;
-  }
+      .note-box ul {
+        list-style: none;
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+      }
 
-  .note-box ul li::before {
-    content: "•";
-    position: absolute;
-    left: 0;
-    color: var(--accent-yellow);
-  }
+      .note-box ul li {
+        padding: 4px 0;
+        padding-left: 16px;
+        position: relative;
+      }
 
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
+      .note-box ul li::before {
+        content: "•";
+        position: absolute;
+        left: 0;
+        color: var(--accent-yellow);
+      }
 
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
 
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
 
-    .input-row {
-      grid-template-columns: 1fr;
-    }
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
 
-    .vehicle-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
+        .input-row {
+          grid-template-columns: 1fr;
+        }
 
-    .result-details {
-      grid-template-columns: 1fr;
-      gap: 12px;
-    }
+        .vehicle-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
 
-    .result-amount {
-      font-size: 2.5rem;
-    }
+        .result-details {
+          grid-template-columns: 1fr;
+          gap: 12px;
+        }
 
-    .btn-row {
-      flex-direction: column;
-    }
+        .result-amount {
+          font-size: 2.5rem;
+        }
 
-    .btn {
-      width: 100%;
-    }
-  }
-</style>
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">过路费计算</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🛣️</span>
-        过路费计算
-      </h1>
-      <p>中国高速公路过路费估算工具</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <div class="tool-section">
-      <div class="section-title">行驶距离</div>
-      <div class="input-group">
-        <label class="input-label">距离 (公里)</label>
-        <input type="number" id="distance" placeholder="请输入行驶距离" min="0" step="0.1">
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">选择车型</div>
-      <div class="vehicle-grid" id="vehicleGrid">
-        <div class="vehicle-card selected" data-type="car1">
-          <div class="icon">🚗</div>
-          <div class="name">小轿车</div>
-          <div class="rate">≤7座 | ¥0.40/km</div>
-        </div>
-        <div class="vehicle-card" data-type="car2">
-          <div class="icon">🚐</div>
-          <div class="name">小客车</div>
-          <div class="rate">8-9座 | ¥0.45/km</div>
-        </div>
-        <div class="vehicle-card" data-type="minibus">
-          <div class="icon">🚌</div>
-          <div class="name">中型客车</div>
-          <div class="rate">10-19座 | ¥0.60/km</div>
-        </div>
-        <div class="vehicle-card" data-type="bus">
-          <div class="icon">🚎</div>
-          <div class="name">大型客车</div>
-          <div class="rate">20-39座 | ¥0.80/km</div>
-        </div>
-        <div class="vehicle-card" data-type="coach">
-          <div class="icon">🚍</div>
-          <div class="name">特大客车</div>
-          <div class="rate">≥40座 | ¥1.00/km</div>
-        </div>
-        <div class="vehicle-card" data-type="truck1">
-          <div class="icon">🛻</div>
-          <div class="name">轻型货车</div>
-          <div class="rate">≤2吨 | ¥0.45/km</div>
-        </div>
-        <div class="vehicle-card" data-type="truck2">
-          <div class="icon">🚚</div>
-          <div class="name">中型货车</div>
-          <div class="rate">2-5吨 | ¥0.65/km</div>
-        </div>
-        <div class="vehicle-card" data-type="truck3">
-          <div class="icon">🚛</div>
-          <div class="name">大型货车</div>
-          <div class="rate">5-10吨 | ¥1.00/km</div>
-        </div>
-        <div class="vehicle-card" data-type="truck4">
-          <div class="icon">🚜</div>
-          <div class="name">特大货车</div>
-          <div class="rate">10-20吨 | ¥1.30/km</div>
-        </div>
-        <div class="vehicle-card" data-type="truck5">
-          <div class="icon">🏗️</div>
-          <div class="name">重型货车</div>
-          <div class="rate">&gt;20吨 | ¥1.60/km</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="calculate()">🧮 计算费用</button>
-        <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
-      </div>
-    </div>
-
-    <div class="tool-section">
-      <div class="section-title">估算结果</div>
-      <div class="result-box">
-        <div class="result-amount" id="resultAmount">
-          <span class="currency">¥</span>
-          <span id="tollAmount">0.00</span>
-        </div>
-        <div class="result-label">预估过路费</div>
-        <div class="result-details">
-          <div class="detail-item">
-            <div class="value" id="resultDistance">0 km</div>
-            <div class="label">行驶距离</div>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">过路费计算</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🛣️</span>
+              过路费计算
+            </h1>
+            <p>中国高速公路过路费估算工具</p>
           </div>
-          <div class="detail-item">
-            <div class="value" id="resultVehicle">小轿车</div>
-            <div class="label">车辆类型</div>
+        </header>
+
+        <main class="main-content">
+          <div class="tool-section">
+            <div class="section-title">行驶距离</div>
+            <div class="input-group">
+              <label class="input-label">距离 (公里)</label>
+              <input type="number" id="distance" placeholder="请输入行驶距离" min="0" step="0.1" />
+            </div>
           </div>
-          <div class="detail-item">
-            <div class="value" id="resultRate">¥0.40/km</div>
-            <div class="label">费率</div>
+
+          <div class="tool-section">
+            <div class="section-title">选择车型</div>
+            <div class="vehicle-grid" id="vehicleGrid">
+              <div class="vehicle-card selected" data-type="car1">
+                <div class="icon">🚗</div>
+                <div class="name">小轿车</div>
+                <div class="rate">≤7座 | ¥0.40/km</div>
+              </div>
+              <div class="vehicle-card" data-type="car2">
+                <div class="icon">🚐</div>
+                <div class="name">小客车</div>
+                <div class="rate">8-9座 | ¥0.45/km</div>
+              </div>
+              <div class="vehicle-card" data-type="minibus">
+                <div class="icon">🚌</div>
+                <div class="name">中型客车</div>
+                <div class="rate">10-19座 | ¥0.60/km</div>
+              </div>
+              <div class="vehicle-card" data-type="bus">
+                <div class="icon">🚎</div>
+                <div class="name">大型客车</div>
+                <div class="rate">20-39座 | ¥0.80/km</div>
+              </div>
+              <div class="vehicle-card" data-type="coach">
+                <div class="icon">🚍</div>
+                <div class="name">特大客车</div>
+                <div class="rate">≥40座 | ¥1.00/km</div>
+              </div>
+              <div class="vehicle-card" data-type="truck1">
+                <div class="icon">🛻</div>
+                <div class="name">轻型货车</div>
+                <div class="rate">≤2吨 | ¥0.45/km</div>
+              </div>
+              <div class="vehicle-card" data-type="truck2">
+                <div class="icon">🚚</div>
+                <div class="name">中型货车</div>
+                <div class="rate">2-5吨 | ¥0.65/km</div>
+              </div>
+              <div class="vehicle-card" data-type="truck3">
+                <div class="icon">🚛</div>
+                <div class="name">大型货车</div>
+                <div class="rate">5-10吨 | ¥1.00/km</div>
+              </div>
+              <div class="vehicle-card" data-type="truck4">
+                <div class="icon">🚜</div>
+                <div class="name">特大货车</div>
+                <div class="rate">10-20吨 | ¥1.30/km</div>
+              </div>
+              <div class="vehicle-card" data-type="truck5">
+                <div class="icon">🏗️</div>
+                <div class="name">重型货车</div>
+                <div class="rate">&gt;20吨 | ¥1.60/km</div>
+              </div>
+            </div>
           </div>
-        </div>
+
+          <div class="tool-section">
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="calculate()">🧮 计算费用</button>
+              <button class="btn btn-secondary" onclick="clearAll()">🔄 清空</button>
+            </div>
+          </div>
+
+          <div class="tool-section">
+            <div class="section-title">估算结果</div>
+            <div class="result-box">
+              <div class="result-amount" id="resultAmount">
+                <span class="currency">¥</span>
+                <span id="tollAmount">0.00</span>
+              </div>
+              <div class="result-label">预估过路费</div>
+              <div class="result-details">
+                <div class="detail-item">
+                  <div class="value" id="resultDistance">0 km</div>
+                  <div class="label">行驶距离</div>
+                </div>
+                <div class="detail-item">
+                  <div class="value" id="resultVehicle">小轿车</div>
+                  <div class="label">车辆类型</div>
+                </div>
+                <div class="detail-item">
+                  <div class="value" id="resultRate">¥0.40/km</div>
+                  <div class="label">费率</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="note-box">
+            <div class="note-title">⚠️ 重要说明</div>
+            <ul>
+              <li>本工具仅供参考估算，实际收费以高速公路收费站为准</li>
+              <li>不同省份、路段收费标准可能有所差异</li>
+              <li>节假日部分车型可能享受免费通行政策</li>
+              <li>ETC 用户通常可享受 95% 左右的折扣</li>
+              <li>货车计费方式可能因实际载重而有所不同</li>
+            </ul>
+          </div>
+        </main>
+        <div class="toast" id="toast" role="status" aria-live="polite"></div>
       </div>
     </div>
 
-    <div class="note-box">
-      <div class="note-title">⚠️ 重要说明</div>
-      <ul>
-        <li>本工具仅供参考估算，实际收费以高速公路收费站为准</li>
-        <li>不同省份、路段收费标准可能有所差异</li>
-        <li>节假日部分车型可能享受免费通行政策</li>
-        <li>ETC 用户通常可享受 95% 左右的折扣</li>
-        <li>货车计费方式可能因实际载重而有所不同</li>
-      </ul>
-    </div>
-  </main>
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "过路费计算",
-              "item": "https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
-            }
-          ]
-        }
-
-  </script>
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "过路费计算",
+            "item": "https://tools.realtime-ai.chat/tools/travel/toll-calculator.html"
+          }
+        ]
+      }
+    </script>
     <script>
+      // 车型费率配置 (元/公里)
+      const VEHICLE_RATES = {
+        car1: { name: "小轿车", rate: 0.4, desc: "≤7座客车" },
+        car2: { name: "小客车", rate: 0.45, desc: "8-9座客车" },
+        minibus: { name: "中型客车", rate: 0.6, desc: "10-19座客车" },
+        bus: { name: "大型客车", rate: 0.8, desc: "20-39座客车" },
+        coach: { name: "特大客车", rate: 1.0, desc: "≥40座客车" },
+        truck1: { name: "轻型货车", rate: 0.45, desc: "≤2吨货车" },
+        truck2: { name: "中型货车", rate: 0.65, desc: "2-5吨货车" },
+        truck3: { name: "大型货车", rate: 1.0, desc: "5-10吨货车" },
+        truck4: { name: "特大货车", rate: 1.3, desc: "10-20吨货车" },
+        truck5: { name: "重型货车", rate: 1.6, desc: ">20吨货车" }
+      };
 
-  // 车型费率配置 (元/公里)
-        const VEHICLE_RATES = {
-          car1: { name: "小轿车", rate: 0.4, desc: "≤7座客车" },
-          car2: { name: "小客车", rate: 0.45, desc: "8-9座客车" },
-          minibus: { name: "中型客车", rate: 0.6, desc: "10-19座客车" },
-          bus: { name: "大型客车", rate: 0.8, desc: "20-39座客车" },
-          coach: { name: "特大客车", rate: 1.0, desc: "≥40座客车" },
-          truck1: { name: "轻型货车", rate: 0.45, desc: "≤2吨货车" },
-          truck2: { name: "中型货车", rate: 0.65, desc: "2-5吨货车" },
-          truck3: { name: "大型货车", rate: 1.0, desc: "5-10吨货车" },
-          truck4: { name: "特大货车", rate: 1.3, desc: "10-20吨货车" },
-          truck5: { name: "重型货车", rate: 1.6, desc: ">20吨货车" }
-        };
+      // 当前选中的车型
+      let selectedVehicle = "car1";
 
-        // 当前选中的车型
-        let selectedVehicle = "car1";
+      // localStorage key
+      const LS_KEY = "toll_calculator_v1";
 
-        // localStorage key
-        const LS_KEY = "toll_calculator_v1";
+      // 主题切换
+      function toggleTheme() {
+        const body = document.body;
+        const isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
 
-        // 主题切换
-        function toggleTheme() {
-          const body = document.body;
-          const isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+      // 加载主题
+      (function () {
+        const saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
         }
+      })();
 
-        // 加载主题
-        (function () {
-          const saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
-          }
-        })();
+      // 初始化车型选择
+      function initVehicleSelection() {
+        const grid = document.getElementById("vehicleGrid");
+        const cards = grid.querySelectorAll(".vehicle-card");
 
-        // 初始化车型选择
-        function initVehicleSelection() {
-          const grid = document.getElementById("vehicleGrid");
-          const cards = grid.querySelectorAll(".vehicle-card");
-
-          cards.forEach((card) => {
-            card.addEventListener("click", () => {
-              // 移除所有选中状态
-              cards.forEach((c) => c.classList.remove("selected"));
-              // 添加当前选中状态
-              card.classList.add("selected");
-              // 更新选中车型
-              selectedVehicle = card.dataset.type;
-              // 保存状态
-              saveState();
-              // 自动计算
-              calculate();
-            });
-          });
-        }
-
-        // 计算过路费
-        function calculate() {
-          const distanceInput = document.getElementById("distance");
-          const distance = parseFloat(distanceInput.value) || 0;
-
-          if (distance <= 0) {
-            showToast("请输入有效的行驶距离");
-            return;
-          }
-
-          const vehicle = VEHICLE_RATES[selectedVehicle];
-          const toll = distance * vehicle.rate;
-
-          // 更新结果显示
-          document.getElementById("tollAmount").textContent = toll.toFixed(2);
-          document.getElementById("resultDistance").textContent = distance.toFixed(1) + " km";
-          document.getElementById("resultVehicle").textContent = vehicle.name;
-          document.getElementById("resultRate").textContent = "¥" + vehicle.rate.toFixed(2) + "/km";
-
-          // 保存状态
-          saveState();
-
-          showToast("计算完成");
-        }
-
-        // 清空所有内容
-        function clearAll() {
-          document.getElementById("distance").value = "";
-          document.getElementById("tollAmount").textContent = "0.00";
-          document.getElementById("resultDistance").textContent = "0 km";
-          document.getElementById("resultVehicle").textContent = "小轿车";
-          document.getElementById("resultRate").textContent = "¥0.40/km";
-
-          // 重置车型选择
-          selectedVehicle = "car1";
-          const cards = document.querySelectorAll(".vehicle-card");
-          cards.forEach((c) => c.classList.remove("selected"));
-          cards[0].classList.add("selected");
-
-          // 清除 localStorage
-          localStorage.removeItem(LS_KEY);
-
-          showToast("已清空");
-        }
-
-        // 保存状态到 localStorage
-        function saveState() {
-          const state = {
-            distance: document.getElementById("distance").value,
-            vehicle: selectedVehicle
-          };
-          localStorage.setItem(LS_KEY, JSON.stringify(state));
-        }
-
-        // 从 localStorage 加载状态
-        function loadState() {
-          const saved = localStorage.getItem(LS_KEY);
-          if (!saved) return;
-
-          try {
-            const state = JSON.parse(saved);
-
-            if (state.distance) {
-              document.getElementById("distance").value = state.distance;
-            }
-
-            if (state.vehicle && VEHICLE_RATES[state.vehicle]) {
-              selectedVehicle = state.vehicle;
-              const cards = document.querySelectorAll(".vehicle-card");
-              cards.forEach((c) => {
-                if (c.dataset.type === selectedVehicle) {
-                  c.classList.add("selected");
-                } else {
-                  c.classList.remove("selected");
-                }
-              });
-            }
-
+        cards.forEach((card) => {
+          card.addEventListener("click", () => {
+            // 移除所有选中状态
+            cards.forEach((c) => c.classList.remove("selected"));
+            // 添加当前选中状态
+            card.classList.add("selected");
+            // 更新选中车型
+            selectedVehicle = card.dataset.type;
+            // 保存状态
+            saveState();
             // 自动计算
-            if (state.distance) {
-              calculate();
-            }
-          } catch (e) {
-            console.error("Failed to load state:", e);
-          }
-        }
-
-        // 显示提示
-        function showToast(msg) {
-          const toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.classList.add("show");
-          setTimeout(() => toast.classList.remove("show"), 2000);
-        }
-
-        // 监听输入变化
-        document.getElementById("distance").addEventListener("input", () => {
-          saveState();
+            calculate();
+          });
         });
+      }
 
-        // 监听回车键计算
-        document.getElementById("distance").addEventListener("keypress", (e) => {
-          if (e.key === "Enter") {
+      // 计算过路费
+      function calculate() {
+        const distanceInput = document.getElementById("distance");
+        const distance = parseFloat(distanceInput.value) || 0;
+
+        if (distance <= 0) {
+          showToast("请输入有效的行驶距离");
+          return;
+        }
+
+        const vehicle = VEHICLE_RATES[selectedVehicle];
+        const toll = distance * vehicle.rate;
+
+        // 更新结果显示
+        document.getElementById("tollAmount").textContent = toll.toFixed(2);
+        document.getElementById("resultDistance").textContent = distance.toFixed(1) + " km";
+        document.getElementById("resultVehicle").textContent = vehicle.name;
+        document.getElementById("resultRate").textContent = "¥" + vehicle.rate.toFixed(2) + "/km";
+
+        // 保存状态
+        saveState();
+
+        showToast("计算完成");
+      }
+
+      // 清空所有内容
+      function clearAll() {
+        document.getElementById("distance").value = "";
+        document.getElementById("tollAmount").textContent = "0.00";
+        document.getElementById("resultDistance").textContent = "0 km";
+        document.getElementById("resultVehicle").textContent = "小轿车";
+        document.getElementById("resultRate").textContent = "¥0.40/km";
+
+        // 重置车型选择
+        selectedVehicle = "car1";
+        const cards = document.querySelectorAll(".vehicle-card");
+        cards.forEach((c) => c.classList.remove("selected"));
+        cards[0].classList.add("selected");
+
+        // 清除 localStorage
+        localStorage.removeItem(LS_KEY);
+
+        showToast("已清空");
+      }
+
+      // 保存状态到 localStorage
+      function saveState() {
+        const state = {
+          distance: document.getElementById("distance").value,
+          vehicle: selectedVehicle
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(state));
+      }
+
+      // 从 localStorage 加载状态
+      function loadState() {
+        const saved = localStorage.getItem(LS_KEY);
+        if (!saved) return;
+
+        try {
+          const state = JSON.parse(saved);
+
+          if (state.distance) {
+            document.getElementById("distance").value = state.distance;
+          }
+
+          if (state.vehicle && VEHICLE_RATES[state.vehicle]) {
+            selectedVehicle = state.vehicle;
+            const cards = document.querySelectorAll(".vehicle-card");
+            cards.forEach((c) => {
+              if (c.dataset.type === selectedVehicle) {
+                c.classList.add("selected");
+              } else {
+                c.classList.remove("selected");
+              }
+            });
+          }
+
+          // 自动计算
+          if (state.distance) {
             calculate();
           }
-        });
+        } catch (e) {
+          console.error("Failed to load state:", e);
+        }
+      }
 
-        // 初始化
-        initVehicleSelection();
-        loadState();
-</script>
-    
+      // 显示提示
+      function showToast(msg) {
+        const toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      }
+
+      // 监听输入变化
+      document.getElementById("distance").addEventListener("input", () => {
+        saveState();
+      });
+
+      // 监听回车键计算
+      document.getElementById("distance").addEventListener("keypress", (e) => {
+        if (e.key === "Enter") {
+          calculate();
+        }
+      });
+
+      // 初始化
+      initVehicleSelection();
+      loadState();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/trip-cost-splitter.html
+++ b/tools/travel/trip-cost-splitter.html
@@ -6,17 +6,29 @@
     <title>Trip Cost Splitter - WebUtils</title>
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="description"
+      content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="keywords" content="trip cost splitter" />
     <meta name="author" content="WebUtils" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html" />
+    <link
+      rel="canonical"
+      href="https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
+    />
 
     <!-- Open Graph -->
     <meta property="og:title" content="Trip Cost Splitter - WebUtils" />
-    <meta property="og:description" content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +39,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Trip Cost Splitter - WebUtils" />
-    <meta name="twitter:description" content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Trip Cost Splitter，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +56,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Trip Cost Splitter",
-      "item": "https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Trip Cost Splitter",
+            "item": "https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Trip Cost Splitter - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Trip Cost Splitter - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,992 +103,1000 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --bg-hover: #252535;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-purple: #a855f7;
-    --glow-green: rgb(16, 185, 129, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f0f0f0;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-  }
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-  .title-section {
-    flex: 1;
-  }
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-  .main-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    flex: 1;
-  }
-  .panel {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-  }
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .section-title .count {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    font-size: 0.75rem;
-    padding: 2px 8px;
-    border-radius: 10px;
-  }
-  .input-row {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-  .input-row input {
-    flex: 1;
-  }
-  input[type="text"],
-  input[type="number"],
-  select {
-    padding: 10px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-  }
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
-  input::placeholder {
-    color: var(--color-text-muted);
-  }
-  .btn {
-    padding: 10px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    white-space: nowrap;
-  }
-  .btn-primary {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-  }
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-  .btn-secondary:hover {
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-  }
-  .btn-danger {
-    background: transparent;
-    color: var(--accent-red);
-    border: 1px solid var(--accent-red);
-    padding: 6px 10px;
-    font-size: 0.75rem;
-  }
-  .btn-danger:hover {
-    background: var(--accent-red);
-    color: white;
-  }
-  .btn-icon {
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    font-size: 1rem;
-  }
-  .list-container {
-    flex: 1;
-    overflow-y: auto;
-    max-height: 300px;
-    margin-bottom: 16px;
-  }
-  .list-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 8px;
-    transition: all 0.2s;
-  }
-  .list-item:hover {
-    background: var(--bg-hover);
-  }
-  .list-item .name {
-    font-family: var(--font-mono);
-    font-weight: 500;
-    color: var(--color-text-primary);
-  }
-  .list-item .details {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-  }
-  .list-item .amount {
-    font-family: var(--font-mono);
-    font-weight: 600;
-    color: var(--accent-green);
-  }
-  .expense-form {
-    display: grid;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-  .expense-form .row {
-    display: grid;
-    grid-template-columns: 1fr 120px;
-    gap: 12px;
-  }
-  .expense-form select {
-    width: 100%;
-  }
-  .summary-panel {
-    grid-column: 1 / -1;
-  }
-  .summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px;
-    margin-bottom: 20px;
-  }
-  .summary-card {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    text-align: center;
-  }
-  .summary-card .label {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-  .summary-card .value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--accent-green);
-  }
-  .summary-card .value.cyan {
-    color: var(--accent-cyan);
-  }
-  .summary-card .value.yellow {
-    color: var(--accent-yellow);
-  }
-  .settlement-list {
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: 16px;
-  }
-  .settlement-list h3 {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 12px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .settlement-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px;
-    background: var(--color-bg-card);
-    border-radius: var(--radius-sm);
-    margin-bottom: 8px;
-  }
-  .settlement-item:last-child {
-    margin-bottom: 0;
-  }
-  .settlement-item .from {
-    color: var(--accent-red);
-    font-weight: 600;
-  }
-  .settlement-item .arrow {
-    color: var(--color-text-muted);
-    margin: 0 12px;
-  }
-  .settlement-item .to {
-    color: var(--accent-green);
-    font-weight: 600;
-  }
-  .settlement-item .amount {
-    font-family: var(--font-mono);
-    font-weight: 700;
-    color: var(--accent-yellow);
-    margin-left: auto;
-    padding-left: 16px;
-  }
-  .balance-list {
-    margin-top: 16px;
-  }
-  .balance-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .balance-item:last-child {
-    border-bottom: none;
-  }
-  .balance-item .name {
-    font-weight: 500;
-  }
-  .balance-item .paid {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-  }
-  .balance-item .balance {
-    font-family: var(--font-mono);
-    font-weight: 600;
-  }
-  .balance-item .balance.positive {
-    color: var(--accent-green);
-  }
-  .balance-item .balance.negative {
-    color: var(--accent-red);
-  }
-  .empty-state {
-    text-align: center;
-    padding: 40px 20px;
-    color: var(--color-text-muted);
-  }
-  .empty-state .icon {
-    font-size: 3rem;
-    margin-bottom: 12px;
-  }
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    margin-top: auto;
-  }
-  .btn-row .btn {
-    flex: 1;
-  }
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-  .toast.error {
-    background: var(--accent-red);
-  }
-  @media (max-width: 768px) {
-    .container {
-      padding: 16px;
-    }
-    .main-content {
-      grid-template-columns: 1fr;
-    }
-    .summary-panel {
-      grid-column: 1;
-    }
-    .expense-form .row {
-      grid-template-columns: 1fr;
-    }
-    .input-row {
-      flex-direction: column;
-    }
-    .btn-row {
-      flex-direction: column;
-    }
-    .settlement-item {
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-    .settlement-item .amount {
-      width: 100%;
-      text-align: right;
-      padding-left: 0;
-      margin-left: 0;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --bg-hover: #252535;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-purple: #a855f7;
+        --glow-green: rgb(16, 185, 129, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f0f0f0;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+      .title-section {
+        flex: 1;
+      }
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+      .main-content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+        flex: 1;
+      }
+      .panel {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+      }
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .section-title .count {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        font-size: 0.75rem;
+        padding: 2px 8px;
+        border-radius: 10px;
+      }
+      .input-row {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+      .input-row input {
+        flex: 1;
+      }
+      input[type="text"],
+      input[type="number"],
+      select {
+        padding: 10px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+      }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
+      input::placeholder {
+        color: var(--color-text-muted);
+      }
+      .btn {
+        padding: 10px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        white-space: nowrap;
+      }
+      .btn-primary {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+      }
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+      .btn-secondary:hover {
+        border-color: var(--accent-green);
+        color: var(--accent-green);
+      }
+      .btn-danger {
+        background: transparent;
+        color: var(--accent-red);
+        border: 1px solid var(--accent-red);
+        padding: 6px 10px;
+        font-size: 0.75rem;
+      }
+      .btn-danger:hover {
+        background: var(--accent-red);
+        color: white;
+      }
+      .btn-icon {
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        font-size: 1rem;
+      }
+      .list-container {
+        flex: 1;
+        overflow-y: auto;
+        max-height: 300px;
+        margin-bottom: 16px;
+      }
+      .list-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        margin-bottom: 8px;
+        transition: all 0.2s;
+      }
+      .list-item:hover {
+        background: var(--bg-hover);
+      }
+      .list-item .name {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        color: var(--color-text-primary);
+      }
+      .list-item .details {
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+      }
+      .list-item .amount {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        color: var(--accent-green);
+      }
+      .expense-form {
+        display: grid;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+      .expense-form .row {
+        display: grid;
+        grid-template-columns: 1fr 120px;
+        gap: 12px;
+      }
+      .expense-form select {
+        width: 100%;
+      }
+      .summary-panel {
+        grid-column: 1 / -1;
+      }
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin-bottom: 20px;
+      }
+      .summary-card {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+        text-align: center;
+      }
+      .summary-card .label {
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .summary-card .value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--accent-green);
+      }
+      .summary-card .value.cyan {
+        color: var(--accent-cyan);
+      }
+      .summary-card .value.yellow {
+        color: var(--accent-yellow);
+      }
+      .settlement-list {
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: 16px;
+      }
+      .settlement-list h3 {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .settlement-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px;
+        background: var(--color-bg-card);
+        border-radius: var(--radius-sm);
+        margin-bottom: 8px;
+      }
+      .settlement-item:last-child {
+        margin-bottom: 0;
+      }
+      .settlement-item .from {
+        color: var(--accent-red);
+        font-weight: 600;
+      }
+      .settlement-item .arrow {
+        color: var(--color-text-muted);
+        margin: 0 12px;
+      }
+      .settlement-item .to {
+        color: var(--accent-green);
+        font-weight: 600;
+      }
+      .settlement-item .amount {
+        font-family: var(--font-mono);
+        font-weight: 700;
+        color: var(--accent-yellow);
+        margin-left: auto;
+        padding-left: 16px;
+      }
+      .balance-list {
+        margin-top: 16px;
+      }
+      .balance-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+      .balance-item:last-child {
+        border-bottom: none;
+      }
+      .balance-item .name {
+        font-weight: 500;
+      }
+      .balance-item .paid {
+        font-size: 0.8rem;
+        color: var(--color-text-secondary);
+      }
+      .balance-item .balance {
+        font-family: var(--font-mono);
+        font-weight: 600;
+      }
+      .balance-item .balance.positive {
+        color: var(--accent-green);
+      }
+      .balance-item .balance.negative {
+        color: var(--accent-red);
+      }
+      .empty-state {
+        text-align: center;
+        padding: 40px 20px;
+        color: var(--color-text-muted);
+      }
+      .empty-state .icon {
+        font-size: 3rem;
+        margin-bottom: 12px;
+      }
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        margin-top: auto;
+      }
+      .btn-row .btn {
+        flex: 1;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .toast.error {
+        background: var(--accent-red);
+      }
+      @media (max-width: 768px) {
+        .container {
+          padding: 16px;
+        }
+        .main-content {
+          grid-template-columns: 1fr;
+        }
+        .summary-panel {
+          grid-column: 1;
+        }
+        .expense-form .row {
+          grid-template-columns: 1fr;
+        }
+        .input-row {
+          flex-direction: column;
+        }
+        .btn-row {
+          flex-direction: column;
+        }
+        .settlement-item {
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+        .settlement-item .amount {
+          width: 100%;
+          text-align: right;
+          padding-left: 0;
+          margin-left: 0;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">旅行费用分摊</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">💰</span>
-        旅行费用分摊
-      </h1>
-      <p>多人旅行费用分摊计算，自动计算每人应付金额和结算方案</p>
-    </div>
-  </header>
-  <main class="main-content">
-    <div class="panel">
-      <div class="section-title">
-        👥 旅行者
-        <span class="count" id="travelerCount">0</span>
-      </div>
-      <div class="input-row">
-        <input type="text" id="travelerName" placeholder="输入旅行者姓名" onkeypress="if (event.key === 'Enter') addTraveler();">
-        <button class="btn btn-primary" onclick="addTraveler()">+ 添加</button>
-      </div>
-      <div class="list-container" id="travelerList">
-        <div class="empty-state">
-          <div class="icon">👤</div>
-          <div>还没有添加旅行者</div>
-        </div>
-      </div>
-    </div>
-    <div class="panel">
-      <div class="section-title">
-        📝 费用记录
-        <span class="count" id="expenseCount">0</span>
-      </div>
-      <div class="expense-form">
-        <input type="text" id="expenseDesc" placeholder="费用描述（如：酒店、机票、餐饮）">
-        <div class="row">
-          <input type="number" id="expenseAmount" placeholder="金额" min="0" step="0.01">
-          <select id="expensePayer">
-            <option value="">谁付的钱</option>
-          </select>
-        </div>
-        <button class="btn btn-primary" onclick="addExpense()">+ 添加费用</button>
-      </div>
-      <div class="list-container" id="expenseList">
-        <div class="empty-state">
-          <div class="icon">📋</div>
-          <div>还没有添加费用</div>
-        </div>
-      </div>
-    </div>
-    <div class="panel summary-panel">
-      <div class="section-title">📊 费用汇总</div>
-      <div class="summary-grid">
-        <div class="summary-card">
-          <div class="label">总费用</div>
-          <div class="value" id="totalAmount">¥0.00</div>
-        </div>
-        <div class="summary-card">
-          <div class="label">人均费用</div>
-          <div class="value cyan" id="perPersonAmount">¥0.00</div>
-        </div>
-        <div class="summary-card">
-          <div class="label">参与人数</div>
-          <div class="value yellow" id="participantCount">0</div>
-        </div>
-      </div>
-      <div class="settlement-list">
-        <h3>💸 结算方案（谁应该给谁多少钱）</h3>
-        <div id="settlementList">
-          <div class="empty-state" style="padding: 20px">
-            <div>添加旅行者和费用后自动计算</div>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">旅行费用分摊</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">💰</span>
+              旅行费用分摊
+            </h1>
+            <p>多人旅行费用分摊计算，自动计算每人应付金额和结算方案</p>
           </div>
-        </div>
-      </div>
-      <div class="balance-list" id="balanceList"></div>
-      <div class="btn-row" style="margin-top: 20px">
-        <button class="btn btn-secondary" onclick="copySettlement()">📋 复制结算</button>
-        <button class="btn btn-secondary" onclick="shareData()">🔗 分享</button>
-        <button class="btn btn-danger" onclick="clearAll()">🗑️ 清空全部</button>
+        </header>
+        <main class="main-content">
+          <div class="panel">
+            <div class="section-title">
+              👥 旅行者
+              <span class="count" id="travelerCount">0</span>
+            </div>
+            <div class="input-row">
+              <input
+                type="text"
+                id="travelerName"
+                placeholder="输入旅行者姓名"
+                onkeypress="if (event.key === 'Enter') addTraveler();"
+              />
+              <button class="btn btn-primary" onclick="addTraveler()">+ 添加</button>
+            </div>
+            <div class="list-container" id="travelerList">
+              <div class="empty-state">
+                <div class="icon">👤</div>
+                <div>还没有添加旅行者</div>
+              </div>
+            </div>
+          </div>
+          <div class="panel">
+            <div class="section-title">
+              📝 费用记录
+              <span class="count" id="expenseCount">0</span>
+            </div>
+            <div class="expense-form">
+              <input type="text" id="expenseDesc" placeholder="费用描述（如：酒店、机票、餐饮）" />
+              <div class="row">
+                <input type="number" id="expenseAmount" placeholder="金额" min="0" step="0.01" />
+                <select id="expensePayer">
+                  <option value="">谁付的钱</option>
+                </select>
+              </div>
+              <button class="btn btn-primary" onclick="addExpense()">+ 添加费用</button>
+            </div>
+            <div class="list-container" id="expenseList">
+              <div class="empty-state">
+                <div class="icon">📋</div>
+                <div>还没有添加费用</div>
+              </div>
+            </div>
+          </div>
+          <div class="panel summary-panel">
+            <div class="section-title">📊 费用汇总</div>
+            <div class="summary-grid">
+              <div class="summary-card">
+                <div class="label">总费用</div>
+                <div class="value" id="totalAmount">¥0.00</div>
+              </div>
+              <div class="summary-card">
+                <div class="label">人均费用</div>
+                <div class="value cyan" id="perPersonAmount">¥0.00</div>
+              </div>
+              <div class="summary-card">
+                <div class="label">参与人数</div>
+                <div class="value yellow" id="participantCount">0</div>
+              </div>
+            </div>
+            <div class="settlement-list">
+              <h3>💸 结算方案（谁应该给谁多少钱）</h3>
+              <div id="settlementList">
+                <div class="empty-state" style="padding: 20px">
+                  <div>添加旅行者和费用后自动计算</div>
+                </div>
+              </div>
+            </div>
+            <div class="balance-list" id="balanceList"></div>
+            <div class="btn-row" style="margin-top: 20px">
+              <button class="btn btn-secondary" onclick="copySettlement()">📋 复制结算</button>
+              <button class="btn btn-secondary" onclick="shareData()">🔗 分享</button>
+              <button class="btn btn-danger" onclick="clearAll()">🗑️ 清空全部</button>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
-  </main>
-</div>
-    </div>
-    
+
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "旅行费用分摊",
-              "item": "https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "旅行费用分摊",
+            "item": "https://tools.realtime-ai.chat/tools/travel/trip-cost-splitter.html"
+          }
+        ]
+      }
     </script>
     <script>
+      var LS_KEY = "trip_cost_splitter_v1";
+      var travelers = [];
+      var expenses = [];
 
-  var LS_KEY = "trip_cost_splitter_v1";
-        var travelers = [];
-        var expenses = [];
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") document.body.setAttribute("data-theme", "light");
+      })();
 
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
-        }
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") document.body.setAttribute("data-theme", "light");
-        })();
-
-        function saveData() {
-          localStorage.setItem(LS_KEY, JSON.stringify({ travelers: travelers, expenses: expenses }));
-        }
-        function loadData() {
-          try {
-            var saved = localStorage.getItem(LS_KEY);
-            if (saved) {
-              var data = JSON.parse(saved);
-              travelers = data.travelers || [];
-              expenses = data.expenses || [];
-            }
-          } catch (e) {
-            console.error("加载数据失败:", e);
-          }
-        }
-        function loadFromUrl() {
-          var hash = location.hash.slice(1);
-          if (!hash) return false;
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
+      function saveData() {
+        localStorage.setItem(LS_KEY, JSON.stringify({ travelers: travelers, expenses: expenses }));
+      }
+      function loadData() {
+        try {
+          var saved = localStorage.getItem(LS_KEY);
+          if (saved) {
+            var data = JSON.parse(saved);
             travelers = data.travelers || [];
             expenses = data.expenses || [];
-            saveData();
-            return true;
-          } catch (e) {
-            return false;
           }
+        } catch (e) {
+          console.error("加载数据失败:", e);
         }
-        function saveToUrl() {
-          try {
-            var data = JSON.stringify({ travelers: travelers, expenses: expenses });
-            if (data.length > 2000) return;
-            history.replaceState(null, "", "#" + btoa(encodeURIComponent(data)));
-          } catch (e) {}
-        }
-
-        function addTraveler() {
-          var input = document.getElementById("travelerName");
-          var name = input.value.trim();
-          if (!name) {
-            showToast("请输入旅行者姓名", "error");
-            return;
-          }
-          if (travelers.indexOf(name) > -1) {
-            showToast("该旅行者已存在", "error");
-            return;
-          }
-          travelers.push(name);
-          input.value = "";
+      }
+      function loadFromUrl() {
+        var hash = location.hash.slice(1);
+        if (!hash) return false;
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          travelers = data.travelers || [];
+          expenses = data.expenses || [];
           saveData();
-          saveToUrl();
-          renderAll();
-          showToast("已添加旅行者: " + name);
+          return true;
+        } catch (e) {
+          return false;
         }
-        function deleteTraveler(index) {
-          var name = travelers[index];
-          var hasExpenses = expenses.some(function (e) {
-            return e.payer === name;
-          });
-          if (hasExpenses) {
-            showToast("该旅行者有费用记录，请先删除相关费用", "error");
-            return;
-          }
-          travelers.splice(index, 1);
-          saveData();
-          saveToUrl();
-          renderAll();
-          showToast("已删除旅行者: " + name);
-        }
-        function addExpense() {
-          var descInput = document.getElementById("expenseDesc");
-          var amountInput = document.getElementById("expenseAmount");
-          var payerSelect = document.getElementById("expensePayer");
-          var desc = descInput.value.trim();
-          var amount = parseFloat(amountInput.value);
-          var payer = payerSelect.value;
-          if (!desc) {
-            showToast("请输入费用描述", "error");
-            return;
-          }
-          if (!amount || amount <= 0) {
-            showToast("请输入有效金额", "error");
-            return;
-          }
-          if (!payer) {
-            showToast("请选择付款人", "error");
-            return;
-          }
-          expenses.push({ id: Date.now(), desc: desc, amount: amount, payer: payer });
-          descInput.value = "";
-          amountInput.value = "";
-          payerSelect.value = "";
-          saveData();
-          saveToUrl();
-          renderAll();
-          showToast("已添加费用: " + desc);
-        }
-        function deleteExpense(id) {
-          var index = -1;
-          for (var i = 0; i < expenses.length; i++) {
-            if (expenses[i].id === id) {
-              index = i;
-              break;
-            }
-          }
-          if (index > -1) {
-            var expense = expenses[index];
-            expenses.splice(index, 1);
-            saveData();
-            saveToUrl();
-            renderAll();
-            showToast("已删除费用: " + expense.desc);
-          }
-        }
+      }
+      function saveToUrl() {
+        try {
+          var data = JSON.stringify({ travelers: travelers, expenses: expenses });
+          if (data.length > 2000) return;
+          history.replaceState(null, "", "#" + btoa(encodeURIComponent(data)));
+        } catch (e) {}
+      }
 
-        function calculateSettlement() {
-          if (travelers.length === 0 || expenses.length === 0) {
-            return { total: 0, perPerson: 0, balances: {}, settlements: [] };
-          }
-          var total = 0;
-          for (var i = 0; i < expenses.length; i++) total += expenses[i].amount;
-          var perPerson = total / travelers.length;
-          var balances = {};
-          for (var i = 0; i < travelers.length; i++) {
-            var t = travelers[i];
-            var paid = 0;
-            for (var j = 0; j < expenses.length; j++) {
-              if (expenses[j].payer === t) paid += expenses[j].amount;
-            }
-            balances[t] = { paid: paid, shouldPay: perPerson, balance: paid - perPerson };
-          }
-          var settlements = [];
-          var debtors = [],
-            creditors = [];
-          for (var name in balances) {
-            var data = balances[name];
-            if (data.balance < -0.01) debtors.push({ name: name, amount: -data.balance });
-            else if (data.balance > 0.01) creditors.push({ name: name, amount: data.balance });
-          }
-          debtors.sort(function (a, b) {
-            return b.amount - a.amount;
-          });
-          creditors.sort(function (a, b) {
-            return b.amount - a.amount;
-          });
-          var i = 0,
-            j = 0;
-          while (i < debtors.length && j < creditors.length) {
-            var debtor = debtors[i],
-              creditor = creditors[j];
-            var amount = Math.min(debtor.amount, creditor.amount);
-            if (amount > 0.01) {
-              settlements.push({
-                from: debtor.name,
-                to: creditor.name,
-                amount: Math.round(amount * 100) / 100
-              });
-            }
-            debtor.amount -= amount;
-            creditor.amount -= amount;
-            if (debtor.amount < 0.01) i++;
-            if (creditor.amount < 0.01) j++;
-          }
-          return { total: total, perPerson: perPerson, balances: balances, settlements: settlements };
+      function addTraveler() {
+        var input = document.getElementById("travelerName");
+        var name = input.value.trim();
+        if (!name) {
+          showToast("请输入旅行者姓名", "error");
+          return;
         }
-
-        function escapeHtml(text) {
-          var div = document.createElement("div");
-          div.textContent = text;
-          return div.innerHTML;
+        if (travelers.indexOf(name) > -1) {
+          showToast("该旅行者已存在", "error");
+          return;
         }
-
-        function renderTravelerList() {
-          var container = document.getElementById("travelerList");
-          document.getElementById("travelerCount").textContent = travelers.length;
-          if (travelers.length === 0) {
-            container.innerHTML =
-              '<div class="empty-state"><div class="icon">👤</div><div>还没有添加旅行者</div></div>';
-            return;
-          }
-          var html = "";
-          for (var i = 0; i < travelers.length; i++) {
-            html +=
-              '<div class="list-item"><div><div class="name">' +
-              escapeHtml(travelers[i]) +
-              "</div></div>" +
-              '<button class="btn btn-danger btn-icon" onclick="deleteTraveler(' +
-              i +
-              ')" title="删除">×</button></div>';
-          }
-          container.innerHTML = html;
-        }
-        function renderExpenseList() {
-          var container = document.getElementById("expenseList");
-          document.getElementById("expenseCount").textContent = expenses.length;
-          if (expenses.length === 0) {
-            container.innerHTML =
-              '<div class="empty-state"><div class="icon">📋</div><div>还没有添加费用</div></div>';
-            return;
-          }
-          var html = "";
-          for (var i = 0; i < expenses.length; i++) {
-            var e = expenses[i];
-            html +=
-              '<div class="list-item"><div><div class="name">' +
-              escapeHtml(e.desc) +
-              "</div>" +
-              '<div class="details">' +
-              escapeHtml(e.payer) +
-              " 付款</div></div>" +
-              '<div style="display: flex; align-items: center; gap: 12px;">' +
-              '<span class="amount">¥' +
-              e.amount.toFixed(2) +
-              "</span>" +
-              '<button class="btn btn-danger btn-icon" onclick="deleteExpense(' +
-              e.id +
-              ')" title="删除">×</button></div></div>';
-          }
-          container.innerHTML = html;
-        }
-        function renderPayerSelect() {
-          var select = document.getElementById("expensePayer");
-          var currentValue = select.value;
-          var html = '<option value="">谁付的钱</option>';
-          for (var i = 0; i < travelers.length; i++) {
-            html +=
-              '<option value="' +
-              escapeHtml(travelers[i]) +
-              '">' +
-              escapeHtml(travelers[i]) +
-              "</option>";
-          }
-          select.innerHTML = html;
-          if (travelers.indexOf(currentValue) > -1) select.value = currentValue;
-        }
-        function renderSummary() {
-          var result = calculateSettlement();
-          document.getElementById("totalAmount").textContent = "¥" + result.total.toFixed(2);
-          document.getElementById("perPersonAmount").textContent = "¥" + result.perPerson.toFixed(2);
-          document.getElementById("participantCount").textContent = travelers.length;
-          var settlementContainer = document.getElementById("settlementList");
-          if (result.settlements.length === 0) {
-            var emptyMsg =
-              travelers.length === 0 || expenses.length === 0
-                ? "添加旅行者和费用后自动计算"
-                : "无需结算，费用已平衡";
-            settlementContainer.innerHTML =
-              '<div class="empty-state" style="padding: 20px"><div>' + emptyMsg + "</div></div>";
-          } else {
-            var html = "";
-            for (var i = 0; i < result.settlements.length; i++) {
-              var s = result.settlements[i];
-              html +=
-                '<div class="settlement-item"><span class="from">' +
-                escapeHtml(s.from) +
-                "</span>" +
-                '<span class="arrow">→</span><span class="to">' +
-                escapeHtml(s.to) +
-                "</span>" +
-                '<span class="amount">¥' +
-                s.amount.toFixed(2) +
-                "</span></div>";
-            }
-            settlementContainer.innerHTML = html;
-          }
-          var balanceContainer = document.getElementById("balanceList");
-          var balanceKeys = Object.keys(result.balances);
-          if (balanceKeys.length > 0) {
-            var html =
-              '<div class="section-title" style="margin-top: 16px; border-top: 1px solid var(--border-subtle); padding-top: 16px;">👤 个人明细</div>';
-            for (var i = 0; i < balanceKeys.length; i++) {
-              var name = balanceKeys[i],
-                data = result.balances[name];
-              var balanceClass = data.balance >= 0 ? "positive" : "negative";
-              var balanceSign = data.balance >= 0 ? "+" : "";
-              html +=
-                '<div class="balance-item"><div><div class="name">' +
-                escapeHtml(name) +
-                "</div>" +
-                '<div class="paid">已付 ¥' +
-                data.paid.toFixed(2) +
-                " / 应付 ¥" +
-                data.shouldPay.toFixed(2) +
-                "</div></div>" +
-                '<div class="balance ' +
-                balanceClass +
-                '">' +
-                balanceSign +
-                "¥" +
-                data.balance.toFixed(2) +
-                "</div></div>";
-            }
-            balanceContainer.innerHTML = html;
-          } else {
-            balanceContainer.innerHTML = "";
-          }
-        }
-        function renderAll() {
-          renderTravelerList();
-          renderExpenseList();
-          renderPayerSelect();
-          renderSummary();
-        }
-
-        function copySettlement() {
-          var result = calculateSettlement();
-          if (travelers.length === 0 || expenses.length === 0) {
-            showToast("没有可复制的内容", "error");
-            return;
-          }
-          var text = "【旅行费用分摊】\n\n";
-          text += "参与人: " + travelers.join("、") + "\n";
-          text += "总费用: ¥" + result.total.toFixed(2) + "\n";
-          text += "人均: ¥" + result.perPerson.toFixed(2) + "\n\n";
-          text += "费用明细:\n";
-          for (var i = 0; i < expenses.length; i++) {
-            var e = expenses[i];
-            text += "- " + e.desc + ": ¥" + e.amount.toFixed(2) + " (" + e.payer + "付)\n";
-          }
-          text += "\n结算方案:\n";
-          if (result.settlements.length === 0) {
-            text += "无需结算，费用已平衡\n";
-          } else {
-            for (var i = 0; i < result.settlements.length; i++) {
-              var s = result.settlements[i];
-              text += "- " + s.from + " → " + s.to + ": ¥" + s.amount.toFixed(2) + "\n";
-            }
-          }
-          navigator.clipboard.writeText(text).then(function () {
-            showToast("已复制到剪贴板");
-          });
-        }
-        function shareData() {
-          if (travelers.length === 0) {
-            showToast("没有可分享的内容", "error");
-            return;
-          }
-          saveToUrl();
-          navigator.clipboard.writeText(location.href).then(function () {
-            showToast("链接已复制到剪贴板");
-          });
-        }
-        function clearAll() {
-          if (travelers.length === 0 && expenses.length === 0) {
-            showToast("已经是空的了");
-            return;
-          }
-          if (!confirm("确定要清空所有数据吗？")) return;
-          travelers = [];
-          expenses = [];
-          saveData();
-          history.replaceState(null, "", location.pathname);
-          renderAll();
-          showToast("已清空全部数据");
-        }
-        function showToast(msg, type) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (type === "error" ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
-
-        if (!loadFromUrl()) loadData();
+        travelers.push(name);
+        input.value = "";
+        saveData();
+        saveToUrl();
         renderAll();
-</script>
-    
+        showToast("已添加旅行者: " + name);
+      }
+      function deleteTraveler(index) {
+        var name = travelers[index];
+        var hasExpenses = expenses.some(function (e) {
+          return e.payer === name;
+        });
+        if (hasExpenses) {
+          showToast("该旅行者有费用记录，请先删除相关费用", "error");
+          return;
+        }
+        travelers.splice(index, 1);
+        saveData();
+        saveToUrl();
+        renderAll();
+        showToast("已删除旅行者: " + name);
+      }
+      function addExpense() {
+        var descInput = document.getElementById("expenseDesc");
+        var amountInput = document.getElementById("expenseAmount");
+        var payerSelect = document.getElementById("expensePayer");
+        var desc = descInput.value.trim();
+        var amount = parseFloat(amountInput.value);
+        var payer = payerSelect.value;
+        if (!desc) {
+          showToast("请输入费用描述", "error");
+          return;
+        }
+        if (!amount || amount <= 0) {
+          showToast("请输入有效金额", "error");
+          return;
+        }
+        if (!payer) {
+          showToast("请选择付款人", "error");
+          return;
+        }
+        expenses.push({ id: Date.now(), desc: desc, amount: amount, payer: payer });
+        descInput.value = "";
+        amountInput.value = "";
+        payerSelect.value = "";
+        saveData();
+        saveToUrl();
+        renderAll();
+        showToast("已添加费用: " + desc);
+      }
+      function deleteExpense(id) {
+        var index = -1;
+        for (var i = 0; i < expenses.length; i++) {
+          if (expenses[i].id === id) {
+            index = i;
+            break;
+          }
+        }
+        if (index > -1) {
+          var expense = expenses[index];
+          expenses.splice(index, 1);
+          saveData();
+          saveToUrl();
+          renderAll();
+          showToast("已删除费用: " + expense.desc);
+        }
+      }
+
+      function calculateSettlement() {
+        if (travelers.length === 0 || expenses.length === 0) {
+          return { total: 0, perPerson: 0, balances: {}, settlements: [] };
+        }
+        var total = 0;
+        for (var i = 0; i < expenses.length; i++) total += expenses[i].amount;
+        var perPerson = total / travelers.length;
+        var balances = {};
+        for (var i = 0; i < travelers.length; i++) {
+          var t = travelers[i];
+          var paid = 0;
+          for (var j = 0; j < expenses.length; j++) {
+            if (expenses[j].payer === t) paid += expenses[j].amount;
+          }
+          balances[t] = { paid: paid, shouldPay: perPerson, balance: paid - perPerson };
+        }
+        var settlements = [];
+        var debtors = [],
+          creditors = [];
+        for (var name in balances) {
+          var data = balances[name];
+          if (data.balance < -0.01) debtors.push({ name: name, amount: -data.balance });
+          else if (data.balance > 0.01) creditors.push({ name: name, amount: data.balance });
+        }
+        debtors.sort(function (a, b) {
+          return b.amount - a.amount;
+        });
+        creditors.sort(function (a, b) {
+          return b.amount - a.amount;
+        });
+        var i = 0,
+          j = 0;
+        while (i < debtors.length && j < creditors.length) {
+          var debtor = debtors[i],
+            creditor = creditors[j];
+          var amount = Math.min(debtor.amount, creditor.amount);
+          if (amount > 0.01) {
+            settlements.push({
+              from: debtor.name,
+              to: creditor.name,
+              amount: Math.round(amount * 100) / 100
+            });
+          }
+          debtor.amount -= amount;
+          creditor.amount -= amount;
+          if (debtor.amount < 0.01) i++;
+          if (creditor.amount < 0.01) j++;
+        }
+        return { total: total, perPerson: perPerson, balances: balances, settlements: settlements };
+      }
+
+      function escapeHtml(text) {
+        var div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+      }
+
+      function renderTravelerList() {
+        var container = document.getElementById("travelerList");
+        document.getElementById("travelerCount").textContent = travelers.length;
+        if (travelers.length === 0) {
+          container.innerHTML =
+            '<div class="empty-state"><div class="icon">👤</div><div>还没有添加旅行者</div></div>';
+          return;
+        }
+        var html = "";
+        for (var i = 0; i < travelers.length; i++) {
+          html +=
+            '<div class="list-item"><div><div class="name">' +
+            escapeHtml(travelers[i]) +
+            "</div></div>" +
+            '<button class="btn btn-danger btn-icon" onclick="deleteTraveler(' +
+            i +
+            ')" title="删除">×</button></div>';
+        }
+        container.innerHTML = html;
+      }
+      function renderExpenseList() {
+        var container = document.getElementById("expenseList");
+        document.getElementById("expenseCount").textContent = expenses.length;
+        if (expenses.length === 0) {
+          container.innerHTML =
+            '<div class="empty-state"><div class="icon">📋</div><div>还没有添加费用</div></div>';
+          return;
+        }
+        var html = "";
+        for (var i = 0; i < expenses.length; i++) {
+          var e = expenses[i];
+          html +=
+            '<div class="list-item"><div><div class="name">' +
+            escapeHtml(e.desc) +
+            "</div>" +
+            '<div class="details">' +
+            escapeHtml(e.payer) +
+            " 付款</div></div>" +
+            '<div style="display: flex; align-items: center; gap: 12px;">' +
+            '<span class="amount">¥' +
+            e.amount.toFixed(2) +
+            "</span>" +
+            '<button class="btn btn-danger btn-icon" onclick="deleteExpense(' +
+            e.id +
+            ')" title="删除">×</button></div></div>';
+        }
+        container.innerHTML = html;
+      }
+      function renderPayerSelect() {
+        var select = document.getElementById("expensePayer");
+        var currentValue = select.value;
+        var html = '<option value="">谁付的钱</option>';
+        for (var i = 0; i < travelers.length; i++) {
+          html +=
+            '<option value="' +
+            escapeHtml(travelers[i]) +
+            '">' +
+            escapeHtml(travelers[i]) +
+            "</option>";
+        }
+        select.innerHTML = html;
+        if (travelers.indexOf(currentValue) > -1) select.value = currentValue;
+      }
+      function renderSummary() {
+        var result = calculateSettlement();
+        document.getElementById("totalAmount").textContent = "¥" + result.total.toFixed(2);
+        document.getElementById("perPersonAmount").textContent = "¥" + result.perPerson.toFixed(2);
+        document.getElementById("participantCount").textContent = travelers.length;
+        var settlementContainer = document.getElementById("settlementList");
+        if (result.settlements.length === 0) {
+          var emptyMsg =
+            travelers.length === 0 || expenses.length === 0
+              ? "添加旅行者和费用后自动计算"
+              : "无需结算，费用已平衡";
+          settlementContainer.innerHTML =
+            '<div class="empty-state" style="padding: 20px"><div>' + emptyMsg + "</div></div>";
+        } else {
+          var html = "";
+          for (var i = 0; i < result.settlements.length; i++) {
+            var s = result.settlements[i];
+            html +=
+              '<div class="settlement-item"><span class="from">' +
+              escapeHtml(s.from) +
+              "</span>" +
+              '<span class="arrow">→</span><span class="to">' +
+              escapeHtml(s.to) +
+              "</span>" +
+              '<span class="amount">¥' +
+              s.amount.toFixed(2) +
+              "</span></div>";
+          }
+          settlementContainer.innerHTML = html;
+        }
+        var balanceContainer = document.getElementById("balanceList");
+        var balanceKeys = Object.keys(result.balances);
+        if (balanceKeys.length > 0) {
+          var html =
+            '<div class="section-title" style="margin-top: 16px; border-top: 1px solid var(--border-subtle); padding-top: 16px;">👤 个人明细</div>';
+          for (var i = 0; i < balanceKeys.length; i++) {
+            var name = balanceKeys[i],
+              data = result.balances[name];
+            var balanceClass = data.balance >= 0 ? "positive" : "negative";
+            var balanceSign = data.balance >= 0 ? "+" : "";
+            html +=
+              '<div class="balance-item"><div><div class="name">' +
+              escapeHtml(name) +
+              "</div>" +
+              '<div class="paid">已付 ¥' +
+              data.paid.toFixed(2) +
+              " / 应付 ¥" +
+              data.shouldPay.toFixed(2) +
+              "</div></div>" +
+              '<div class="balance ' +
+              balanceClass +
+              '">' +
+              balanceSign +
+              "¥" +
+              data.balance.toFixed(2) +
+              "</div></div>";
+          }
+          balanceContainer.innerHTML = html;
+        } else {
+          balanceContainer.innerHTML = "";
+        }
+      }
+      function renderAll() {
+        renderTravelerList();
+        renderExpenseList();
+        renderPayerSelect();
+        renderSummary();
+      }
+
+      function copySettlement() {
+        var result = calculateSettlement();
+        if (travelers.length === 0 || expenses.length === 0) {
+          showToast("没有可复制的内容", "error");
+          return;
+        }
+        var text = "【旅行费用分摊】\n\n";
+        text += "参与人: " + travelers.join("、") + "\n";
+        text += "总费用: ¥" + result.total.toFixed(2) + "\n";
+        text += "人均: ¥" + result.perPerson.toFixed(2) + "\n\n";
+        text += "费用明细:\n";
+        for (var i = 0; i < expenses.length; i++) {
+          var e = expenses[i];
+          text += "- " + e.desc + ": ¥" + e.amount.toFixed(2) + " (" + e.payer + "付)\n";
+        }
+        text += "\n结算方案:\n";
+        if (result.settlements.length === 0) {
+          text += "无需结算，费用已平衡\n";
+        } else {
+          for (var i = 0; i < result.settlements.length; i++) {
+            var s = result.settlements[i];
+            text += "- " + s.from + " → " + s.to + ": ¥" + s.amount.toFixed(2) + "\n";
+          }
+        }
+        navigator.clipboard.writeText(text).then(function () {
+          showToast("已复制到剪贴板");
+        });
+      }
+      function shareData() {
+        if (travelers.length === 0) {
+          showToast("没有可分享的内容", "error");
+          return;
+        }
+        saveToUrl();
+        navigator.clipboard.writeText(location.href).then(function () {
+          showToast("链接已复制到剪贴板");
+        });
+      }
+      function clearAll() {
+        if (travelers.length === 0 && expenses.length === 0) {
+          showToast("已经是空的了");
+          return;
+        }
+        if (!confirm("确定要清空所有数据吗？")) return;
+        travelers = [];
+        expenses = [];
+        saveData();
+        history.replaceState(null, "", location.pathname);
+        renderAll();
+        showToast("已清空全部数据");
+      }
+      function showToast(msg, type) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (type === "error" ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      if (!loadFromUrl()) loadData();
+      renderAll();
+    </script>
+
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>

--- a/tools/travel/visa-checker.html
+++ b/tools/travel/visa-checker.html
@@ -14,9 +14,15 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="Visa Checker - WebUtils" />
-    <meta property="og:description" content="Visa Checker，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      property="og:description"
+      content="Visa Checker，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tools.realtime-ai.chat/tools/travel/visa-checker.html" />
+    <meta
+      property="og:url"
+      content="https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
+    />
     <meta property="og:site_name" content="WebUtils" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:image" content="https://tools.realtime-ai.chat/social-preview.png" />
@@ -27,7 +33,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Visa Checker - WebUtils" />
-    <meta name="twitter:description" content="Visa Checker，在线使用，旅行工具，浏览器本地运行无需上传" />
+    <meta
+      name="twitter:description"
+      content="Visa Checker，在线使用，旅行工具，浏览器本地运行无需上传"
+    />
     <meta name="twitter:image" content="https://tools.realtime-ai.chat/social-preview.png" />
 
     <!-- Favicon & PWA -->
@@ -41,43 +50,43 @@
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "首页",
-      "item": "https://tools.realtime-ai.chat/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "旅行工具",
-      "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Visa Checker",
-      "item": "https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
-    }
-  ]
-}
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/tools/travel/index.html"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Visa Checker",
+            "item": "https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
+          }
+        ]
+      }
     </script>
     <script type="application/ld+json">
       {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "Visa Checker - WebUtils",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD"
-  }
-}
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Visa Checker - WebUtils",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
     </script>
 
     <!-- Global & Tool Styles -->
@@ -88,1741 +97,1746 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<style>
-  :root {
-    --color-bg-deep: #0a0a0f;
-    --color-bg-surface: #12121a;
-    --color-bg-card: #1a1a24;
-    --bg-input: #0e0e14;
-    --bg-hover: #22222e;
-    --color-text-primary: #e8e8ed;
-    --color-text-secondary: #8888a0;
-    --color-text-muted: #55556a;
-    --border-subtle: #2a2a3a;
-    --border-strong: #3a3a4a;
-    --color-accent-cyan: #00f5d4;
-    --accent-green: #10b981;
-    --accent-red: #f43f5e;
-    --accent-yellow: #fbbf24;
-    --accent-blue: #3b82f6;
-    --accent-orange: #f97316;
-    --color-accent-purple: #a855f7;
-    --glow-cyan: rgba(0, 245, 212, 0.15);
-    --glow-green: rgba(16, 185, 129, 0.15);
-    --glow-yellow: rgba(251, 191, 36, 0.15);
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
-    --font-sans: "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
-    --font-mono: "JetBrains Mono", "Courier New", monospace;
-  }
-
-  [data-theme="light"] {
-    --color-bg-deep: #fafafa;
-    --color-bg-surface: #fff;
-    --color-bg-card: #fff;
-    --bg-input: #f5f5f5;
-    --bg-hover: #f0f0f0;
-    --color-text-primary: #1a1a1a;
-    --color-text-secondary: #666;
-    --color-text-muted: #999;
-    --border-subtle: #e5e5e5;
-    --border-strong: #d5d5d5;
-  }
-
-  .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-subtle);
-    background: var(--color-bg-card);
-    cursor: pointer;
-    font-size: 1.2rem;
-    z-index: 100;
-    transition: all 0.2s;
-  }
-
-  .theme-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  body {
-    font-family: var(--font-sans);
-    background: var(--color-bg-deep);
-    color: var(--color-text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-  }
-
-  .bg-grid {
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .container {
-    position: relative;
-    z-index: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 24px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 24px;
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    padding: 8px 14px;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    flex-wrap: wrap;
-  }
-
-  .breadcrumb a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .breadcrumb a:hover {
-    color: var(--accent-green);
-  }
-
-  .breadcrumb-separator {
-    color: var(--color-text-muted);
-    user-select: none;
-  }
-
-  .breadcrumb-current {
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
-
-  .title-section {
-    flex: 1;
-  }
-
-  .title-section h1 {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .title-section h1 .icon {
-    font-size: 1.8rem;
-  }
-
-  .title-section p {
-    color: var(--color-text-secondary);
-    margin-top: 4px;
-    font-size: 0.9rem;
-  }
-
-  .main-content {
-    background: var(--color-bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    flex: 1;
-  }
-
-  .tool-section {
-    margin-bottom: 24px;
-  }
-
-  .section-title {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .input-group {
-    margin-bottom: 16px;
-  }
-
-  .input-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
-    margin-bottom: 8px;
-  }
-
-  select {
-    width: 100%;
-    padding: 12px 14px;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-primary);
-    transition: border-color 0.2s;
-    cursor: pointer;
-  }
-
-  select:focus {
-    outline: none;
-    border-color: var(--accent-green);
-  }
-
-  .row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-  }
-
-  .row > * {
-    flex: 1;
-    min-width: 250px;
-  }
-
-  .btn-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-top: 16px;
-  }
-
-  .btn {
-    flex: 1;
-    min-width: 120px;
-    padding: 12px 20px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .btn-primary {
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px var(--glow-green);
-  }
-
-  .btn-secondary {
-    background: var(--color-bg-surface);
-    color: var(--color-text-primary);
-    border: 1px solid var(--border-subtle);
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-  }
-
-  /* Popular destinations */
-  .popular-destinations {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 12px;
-  }
-
-  .dest-btn {
-    padding: 8px 16px;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .dest-btn:hover {
-    border-color: var(--color-accent-cyan);
-    color: var(--color-accent-cyan);
-    background: rgba(0, 245, 212, 0.1);
-  }
-
-  .dest-btn .flag {
-    margin-right: 6px;
-  }
-
-  /* Result card */
-  .result-card {
-    background: var(--bg-input);
-    border: 2px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    margin-top: 16px;
-    display: none;
-  }
-
-  .result-card.show {
-    display: block;
-  }
-
-  .result-header {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-  }
-
-  .result-route {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-size: 1.1rem;
-  }
-
-  .result-route .country {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-weight: 600;
-  }
-
-  .result-route .arrow {
-    color: var(--color-text-muted);
-    font-size: 1.2rem;
-  }
-
-  .visa-badge {
-    padding: 8px 16px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .visa-badge.visa-free {
-    background: rgba(16, 185, 129, 0.2);
-    color: var(--accent-green);
-    border: 1px solid var(--accent-green);
-  }
-
-  .visa-badge.visa-on-arrival {
-    background: rgba(251, 191, 36, 0.2);
-    color: var(--accent-yellow);
-    border: 1px solid var(--accent-yellow);
-  }
-
-  .visa-badge.e-visa {
-    background: rgba(59, 130, 246, 0.2);
-    color: var(--accent-blue);
-    border: 1px solid var(--accent-blue);
-  }
-
-  .visa-badge.visa-required {
-    background: rgba(244, 63, 94, 0.2);
-    color: var(--accent-red);
-    border: 1px solid var(--accent-red);
-  }
-
-  .result-details {
-    margin-top: 16px;
-  }
-
-  .detail-item {
-    display: flex;
-    padding: 12px 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .detail-item:last-child {
-    border-bottom: none;
-  }
-
-  .detail-label {
-    flex: 0 0 140px;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-  }
-
-  .detail-value {
-    flex: 1;
-    font-size: 0.95rem;
-    color: var(--color-text-primary);
-  }
-
-  .detail-value.highlight {
-    color: var(--accent-green);
-    font-weight: 500;
-  }
-
-  .notes-section {
-    margin-top: 20px;
-    padding: 16px;
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid rgba(251, 191, 36, 0.3);
-    border-radius: var(--radius-md);
-  }
-
-  .notes-section h4 {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--accent-yellow);
-    margin-bottom: 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .notes-section ul {
-    margin: 0;
-    padding-left: 20px;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-  }
-
-  .notes-section li {
-    margin-bottom: 4px;
-  }
-
-  /* Disclaimer */
-  .disclaimer {
-    margin-top: 24px;
-    padding: 16px;
-    background: rgba(244, 63, 94, 0.1);
-    border: 1px solid rgba(244, 63, 94, 0.3);
-    border-radius: var(--radius-md);
-  }
-
-  .disclaimer h4 {
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--accent-red);
-    margin-bottom: 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .disclaimer p {
-    color: var(--color-text-secondary);
-    font-size: 0.85rem;
-    line-height: 1.5;
-  }
-
-  .toast {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: var(--accent-green);
-    color: var(--color-bg-deep);
-    padding: 12px 24px;
-    border-radius: var(--radius-md);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 500;
-    opacity: 0;
-    transition: all 0.3s ease;
-    z-index: 1000;
-  }
-
-  .toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-  }
-
-  .toast.error {
-    background: var(--accent-red);
-  }
-
-  /* Stats summary */
-  .stats-summary {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-top: 16px;
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-  }
-
-  .stat-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 8px 16px;
-  }
-
-  .stat-value {
-    font-family: var(--font-mono);
-    font-size: 1.5rem;
-    font-weight: 700;
-  }
-
-  .stat-value.green {
-    color: var(--accent-green);
-  }
-  .stat-value.yellow {
-    color: var(--accent-yellow);
-  }
-  .stat-value.blue {
-    color: var(--accent-blue);
-  }
-  .stat-value.red {
-    color: var(--accent-red);
-  }
-
-  .stat-label {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-  }
-
-  @media (max-width: 600px) {
-    .container {
-      padding: 16px;
-    }
-
-    .row > * {
-      min-width: 100%;
-    }
-
-    .btn-row {
-      flex-direction: column;
-    }
-
-    .btn {
-      width: 100%;
-    }
-
-    .result-header {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    .detail-item {
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .detail-label {
-      flex: none;
-    }
-  }
-</style>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-bg-deep: #0a0a0f;
+        --color-bg-surface: #12121a;
+        --color-bg-card: #1a1a24;
+        --bg-input: #0e0e14;
+        --bg-hover: #22222e;
+        --color-text-primary: #e8e8ed;
+        --color-text-secondary: #8888a0;
+        --color-text-muted: #55556a;
+        --border-subtle: #2a2a3a;
+        --border-strong: #3a3a4a;
+        --color-accent-cyan: #00f5d4;
+        --accent-green: #10b981;
+        --accent-red: #f43f5e;
+        --accent-yellow: #fbbf24;
+        --accent-blue: #3b82f6;
+        --accent-orange: #f97316;
+        --color-accent-purple: #a855f7;
+        --glow-cyan: rgba(0, 245, 212, 0.15);
+        --glow-green: rgba(16, 185, 129, 0.15);
+        --glow-yellow: rgba(251, 191, 36, 0.15);
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --font-sans:
+          "Space Grotesk", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "Courier New", monospace;
+      }
+
+      [data-theme="light"] {
+        --color-bg-deep: #fafafa;
+        --color-bg-surface: #fff;
+        --color-bg-card: #fff;
+        --bg-input: #f5f5f5;
+        --bg-hover: #f0f0f0;
+        --color-text-primary: #1a1a1a;
+        --color-text-secondary: #666;
+        --color-text-muted: #999;
+        --border-subtle: #e5e5e5;
+        --border-strong: #d5d5d5;
+      }
+
+      .theme-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 1px solid var(--border-subtle);
+        background: var(--color-bg-card);
+        cursor: pointer;
+        font-size: 1.2rem;
+        z-index: 100;
+        transition: all 0.2s;
+      }
+
+      .theme-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-sans);
+        background: var(--color-bg-deep);
+        color: var(--color-text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      .bg-grid {
+        position: fixed;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(0, 245, 212, 0.02) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 245, 212, 0.02) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 24px;
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 8px 14px;
+        background: var(--color-bg-surface);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        flex-wrap: wrap;
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb a:hover {
+        color: var(--accent-green);
+      }
+
+      .breadcrumb-separator {
+        color: var(--color-text-muted);
+        user-select: none;
+      }
+
+      .breadcrumb-current {
+        color: var(--color-text-primary);
+        font-weight: 500;
+      }
+
+      .title-section {
+        flex: 1;
+      }
+
+      .title-section h1 {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .title-section h1 .icon {
+        font-size: 1.8rem;
+      }
+
+      .title-section p {
+        color: var(--color-text-secondary);
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .main-content {
+        background: var(--color-bg-card);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        flex: 1;
+      }
+
+      .tool-section {
+        margin-bottom: 24px;
+      }
+
+      .section-title {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .input-group {
+        margin-bottom: 16px;
+      }
+
+      .input-label {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        margin-bottom: 8px;
+      }
+
+      select {
+        width: 100%;
+        padding: 12px 14px;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        transition: border-color 0.2s;
+        cursor: pointer;
+      }
+
+      select:focus {
+        outline: none;
+        border-color: var(--accent-green);
+      }
+
+      .row {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .row > * {
+        flex: 1;
+        min-width: 250px;
+      }
+
+      .btn-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+
+      .btn {
+        flex: 1;
+        min-width: 120px;
+        padding: 12px 20px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .btn-primary {
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+      }
+
+      .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 20px var(--glow-green);
+      }
+
+      .btn-secondary {
+        background: var(--color-bg-surface);
+        color: var(--color-text-primary);
+        border: 1px solid var(--border-subtle);
+      }
+
+      .btn-secondary:hover {
+        border-color: var(--accent-green);
+        color: var(--accent-green);
+      }
+
+      /* Popular destinations */
+      .popular-destinations {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .dest-btn {
+        padding: 8px 16px;
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .dest-btn:hover {
+        border-color: var(--color-accent-cyan);
+        color: var(--color-accent-cyan);
+        background: rgba(0, 245, 212, 0.1);
+      }
+
+      .dest-btn .flag {
+        margin-right: 6px;
+      }
+
+      /* Result card */
+      .result-card {
+        background: var(--bg-input);
+        border: 2px solid var(--border-subtle);
+        border-radius: var(--radius-lg);
+        padding: 24px;
+        margin-top: 16px;
+        display: none;
+      }
+
+      .result-card.show {
+        display: block;
+      }
+
+      .result-header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+      }
+
+      .result-route {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 1.1rem;
+      }
+
+      .result-route .country {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+      }
+
+      .result-route .arrow {
+        color: var(--color-text-muted);
+        font-size: 1.2rem;
+      }
+
+      .visa-badge {
+        padding: 8px 16px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .visa-badge.visa-free {
+        background: rgba(16, 185, 129, 0.2);
+        color: var(--accent-green);
+        border: 1px solid var(--accent-green);
+      }
+
+      .visa-badge.visa-on-arrival {
+        background: rgba(251, 191, 36, 0.2);
+        color: var(--accent-yellow);
+        border: 1px solid var(--accent-yellow);
+      }
+
+      .visa-badge.e-visa {
+        background: rgba(59, 130, 246, 0.2);
+        color: var(--accent-blue);
+        border: 1px solid var(--accent-blue);
+      }
+
+      .visa-badge.visa-required {
+        background: rgba(244, 63, 94, 0.2);
+        color: var(--accent-red);
+        border: 1px solid var(--accent-red);
+      }
+
+      .result-details {
+        margin-top: 16px;
+      }
+
+      .detail-item {
+        display: flex;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .detail-item:last-child {
+        border-bottom: none;
+      }
+
+      .detail-label {
+        flex: 0 0 140px;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-muted);
+      }
+
+      .detail-value {
+        flex: 1;
+        font-size: 0.95rem;
+        color: var(--color-text-primary);
+      }
+
+      .detail-value.highlight {
+        color: var(--accent-green);
+        font-weight: 500;
+      }
+
+      .notes-section {
+        margin-top: 20px;
+        padding: 16px;
+        background: rgba(251, 191, 36, 0.1);
+        border: 1px solid rgba(251, 191, 36, 0.3);
+        border-radius: var(--radius-md);
+      }
+
+      .notes-section h4 {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--accent-yellow);
+        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .notes-section ul {
+        margin: 0;
+        padding-left: 20px;
+        color: var(--color-text-secondary);
+        font-size: 0.9rem;
+      }
+
+      .notes-section li {
+        margin-bottom: 4px;
+      }
+
+      /* Disclaimer */
+      .disclaimer {
+        margin-top: 24px;
+        padding: 16px;
+        background: rgba(244, 63, 94, 0.1);
+        border: 1px solid rgba(244, 63, 94, 0.3);
+        border-radius: var(--radius-md);
+      }
+
+      .disclaimer h4 {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--accent-red);
+        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .disclaimer p {
+        color: var(--color-text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.5;
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%) translateY(100px);
+        background: var(--accent-green);
+        color: var(--color-bg-deep);
+        padding: 12px 24px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0;
+        transition: all 0.3s ease;
+        z-index: 1000;
+      }
+
+      .toast.show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+
+      .toast.error {
+        background: var(--accent-red);
+      }
+
+      /* Stats summary */
+      .stats-summary {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+        padding: 16px;
+        background: var(--bg-input);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+      }
+
+      .stat-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        padding: 8px 16px;
+      }
+
+      .stat-value {
+        font-family: var(--font-mono);
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+
+      .stat-value.green {
+        color: var(--accent-green);
+      }
+      .stat-value.yellow {
+        color: var(--accent-yellow);
+      }
+      .stat-value.blue {
+        color: var(--accent-blue);
+      }
+      .stat-value.red {
+        color: var(--accent-red);
+      }
+
+      .stat-label {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+      }
+
+      @media (max-width: 600px) {
+        .container {
+          padding: 16px;
+        }
+
+        .row > * {
+          min-width: 100%;
+        }
+
+        .btn-row {
+          flex-direction: column;
+        }
+
+        .btn {
+          width: 100%;
+        }
+
+        .result-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .detail-item {
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        .detail-label {
+          flex: none;
+        }
+      }
+    </style>
   </head>
   <body>
     <div class="tool-main" role="main">
       <div class="container">
-  <header class="header">
-    <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../../index.html">首页</a>
-      <span class="breadcrumb-separator">/</span>
-      <span class="breadcrumb-current">签证查询</span>
-    </nav>
-    <div class="title-section">
-      <h1>
-        <span class="icon">🛂</span>
-        签证查询
-      </h1>
-      <p>查询中国护照前往各国的签证要求</p>
-    </div>
-  </header>
-
-  <main class="main-content">
-    <!-- Selection Section -->
-    <div class="tool-section">
-      <div class="section-title">
-        <span>📋</span>
-        选择护照和目的地
-      </div>
-      <div class="row">
-        <div class="input-group">
-          <label class="input-label">护照签发国</label>
-          <select id="passportCountry">
-            <option value="CN">🇨🇳 中国 (China)</option>
-            <option value="HK">🇭🇰 中国香港 (Hong Kong SAR)</option>
-            <option value="MO">🇲🇴 中国澳门 (Macau SAR)</option>
-            <option value="TW">🇹🇼 中国台湾 (Taiwan)</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label class="input-label">目的地国家/地区</label>
-          <select id="destinationCountry">
-            <option value="">-- 请选择目的地 --</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="input-group">
-        <label class="input-label">热门目的地</label>
-        <div class="popular-destinations" id="popularDestinations">
-          <!-- Popular destinations will be added by JS -->
-        </div>
-      </div>
-
-      <div class="btn-row">
-        <button class="btn btn-primary" onclick="checkVisa()">🔍 查询签证要求</button>
-        <button class="btn btn-secondary" onclick="clearSelection()">🔄 清空</button>
-        <button class="btn btn-secondary" onclick="shareResult()">🔗 分享</button>
-      </div>
-    </div>
-
-    <!-- Result Section -->
-    <div class="tool-section">
-      <div class="section-title">
-        <span>📄</span>
-        签证要求
-      </div>
-      <div class="result-card" id="resultCard">
-        <div class="result-header">
-          <div class="result-route">
-            <span class="country" id="fromCountry">🇨🇳 中国</span>
-            <span class="arrow">→</span>
-            <span class="country" id="toCountry">🇯🇵 日本</span>
+        <header class="header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="../../index.html">首页</a>
+            <span class="breadcrumb-separator">/</span>
+            <span class="breadcrumb-current">签证查询</span>
+          </nav>
+          <div class="title-section">
+            <h1>
+              <span class="icon">🛂</span>
+              签证查询
+            </h1>
+            <p>查询中国护照前往各国的签证要求</p>
           </div>
-          <span class="visa-badge" id="visaBadge">签证要求</span>
-        </div>
+        </header>
 
-        <div class="result-details" id="resultDetails">
-          <!-- Details will be populated by JS -->
-        </div>
+        <main class="main-content">
+          <!-- Selection Section -->
+          <div class="tool-section">
+            <div class="section-title">
+              <span>📋</span>
+              选择护照和目的地
+            </div>
+            <div class="row">
+              <div class="input-group">
+                <label class="input-label">护照签发国</label>
+                <select id="passportCountry">
+                  <option value="CN">🇨🇳 中国 (China)</option>
+                  <option value="HK">🇭🇰 中国香港 (Hong Kong SAR)</option>
+                  <option value="MO">🇲🇴 中国澳门 (Macau SAR)</option>
+                  <option value="TW">🇹🇼 中国台湾 (Taiwan)</option>
+                </select>
+              </div>
+              <div class="input-group">
+                <label class="input-label">目的地国家/地区</label>
+                <select id="destinationCountry">
+                  <option value="">-- 请选择目的地 --</option>
+                </select>
+              </div>
+            </div>
 
-        <div class="notes-section" id="notesSection">
-          <h4>⚠️ 注意事项</h4>
-          <ul id="notesList">
-            <!-- Notes will be populated by JS -->
-          </ul>
-        </div>
-      </div>
+            <div class="input-group">
+              <label class="input-label">热门目的地</label>
+              <div class="popular-destinations" id="popularDestinations">
+                <!-- Popular destinations will be added by JS -->
+              </div>
+            </div>
 
-      <div class="disclaimer">
-        <h4>⚠️ 免责声明</h4>
-        <p>
-          本工具提供的签证信息仅供参考，可能不是最新数据。签证政策随时可能变化，
-          出行前请务必通过以下渠道核实最新要求：
-        </p>
-        <ul style="
-            margin-top: 8px;
-            padding-left: 20px;
-            color: var(--color-text-secondary);
-            font-size: 0.85rem;
-          ">
-          <li>目的地国家/地区的官方大使馆或领事馆网站</li>
-          <li>中国外交部领事服务网 (cs.mfa.gov.cn)</li>
-          <li>专业签证服务机构</li>
-        </ul>
+            <div class="btn-row">
+              <button class="btn btn-primary" onclick="checkVisa()">🔍 查询签证要求</button>
+              <button class="btn btn-secondary" onclick="clearSelection()">🔄 清空</button>
+              <button class="btn btn-secondary" onclick="shareResult()">🔗 分享</button>
+            </div>
+          </div>
+
+          <!-- Result Section -->
+          <div class="tool-section">
+            <div class="section-title">
+              <span>📄</span>
+              签证要求
+            </div>
+            <div class="result-card" id="resultCard">
+              <div class="result-header">
+                <div class="result-route">
+                  <span class="country" id="fromCountry">🇨🇳 中国</span>
+                  <span class="arrow">→</span>
+                  <span class="country" id="toCountry">🇯🇵 日本</span>
+                </div>
+                <span class="visa-badge" id="visaBadge">签证要求</span>
+              </div>
+
+              <div class="result-details" id="resultDetails">
+                <!-- Details will be populated by JS -->
+              </div>
+
+              <div class="notes-section" id="notesSection">
+                <h4>⚠️ 注意事项</h4>
+                <ul id="notesList">
+                  <!-- Notes will be populated by JS -->
+                </ul>
+              </div>
+            </div>
+
+            <div class="disclaimer">
+              <h4>⚠️ 免责声明</h4>
+              <p>
+                本工具提供的签证信息仅供参考，可能不是最新数据。签证政策随时可能变化，
+                出行前请务必通过以下渠道核实最新要求：
+              </p>
+              <ul
+                style="
+                  margin-top: 8px;
+                  padding-left: 20px;
+                  color: var(--color-text-secondary);
+                  font-size: 0.85rem;
+                "
+              >
+                <li>目的地国家/地区的官方大使馆或领事馆网站</li>
+                <li>中国外交部领事服务网 (cs.mfa.gov.cn)</li>
+                <li>专业签证服务机构</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- Stats Section -->
+          <div class="tool-section">
+            <div class="section-title">
+              <span>📊</span>
+              中国护照免签/落地签统计
+            </div>
+            <div class="stats-summary">
+              <div class="stat-item">
+                <span class="stat-value green" id="statVisaFree">0</span>
+                <span class="stat-label">免签国家</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value yellow" id="statVisaOnArrival">0</span>
+                <span class="stat-label">落地签国家</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value blue" id="statEVisa">0</span>
+                <span class="stat-label">电子签国家</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value red" id="statVisaRequired">0</span>
+                <span class="stat-label">需要签证</span>
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
 
-    <!-- Stats Section -->
-    <div class="tool-section">
-      <div class="section-title">
-        <span>📊</span>
-        中国护照免签/落地签统计
-      </div>
-      <div class="stats-summary">
-        <div class="stat-item">
-          <span class="stat-value green" id="statVisaFree">0</span>
-          <span class="stat-label">免签国家</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value yellow" id="statVisaOnArrival">0</span>
-          <span class="stat-label">落地签国家</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value blue" id="statEVisa">0</span>
-          <span class="stat-label">电子签国家</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value red" id="statVisaRequired">0</span>
-          <span class="stat-label">需要签证</span>
-        </div>
-      </div>
-    </div>
-  </main>
-</div>
-    </div>
-    
     <script type="application/ld+json">
-  {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": [
-            {
-              "@type": "ListItem",
-              "position": 1,
-              "name": "首页",
-              "item": "https://tools.realtime-ai.chat/"
-            },
-            {
-              "@type": "ListItem",
-              "position": 2,
-              "name": "旅行工具",
-              "item": "https://tools.realtime-ai.chat/#travel"
-            },
-            {
-              "@type": "ListItem",
-              "position": 3,
-              "name": "签证查询",
-              "item": "https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
-            }
-          ]
-        }
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "首页",
+            "item": "https://tools.realtime-ai.chat/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "旅行工具",
+            "item": "https://tools.realtime-ai.chat/#travel"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "签证查询",
+            "item": "https://tools.realtime-ai.chat/tools/travel/visa-checker.html"
+          }
+        ]
+      }
     </script>
     <script>
+      // Visa requirement types
+      var VISA_TYPES = {
+        VISA_FREE: "visa-free",
+        VISA_ON_ARRIVAL: "visa-on-arrival",
+        E_VISA: "e-visa",
+        VISA_REQUIRED: "visa-required"
+      };
 
-  // Visa requirement types
-        var VISA_TYPES = {
-          VISA_FREE: "visa-free",
-          VISA_ON_ARRIVAL: "visa-on-arrival",
-          E_VISA: "e-visa",
-          VISA_REQUIRED: "visa-required"
-        };
+      // Visa data for Chinese passport holders (2024 data - approximate)
+      // Format: { type, days, notes }
+      var VISA_DATA = {
+        CN: {
+          // Asia - Visa Free
+          JP: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["2024年11月起单次免签30天", "需持有效护照", "需有返程机票"]
+          },
+          KR: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 15,
+            notes: ["2024年11月起试行免签15天", "需持有效护照", "需有返程机票"]
+          },
+          SG: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["2024年2月起互免签证", "可停留30天", "需有返程机票和足够资金"]
+          },
+          TH: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["2024年3月起永久互免签证", "可停留30天", "需有返程机票"]
+          },
+          MY: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["2023年12月起互免签证", "可停留30天", "需有返程机票和酒店预订"]
+          },
+          KZ: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["2024年11月起互免签证", "可停留30天"]
+          },
+          AE: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["免签入境", "可停留30天", "可续签30天"]
+          },
+          QA: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          GE: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          AM: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "180天内可停留90天"] },
+          AZ: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
 
-        // Visa data for Chinese passport holders (2024 data - approximate)
-        // Format: { type, days, notes }
-        var VISA_DATA = {
-          CN: {
-            // Asia - Visa Free
-            JP: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["2024年11月起单次免签30天", "需持有效护照", "需有返程机票"]
-            },
-            KR: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 15,
-              notes: ["2024年11月起试行免签15天", "需持有效护照", "需有返程机票"]
-            },
-            SG: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["2024年2月起互免签证", "可停留30天", "需有返程机票和足够资金"]
-            },
-            TH: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["2024年3月起永久互免签证", "可停留30天", "需有返程机票"]
-            },
-            MY: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["2023年12月起互免签证", "可停留30天", "需有返程机票和酒店预订"]
-            },
-            KZ: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["2024年11月起互免签证", "可停留30天"]
-            },
-            AE: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["免签入境", "可停留30天", "可续签30天"]
-            },
-            QA: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            GE: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            AM: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "180天内可停留90天"] },
-            AZ: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          // Asia - Visa on Arrival
+          KH: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 30,
+            notes: ["落地签费用约30美元", "需准备2寸照片", "建议提前申请电子签"]
+          },
+          LA: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 20,
+            notes: ["落地签费用约20美元", "需准备2寸照片"]
+          },
+          NP: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 30,
+            notes: ["落地签费用约30美元", "需准备照片和美元现金"]
+          },
+          LK: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 50,
+            notes: ["建议提前申请ETA电子签", "落地签费用约50美元"]
+          },
+          MV: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 0,
+            notes: ["免费落地签", "需有酒店预订和返程机票"]
+          },
+          ID: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 35,
+            notes: ["落地签费用约35美元", "巴厘岛等主要口岸可办理", "建议提前申请电子签"]
+          },
+          BD: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 51,
+            notes: ["落地签费用约51美元", "需有邀请函或酒店预订"]
+          },
+          JO: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 40,
+            notes: ["落地签费用约40约旦第纳尔"]
+          },
+          BH: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 14,
+            fee: 25,
+            notes: ["落地签费用约25巴林第纳尔", "可延期至1个月"]
+          },
+          OM: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 20,
+            notes: ["落地签费用约20阿曼里亚尔"]
+          },
 
-            // Asia - Visa on Arrival
-            KH: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 30,
-              notes: ["落地签费用约30美元", "需准备2寸照片", "建议提前申请电子签"]
-            },
-            LA: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 20,
-              notes: ["落地签费用约20美元", "需准备2寸照片"]
-            },
-            NP: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 30,
-              notes: ["落地签费用约30美元", "需准备照片和美元现金"]
-            },
-            LK: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 50,
-              notes: ["建议提前申请ETA电子签", "落地签费用约50美元"]
-            },
-            MV: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 0,
-              notes: ["免费落地签", "需有酒店预订和返程机票"]
-            },
-            ID: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 35,
-              notes: ["落地签费用约35美元", "巴厘岛等主要口岸可办理", "建议提前申请电子签"]
-            },
-            BD: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 51,
-              notes: ["落地签费用约51美元", "需有邀请函或酒店预订"]
-            },
-            JO: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 40,
-              notes: ["落地签费用约40约旦第纳尔"]
-            },
-            BH: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 14,
-              fee: 25,
-              notes: ["落地签费用约25巴林第纳尔", "可延期至1个月"]
-            },
-            OM: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 20,
-              notes: ["落地签费用约20阿曼里亚尔"]
-            },
+          // Asia - E-Visa
+          VN: {
+            type: VISA_TYPES.E_VISA,
+            days: 30,
+            fee: 25,
+            notes: ["电子签费用约25美元", "可在线申请", "处理时间约3个工作日"]
+          },
+          IN: {
+            type: VISA_TYPES.E_VISA,
+            days: 30,
+            fee: 25,
+            notes: ["电子签费用约25美元", "需提前申请", "可多次入境"]
+          },
+          MM: {
+            type: VISA_TYPES.E_VISA,
+            days: 28,
+            fee: 50,
+            notes: ["电子签费用约50美元", "仅限旅游签"]
+          },
+          PK: {
+            type: VISA_TYPES.E_VISA,
+            days: 30,
+            fee: 60,
+            notes: ["电子签费用约60美元", "处理时间约7-10个工作日"]
+          },
+          UZ: {
+            type: VISA_TYPES.E_VISA,
+            days: 30,
+            fee: 20,
+            notes: ["电子签费用约20美元", "可在线申请"]
+          },
+          TJ: { type: VISA_TYPES.E_VISA, days: 45, fee: 50, notes: ["电子签费用约50美元"] },
+          KG: { type: VISA_TYPES.E_VISA, days: 60, fee: 70, notes: ["电子签费用约70美元"] },
 
-            // Asia - E-Visa
-            VN: {
-              type: VISA_TYPES.E_VISA,
-              days: 30,
-              fee: 25,
-              notes: ["电子签费用约25美元", "可在线申请", "处理时间约3个工作日"]
-            },
-            IN: {
-              type: VISA_TYPES.E_VISA,
-              days: 30,
-              fee: 25,
-              notes: ["电子签费用约25美元", "需提前申请", "可多次入境"]
-            },
-            MM: {
-              type: VISA_TYPES.E_VISA,
-              days: 28,
-              fee: 50,
-              notes: ["电子签费用约50美元", "仅限旅游签"]
-            },
-            PK: {
-              type: VISA_TYPES.E_VISA,
-              days: 30,
-              fee: 60,
-              notes: ["电子签费用约60美元", "处理时间约7-10个工作日"]
-            },
-            UZ: {
-              type: VISA_TYPES.E_VISA,
-              days: 30,
-              fee: 20,
-              notes: ["电子签费用约20美元", "可在线申请"]
-            },
-            TJ: { type: VISA_TYPES.E_VISA, days: 45, fee: 50, notes: ["电子签费用约50美元"] },
-            KG: { type: VISA_TYPES.E_VISA, days: 60, fee: 70, notes: ["电子签费用约70美元"] },
+          // Asia - Visa Required
+          IL: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需提前申请签证", "旅游签可停留90天", "需提供行程单和酒店预订"]
+          },
+          SA: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请旅游签证", "2019年开放旅游签"]
+          },
+          KW: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需提前申请签证"] },
+          IR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 30,
+            notes: ["需提前申请签证", "部分情况可落地签"]
+          },
+          IQ: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 30,
+            notes: ["需提前申请签证", "安全形势需关注"]
+          },
+          AF: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证", "不建议前往"] },
+          SY: { type: VISA_TYPES.VISA_REQUIRED, days: 15, notes: ["需提前申请签证", "不建议前往"] },
+          YE: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证", "不建议前往"] },
+          BT: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 15,
+            notes: ["需通过授权旅行社办理", "每日最低消费要求"]
+          },
+          TM: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 10,
+            notes: ["需提前申请签证", "签证较难获得"]
+          },
+          KP: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 30,
+            notes: ["需通过授权旅行社办理", "团队游为主"]
+          },
+          PH: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 30,
+            notes: ["需提前申请签证", "可申请9a旅游签证"]
+          },
+          BN: { type: VISA_TYPES.VISA_REQUIRED, days: 14, notes: ["需提前申请签证"] },
 
-            // Asia - Visa Required
-            IL: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需提前申请签证", "旅游签可停留90天", "需提供行程单和酒店预订"]
-            },
-            SA: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请旅游签证", "2019年开放旅游签"]
-            },
-            KW: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需提前申请签证"] },
-            IR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 30,
-              notes: ["需提前申请签证", "部分情况可落地签"]
-            },
-            IQ: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 30,
-              notes: ["需提前申请签证", "安全形势需关注"]
-            },
-            AF: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证", "不建议前往"] },
-            SY: { type: VISA_TYPES.VISA_REQUIRED, days: 15, notes: ["需提前申请签证", "不建议前往"] },
-            YE: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证", "不建议前往"] },
-            BT: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 15,
-              notes: ["需通过授权旅行社办理", "每日最低消费要求"]
-            },
-            TM: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 10,
-              notes: ["需提前申请签证", "签证较难获得"]
-            },
-            KP: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 30,
-              notes: ["需通过授权旅行社办理", "团队游为主"]
-            },
-            PH: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 30,
-              notes: ["需提前申请签证", "可申请9a旅游签证"]
-            },
-            BN: { type: VISA_TYPES.VISA_REQUIRED, days: 14, notes: ["需提前申请签证"] },
+          // Europe - Visa Free
+          RS: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          BA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "180天内可停留90天"] },
+          AL: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 90,
+            notes: ["旅游旺季免签(4-10月)", "其他时间需签证"]
+          },
+          BY: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["免签入境", "可停留30天", "需从明斯克机场入境"]
+          },
+          ME: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          MK: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["持有效申根签证可免签"] },
 
-            // Europe - Visa Free
-            RS: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            BA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "180天内可停留90天"] },
-            AL: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 90,
-              notes: ["旅游旺季免签(4-10月)", "其他时间需签证"]
-            },
-            BY: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["免签入境", "可停留30天", "需从明斯克机场入境"]
-            },
-            ME: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            MK: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["持有效申根签证可免签"] },
+          // Europe - Visa Required (Schengen)
+          DE: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天", "建议提前2-3个月申请"]
+          },
+          FR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天", "旅游签证较易获得"]
+          },
+          IT: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          ES: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          NL: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          BE: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          AT: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          CH: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          PT: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          GR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          SE: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          NO: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          DK: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          FI: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          PL: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          CZ: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
+          HU: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请申根签证", "可在申根区停留90天/180天"]
+          },
 
-            // Europe - Visa Required (Schengen)
-            DE: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天", "建议提前2-3个月申请"]
-            },
-            FR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天", "旅游签证较易获得"]
-            },
-            IT: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            ES: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            NL: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            BE: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            AT: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            CH: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            PT: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            GR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            SE: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            NO: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            DK: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            FI: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            PL: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            CZ: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
-            HU: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请申根签证", "可在申根区停留90天/180天"]
-            },
+          // Europe - Non-Schengen
+          GB: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 180,
+            notes: ["需申请英国签证", "旅游签可停留6个月", "建议提前申请"]
+          },
+          IE: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请爱尔兰签证", "与英国签证独立"]
+          },
+          RU: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 30,
+            notes: ["团队旅游免签", "个人旅游可申请电子签", "世界杯/大型活动期间有特殊政策"]
+          },
+          UA: { type: VISA_TYPES.E_VISA, days: 30, notes: ["可申请电子签", "注意安全形势"] },
+          TR: {
+            type: VISA_TYPES.E_VISA,
+            days: 30,
+            fee: 50,
+            notes: ["电子签费用约50美元", "可在线申请", "持有效申根/英美签证可免签"]
+          },
+          HR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["2023年加入申根区", "需申请申根签证"]
+          },
+          RO: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["持有效申根签证可入境"] },
+          BG: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["持有效申根签证可入境"] },
 
-            // Europe - Non-Schengen
-            GB: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 180,
-              notes: ["需申请英国签证", "旅游签可停留6个月", "建议提前申请"]
-            },
-            IE: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请爱尔兰签证", "与英国签证独立"]
-            },
-            RU: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 30,
-              notes: ["团队旅游免签", "个人旅游可申请电子签", "世界杯/大型活动期间有特殊政策"]
-            },
-            UA: { type: VISA_TYPES.E_VISA, days: 30, notes: ["可申请电子签", "注意安全形势"] },
-            TR: {
-              type: VISA_TYPES.E_VISA,
-              days: 30,
-              fee: 50,
-              notes: ["电子签费用约50美元", "可在线申请", "持有效申根/英美签证可免签"]
-            },
-            HR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["2023年加入申根区", "需申请申根签证"]
-            },
-            RO: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["持有效申根签证可入境"] },
-            BG: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["持有效申根签证可入境"] },
+          // Americas - Visa Free
+          EC: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
 
-            // Americas - Visa Free
-            EC: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
-
-            // Americas - Visa Required
-            US: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 180,
-              notes: ["需申请B1/B2签证", "面签必须", "建议提前3个月预约"]
-            },
-            CA: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 180,
-              notes: ["需申请访客签证", "可在线申请", "持有效美签可简化申请"]
-            },
-            MX: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 180,
-              notes: ["持有效美签可免签入境", "或需申请墨西哥签证"]
-            },
-            BR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需提前申请签证", "可申请电子签"]
-            },
-            AR: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需提前申请签证", "持有效美签可申请AVE电子授权"]
-            },
-            CL: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["持有效美签可免签", "或需申请签证"] },
-            PE: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 183,
-              notes: ["持有效美签/申根签可免签", "或需申请签证"]
-            },
-            CO: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 90,
-              notes: ["持有效美签/申根签可免签", "或需申请签证"]
-            },
-            CU: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 25,
-              notes: ["需购买旅游卡", "费用约25美元"]
-            },
-            PA: { type: VISA_TYPES.VISA_FREE, days: 180, notes: ["持有效美签可免签入境"] },
-            CR: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["持有效美签/申根签可免签"] },
-
-            // Oceania
-            AU: {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 90,
-              notes: ["需申请访客签证(600类)", "可在线申请", "处理时间约20天"]
-            },
-            NZ: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需申请访客签证", "可在线申请"] },
-            FJ: { type: VISA_TYPES.VISA_FREE, days: 120, notes: ["免签入境", "可停留120天"] },
-            WS: { type: VISA_TYPES.VISA_FREE, days: 60, notes: ["免签入境", "可停留60天"] },
-            TO: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            VU: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            PG: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 60,
-              fee: 100,
-              notes: ["落地签费用约100基那"]
-            },
-
-            // Africa - Visa Free
-            MU: { type: VISA_TYPES.VISA_FREE, days: 60, notes: ["免签入境", "可停留60天"] },
-            SC: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
-            MA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
-            TN: {
-              type: VISA_TYPES.VISA_FREE,
-              days: 90,
-              notes: ["团队旅游免签", "需有返程机票和酒店预订"]
-            },
-            ZA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
-            BW: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
-
-            // Africa - Visa on Arrival
-            EG: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 25,
-              notes: ["落地签费用约25美元", "仅限特定口岸"]
-            },
-            KE: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 90,
-              fee: 50,
-              notes: ["建议申请电子签", "落地签费用约50美元"]
-            },
-            TZ: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 90,
-              fee: 50,
-              notes: ["落地签费用约50美元", "可在线申请电子签"]
-            },
-            ET: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 52,
-              notes: ["仅限亚的斯亚贝巴机场", "费用约52美元"]
-            },
-            MG: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 90,
-              fee: 35,
-              notes: ["落地签费用约35美元"]
-            },
-            RW: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 30,
-              notes: ["落地签费用约30美元"]
-            },
-            UG: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 90,
-              fee: 50,
-              notes: ["建议申请电子签", "落地签费用约50美元"]
-            },
-            ZM: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 90,
-              fee: 50,
-              notes: ["落地签费用约50美元"]
-            },
-            ZW: {
-              type: VISA_TYPES.VISA_ON_ARRIVAL,
-              days: 30,
-              fee: 30,
-              notes: ["落地签费用约30美元", "可申请KAZA签证"]
-            },
-
-            // Africa - Visa Required
-            NG: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            GH: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            SN: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            CI: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            DZ: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            AO: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
-            NA: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需提前申请签证"] }
-          }
-        };
-
-        // Country data with names and flags
-        var COUNTRIES = {
-          // Asia
-          JP: { name: "日本", nameEn: "Japan", flag: "🇯🇵", region: "亚洲" },
-          KR: { name: "韩国", nameEn: "South Korea", flag: "🇰🇷", region: "亚洲" },
-          SG: { name: "新加坡", nameEn: "Singapore", flag: "🇸🇬", region: "亚洲" },
-          TH: { name: "泰国", nameEn: "Thailand", flag: "🇹🇭", region: "亚洲" },
-          MY: { name: "马来西亚", nameEn: "Malaysia", flag: "🇲🇾", region: "亚洲" },
-          VN: { name: "越南", nameEn: "Vietnam", flag: "🇻🇳", region: "亚洲" },
-          KH: { name: "柬埔寨", nameEn: "Cambodia", flag: "🇰🇭", region: "亚洲" },
-          LA: { name: "老挝", nameEn: "Laos", flag: "🇱🇦", region: "亚洲" },
-          MM: { name: "缅甸", nameEn: "Myanmar", flag: "🇲🇲", region: "亚洲" },
-          PH: { name: "菲律宾", nameEn: "Philippines", flag: "🇵🇭", region: "亚洲" },
-          ID: { name: "印度尼西亚", nameEn: "Indonesia", flag: "🇮🇩", region: "亚洲" },
-          BN: { name: "文莱", nameEn: "Brunei", flag: "🇧🇳", region: "亚洲" },
-          IN: { name: "印度", nameEn: "India", flag: "🇮🇳", region: "亚洲" },
-          NP: { name: "尼泊尔", nameEn: "Nepal", flag: "🇳🇵", region: "亚洲" },
-          LK: { name: "斯里兰卡", nameEn: "Sri Lanka", flag: "🇱🇰", region: "亚洲" },
-          MV: { name: "马尔代夫", nameEn: "Maldives", flag: "🇲🇻", region: "亚洲" },
-          BD: { name: "孟加拉国", nameEn: "Bangladesh", flag: "🇧🇩", region: "亚洲" },
-          PK: { name: "巴基斯坦", nameEn: "Pakistan", flag: "🇵🇰", region: "亚洲" },
-          AE: { name: "阿联酋", nameEn: "UAE", flag: "🇦🇪", region: "亚洲" },
-          QA: { name: "卡塔尔", nameEn: "Qatar", flag: "🇶🇦", region: "亚洲" },
-          SA: { name: "沙特阿拉伯", nameEn: "Saudi Arabia", flag: "🇸🇦", region: "亚洲" },
-          KW: { name: "科威特", nameEn: "Kuwait", flag: "🇰🇼", region: "亚洲" },
-          BH: { name: "巴林", nameEn: "Bahrain", flag: "🇧🇭", region: "亚洲" },
-          OM: { name: "阿曼", nameEn: "Oman", flag: "🇴🇲", region: "亚洲" },
-          JO: { name: "约旦", nameEn: "Jordan", flag: "🇯🇴", region: "亚洲" },
-          IL: { name: "以色列", nameEn: "Israel", flag: "🇮🇱", region: "亚洲" },
-          IR: { name: "伊朗", nameEn: "Iran", flag: "🇮🇷", region: "亚洲" },
-          IQ: { name: "伊拉克", nameEn: "Iraq", flag: "🇮🇶", region: "亚洲" },
-          SY: { name: "叙利亚", nameEn: "Syria", flag: "🇸🇾", region: "亚洲" },
-          YE: { name: "也门", nameEn: "Yemen", flag: "🇾🇪", region: "亚洲" },
-          AF: { name: "阿富汗", nameEn: "Afghanistan", flag: "🇦🇫", region: "亚洲" },
-          KZ: { name: "哈萨克斯坦", nameEn: "Kazakhstan", flag: "🇰🇿", region: "亚洲" },
-          UZ: { name: "乌兹别克斯坦", nameEn: "Uzbekistan", flag: "🇺🇿", region: "亚洲" },
-          TJ: { name: "塔吉克斯坦", nameEn: "Tajikistan", flag: "🇹🇯", region: "亚洲" },
-          KG: { name: "吉尔吉斯斯坦", nameEn: "Kyrgyzstan", flag: "🇰🇬", region: "亚洲" },
-          TM: { name: "土库曼斯坦", nameEn: "Turkmenistan", flag: "🇹🇲", region: "亚洲" },
-          GE: { name: "格鲁吉亚", nameEn: "Georgia", flag: "🇬🇪", region: "亚洲" },
-          AM: { name: "亚美尼亚", nameEn: "Armenia", flag: "🇦🇲", region: "亚洲" },
-          AZ: { name: "阿塞拜疆", nameEn: "Azerbaijan", flag: "🇦🇿", region: "亚洲" },
-          BT: { name: "不丹", nameEn: "Bhutan", flag: "🇧🇹", region: "亚洲" },
-          KP: { name: "朝鲜", nameEn: "North Korea", flag: "🇰🇵", region: "亚洲" },
-
-          // Europe
-          GB: { name: "英国", nameEn: "United Kingdom", flag: "🇬🇧", region: "欧洲" },
-          FR: { name: "法国", nameEn: "France", flag: "🇫🇷", region: "欧洲" },
-          DE: { name: "德国", nameEn: "Germany", flag: "🇩🇪", region: "欧洲" },
-          IT: { name: "意大利", nameEn: "Italy", flag: "🇮🇹", region: "欧洲" },
-          ES: { name: "西班牙", nameEn: "Spain", flag: "🇪🇸", region: "欧洲" },
-          PT: { name: "葡萄牙", nameEn: "Portugal", flag: "🇵🇹", region: "欧洲" },
-          NL: { name: "荷兰", nameEn: "Netherlands", flag: "🇳🇱", region: "欧洲" },
-          BE: { name: "比利时", nameEn: "Belgium", flag: "🇧🇪", region: "欧洲" },
-          AT: { name: "奥地利", nameEn: "Austria", flag: "🇦🇹", region: "欧洲" },
-          CH: { name: "瑞士", nameEn: "Switzerland", flag: "🇨🇭", region: "欧洲" },
-          GR: { name: "希腊", nameEn: "Greece", flag: "🇬🇷", region: "欧洲" },
-          SE: { name: "瑞典", nameEn: "Sweden", flag: "🇸🇪", region: "欧洲" },
-          NO: { name: "挪威", nameEn: "Norway", flag: "🇳🇴", region: "欧洲" },
-          DK: { name: "丹麦", nameEn: "Denmark", flag: "🇩🇰", region: "欧洲" },
-          FI: { name: "芬兰", nameEn: "Finland", flag: "🇫🇮", region: "欧洲" },
-          PL: { name: "波兰", nameEn: "Poland", flag: "🇵🇱", region: "欧洲" },
-          CZ: { name: "捷克", nameEn: "Czech Republic", flag: "🇨🇿", region: "欧洲" },
-          HU: { name: "匈牙利", nameEn: "Hungary", flag: "🇭🇺", region: "欧洲" },
-          IE: { name: "爱尔兰", nameEn: "Ireland", flag: "🇮🇪", region: "欧洲" },
-          RU: { name: "俄罗斯", nameEn: "Russia", flag: "🇷🇺", region: "欧洲" },
-          UA: { name: "乌克兰", nameEn: "Ukraine", flag: "🇺🇦", region: "欧洲" },
-          TR: { name: "土耳其", nameEn: "Turkey", flag: "🇹🇷", region: "欧洲" },
-          RS: { name: "塞尔维亚", nameEn: "Serbia", flag: "🇷🇸", region: "欧洲" },
-          HR: { name: "克罗地亚", nameEn: "Croatia", flag: "🇭🇷", region: "欧洲" },
-          BA: { name: "波黑", nameEn: "Bosnia", flag: "🇧🇦", region: "欧洲" },
-          ME: { name: "黑山", nameEn: "Montenegro", flag: "🇲🇪", region: "欧洲" },
-          AL: { name: "阿尔巴尼亚", nameEn: "Albania", flag: "🇦🇱", region: "欧洲" },
-          MK: { name: "北马其顿", nameEn: "North Macedonia", flag: "🇲🇰", region: "欧洲" },
-          BY: { name: "白俄罗斯", nameEn: "Belarus", flag: "🇧🇾", region: "欧洲" },
-          RO: { name: "罗马尼亚", nameEn: "Romania", flag: "🇷🇴", region: "欧洲" },
-          BG: { name: "保加利亚", nameEn: "Bulgaria", flag: "🇧🇬", region: "欧洲" },
-
-          // Americas
-          US: { name: "美国", nameEn: "United States", flag: "🇺🇸", region: "美洲" },
-          CA: { name: "加拿大", nameEn: "Canada", flag: "🇨🇦", region: "美洲" },
-          MX: { name: "墨西哥", nameEn: "Mexico", flag: "🇲🇽", region: "美洲" },
-          BR: { name: "巴西", nameEn: "Brazil", flag: "🇧🇷", region: "美洲" },
-          AR: { name: "阿根廷", nameEn: "Argentina", flag: "🇦🇷", region: "美洲" },
-          CL: { name: "智利", nameEn: "Chile", flag: "🇨🇱", region: "美洲" },
-          PE: { name: "秘鲁", nameEn: "Peru", flag: "🇵🇪", region: "美洲" },
-          CO: { name: "哥伦比亚", nameEn: "Colombia", flag: "🇨🇴", region: "美洲" },
-          EC: { name: "厄瓜多尔", nameEn: "Ecuador", flag: "🇪🇨", region: "美洲" },
-          CU: { name: "古巴", nameEn: "Cuba", flag: "🇨🇺", region: "美洲" },
-          PA: { name: "巴拿马", nameEn: "Panama", flag: "🇵🇦", region: "美洲" },
-          CR: { name: "哥斯达黎加", nameEn: "Costa Rica", flag: "🇨🇷", region: "美洲" },
+          // Americas - Visa Required
+          US: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 180,
+            notes: ["需申请B1/B2签证", "面签必须", "建议提前3个月预约"]
+          },
+          CA: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 180,
+            notes: ["需申请访客签证", "可在线申请", "持有效美签可简化申请"]
+          },
+          MX: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 180,
+            notes: ["持有效美签可免签入境", "或需申请墨西哥签证"]
+          },
+          BR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需提前申请签证", "可申请电子签"]
+          },
+          AR: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需提前申请签证", "持有效美签可申请AVE电子授权"]
+          },
+          CL: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["持有效美签可免签", "或需申请签证"] },
+          PE: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 183,
+            notes: ["持有效美签/申根签可免签", "或需申请签证"]
+          },
+          CO: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 90,
+            notes: ["持有效美签/申根签可免签", "或需申请签证"]
+          },
+          CU: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 25,
+            notes: ["需购买旅游卡", "费用约25美元"]
+          },
+          PA: { type: VISA_TYPES.VISA_FREE, days: 180, notes: ["持有效美签可免签入境"] },
+          CR: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["持有效美签/申根签可免签"] },
 
           // Oceania
-          AU: { name: "澳大利亚", nameEn: "Australia", flag: "🇦🇺", region: "大洋洲" },
-          NZ: { name: "新西兰", nameEn: "New Zealand", flag: "🇳🇿", region: "大洋洲" },
-          FJ: { name: "斐济", nameEn: "Fiji", flag: "🇫🇯", region: "大洋洲" },
-          WS: { name: "萨摩亚", nameEn: "Samoa", flag: "🇼🇸", region: "大洋洲" },
-          TO: { name: "汤加", nameEn: "Tonga", flag: "🇹🇴", region: "大洋洲" },
-          VU: { name: "瓦努阿图", nameEn: "Vanuatu", flag: "🇻🇺", region: "大洋洲" },
-          PG: { name: "巴布亚新几内亚", nameEn: "Papua New Guinea", flag: "🇵🇬", region: "大洋洲" },
+          AU: {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 90,
+            notes: ["需申请访客签证(600类)", "可在线申请", "处理时间约20天"]
+          },
+          NZ: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需申请访客签证", "可在线申请"] },
+          FJ: { type: VISA_TYPES.VISA_FREE, days: 120, notes: ["免签入境", "可停留120天"] },
+          WS: { type: VISA_TYPES.VISA_FREE, days: 60, notes: ["免签入境", "可停留60天"] },
+          TO: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          VU: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          PG: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 60,
+            fee: 100,
+            notes: ["落地签费用约100基那"]
+          },
 
-          // Africa
-          EG: { name: "埃及", nameEn: "Egypt", flag: "🇪🇬", region: "非洲" },
-          MA: { name: "摩洛哥", nameEn: "Morocco", flag: "🇲🇦", region: "非洲" },
-          TN: { name: "突尼斯", nameEn: "Tunisia", flag: "🇹🇳", region: "非洲" },
-          DZ: { name: "阿尔及利亚", nameEn: "Algeria", flag: "🇩🇿", region: "非洲" },
-          ZA: { name: "南非", nameEn: "South Africa", flag: "🇿🇦", region: "非洲" },
-          KE: { name: "肯尼亚", nameEn: "Kenya", flag: "🇰🇪", region: "非洲" },
-          TZ: { name: "坦桑尼亚", nameEn: "Tanzania", flag: "🇹🇿", region: "非洲" },
-          ET: { name: "埃塞俄比亚", nameEn: "Ethiopia", flag: "🇪🇹", region: "非洲" },
-          NG: { name: "尼日利亚", nameEn: "Nigeria", flag: "🇳🇬", region: "非洲" },
-          GH: { name: "加纳", nameEn: "Ghana", flag: "🇬🇭", region: "非洲" },
-          SN: { name: "塞内加尔", nameEn: "Senegal", flag: "🇸🇳", region: "非洲" },
-          CI: { name: "科特迪瓦", nameEn: "Ivory Coast", flag: "🇨🇮", region: "非洲" },
-          MU: { name: "毛里求斯", nameEn: "Mauritius", flag: "🇲🇺", region: "非洲" },
-          SC: { name: "塞舌尔", nameEn: "Seychelles", flag: "🇸🇨", region: "非洲" },
-          MG: { name: "马达加斯加", nameEn: "Madagascar", flag: "🇲🇬", region: "非洲" },
-          RW: { name: "卢旺达", nameEn: "Rwanda", flag: "🇷🇼", region: "非洲" },
-          UG: { name: "乌干达", nameEn: "Uganda", flag: "🇺🇬", region: "非洲" },
-          ZM: { name: "赞比亚", nameEn: "Zambia", flag: "🇿🇲", region: "非洲" },
-          ZW: { name: "津巴布韦", nameEn: "Zimbabwe", flag: "🇿🇼", region: "非洲" },
-          BW: { name: "博茨瓦纳", nameEn: "Botswana", flag: "🇧🇼", region: "非洲" },
-          NA: { name: "纳米比亚", nameEn: "Namibia", flag: "🇳🇦", region: "非洲" },
-          AO: { name: "安哥拉", nameEn: "Angola", flag: "🇦🇴", region: "非洲" }
-        };
+          // Africa - Visa Free
+          MU: { type: VISA_TYPES.VISA_FREE, days: 60, notes: ["免签入境", "可停留60天"] },
+          SC: { type: VISA_TYPES.VISA_FREE, days: 30, notes: ["免签入境", "可停留30天"] },
+          MA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
+          TN: {
+            type: VISA_TYPES.VISA_FREE,
+            days: 90,
+            notes: ["团队旅游免签", "需有返程机票和酒店预订"]
+          },
+          ZA: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
+          BW: { type: VISA_TYPES.VISA_FREE, days: 90, notes: ["免签入境", "可停留90天"] },
 
-        // Popular destinations for quick selection
-        var POPULAR_DESTINATIONS = [
-          "JP",
-          "KR",
-          "TH",
-          "SG",
-          "MY",
-          "US",
-          "AU",
-          "GB",
-          "FR",
-          "DE",
-          "IT",
-          "MV",
-          "AE",
-          "NZ"
-        ];
+          // Africa - Visa on Arrival
+          EG: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 25,
+            notes: ["落地签费用约25美元", "仅限特定口岸"]
+          },
+          KE: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 90,
+            fee: 50,
+            notes: ["建议申请电子签", "落地签费用约50美元"]
+          },
+          TZ: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 90,
+            fee: 50,
+            notes: ["落地签费用约50美元", "可在线申请电子签"]
+          },
+          ET: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 52,
+            notes: ["仅限亚的斯亚贝巴机场", "费用约52美元"]
+          },
+          MG: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 90,
+            fee: 35,
+            notes: ["落地签费用约35美元"]
+          },
+          RW: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 30,
+            notes: ["落地签费用约30美元"]
+          },
+          UG: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 90,
+            fee: 50,
+            notes: ["建议申请电子签", "落地签费用约50美元"]
+          },
+          ZM: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 90,
+            fee: 50,
+            notes: ["落地签费用约50美元"]
+          },
+          ZW: {
+            type: VISA_TYPES.VISA_ON_ARRIVAL,
+            days: 30,
+            fee: 30,
+            notes: ["落地签费用约30美元", "可申请KAZA签证"]
+          },
 
-        // Passport country data
-        var PASSPORT_COUNTRIES = {
-          CN: { name: "中国", nameEn: "China", flag: "🇨🇳" },
-          HK: { name: "中国香港", nameEn: "Hong Kong SAR", flag: "🇭🇰" },
-          MO: { name: "中国澳门", nameEn: "Macau SAR", flag: "🇲🇴" },
-          TW: { name: "中国台湾", nameEn: "Taiwan", flag: "🇹🇼" }
-        };
-
-        var LS_KEY = "visa_checker_state_v1";
-
-        // Theme toggle
-        function toggleTheme() {
-          var body = document.body;
-          var isDark = body.getAttribute("data-theme") !== "light";
-          body.setAttribute("data-theme", isDark ? "light" : "dark");
-          localStorage.setItem("theme", isDark ? "light" : "dark");
+          // Africa - Visa Required
+          NG: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          GH: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          SN: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          CI: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          DZ: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          AO: { type: VISA_TYPES.VISA_REQUIRED, days: 30, notes: ["需提前申请签证"] },
+          NA: { type: VISA_TYPES.VISA_REQUIRED, days: 90, notes: ["需提前申请签证"] }
         }
+      };
 
-        // Load theme
-        (function () {
-          var saved = localStorage.getItem("theme");
-          if (saved === "light") {
-            document.body.setAttribute("data-theme", "light");
+      // Country data with names and flags
+      var COUNTRIES = {
+        // Asia
+        JP: { name: "日本", nameEn: "Japan", flag: "🇯🇵", region: "亚洲" },
+        KR: { name: "韩国", nameEn: "South Korea", flag: "🇰🇷", region: "亚洲" },
+        SG: { name: "新加坡", nameEn: "Singapore", flag: "🇸🇬", region: "亚洲" },
+        TH: { name: "泰国", nameEn: "Thailand", flag: "🇹🇭", region: "亚洲" },
+        MY: { name: "马来西亚", nameEn: "Malaysia", flag: "🇲🇾", region: "亚洲" },
+        VN: { name: "越南", nameEn: "Vietnam", flag: "🇻🇳", region: "亚洲" },
+        KH: { name: "柬埔寨", nameEn: "Cambodia", flag: "🇰🇭", region: "亚洲" },
+        LA: { name: "老挝", nameEn: "Laos", flag: "🇱🇦", region: "亚洲" },
+        MM: { name: "缅甸", nameEn: "Myanmar", flag: "🇲🇲", region: "亚洲" },
+        PH: { name: "菲律宾", nameEn: "Philippines", flag: "🇵🇭", region: "亚洲" },
+        ID: { name: "印度尼西亚", nameEn: "Indonesia", flag: "🇮🇩", region: "亚洲" },
+        BN: { name: "文莱", nameEn: "Brunei", flag: "🇧🇳", region: "亚洲" },
+        IN: { name: "印度", nameEn: "India", flag: "🇮🇳", region: "亚洲" },
+        NP: { name: "尼泊尔", nameEn: "Nepal", flag: "🇳🇵", region: "亚洲" },
+        LK: { name: "斯里兰卡", nameEn: "Sri Lanka", flag: "🇱🇰", region: "亚洲" },
+        MV: { name: "马尔代夫", nameEn: "Maldives", flag: "🇲🇻", region: "亚洲" },
+        BD: { name: "孟加拉国", nameEn: "Bangladesh", flag: "🇧🇩", region: "亚洲" },
+        PK: { name: "巴基斯坦", nameEn: "Pakistan", flag: "🇵🇰", region: "亚洲" },
+        AE: { name: "阿联酋", nameEn: "UAE", flag: "🇦🇪", region: "亚洲" },
+        QA: { name: "卡塔尔", nameEn: "Qatar", flag: "🇶🇦", region: "亚洲" },
+        SA: { name: "沙特阿拉伯", nameEn: "Saudi Arabia", flag: "🇸🇦", region: "亚洲" },
+        KW: { name: "科威特", nameEn: "Kuwait", flag: "🇰🇼", region: "亚洲" },
+        BH: { name: "巴林", nameEn: "Bahrain", flag: "🇧🇭", region: "亚洲" },
+        OM: { name: "阿曼", nameEn: "Oman", flag: "🇴🇲", region: "亚洲" },
+        JO: { name: "约旦", nameEn: "Jordan", flag: "🇯🇴", region: "亚洲" },
+        IL: { name: "以色列", nameEn: "Israel", flag: "🇮🇱", region: "亚洲" },
+        IR: { name: "伊朗", nameEn: "Iran", flag: "🇮🇷", region: "亚洲" },
+        IQ: { name: "伊拉克", nameEn: "Iraq", flag: "🇮🇶", region: "亚洲" },
+        SY: { name: "叙利亚", nameEn: "Syria", flag: "🇸🇾", region: "亚洲" },
+        YE: { name: "也门", nameEn: "Yemen", flag: "🇾🇪", region: "亚洲" },
+        AF: { name: "阿富汗", nameEn: "Afghanistan", flag: "🇦🇫", region: "亚洲" },
+        KZ: { name: "哈萨克斯坦", nameEn: "Kazakhstan", flag: "🇰🇿", region: "亚洲" },
+        UZ: { name: "乌兹别克斯坦", nameEn: "Uzbekistan", flag: "🇺🇿", region: "亚洲" },
+        TJ: { name: "塔吉克斯坦", nameEn: "Tajikistan", flag: "🇹🇯", region: "亚洲" },
+        KG: { name: "吉尔吉斯斯坦", nameEn: "Kyrgyzstan", flag: "🇰🇬", region: "亚洲" },
+        TM: { name: "土库曼斯坦", nameEn: "Turkmenistan", flag: "🇹🇲", region: "亚洲" },
+        GE: { name: "格鲁吉亚", nameEn: "Georgia", flag: "🇬🇪", region: "亚洲" },
+        AM: { name: "亚美尼亚", nameEn: "Armenia", flag: "🇦🇲", region: "亚洲" },
+        AZ: { name: "阿塞拜疆", nameEn: "Azerbaijan", flag: "🇦🇿", region: "亚洲" },
+        BT: { name: "不丹", nameEn: "Bhutan", flag: "🇧🇹", region: "亚洲" },
+        KP: { name: "朝鲜", nameEn: "North Korea", flag: "🇰🇵", region: "亚洲" },
+
+        // Europe
+        GB: { name: "英国", nameEn: "United Kingdom", flag: "🇬🇧", region: "欧洲" },
+        FR: { name: "法国", nameEn: "France", flag: "🇫🇷", region: "欧洲" },
+        DE: { name: "德国", nameEn: "Germany", flag: "🇩🇪", region: "欧洲" },
+        IT: { name: "意大利", nameEn: "Italy", flag: "🇮🇹", region: "欧洲" },
+        ES: { name: "西班牙", nameEn: "Spain", flag: "🇪🇸", region: "欧洲" },
+        PT: { name: "葡萄牙", nameEn: "Portugal", flag: "🇵🇹", region: "欧洲" },
+        NL: { name: "荷兰", nameEn: "Netherlands", flag: "🇳🇱", region: "欧洲" },
+        BE: { name: "比利时", nameEn: "Belgium", flag: "🇧🇪", region: "欧洲" },
+        AT: { name: "奥地利", nameEn: "Austria", flag: "🇦🇹", region: "欧洲" },
+        CH: { name: "瑞士", nameEn: "Switzerland", flag: "🇨🇭", region: "欧洲" },
+        GR: { name: "希腊", nameEn: "Greece", flag: "🇬🇷", region: "欧洲" },
+        SE: { name: "瑞典", nameEn: "Sweden", flag: "🇸🇪", region: "欧洲" },
+        NO: { name: "挪威", nameEn: "Norway", flag: "🇳🇴", region: "欧洲" },
+        DK: { name: "丹麦", nameEn: "Denmark", flag: "🇩🇰", region: "欧洲" },
+        FI: { name: "芬兰", nameEn: "Finland", flag: "🇫🇮", region: "欧洲" },
+        PL: { name: "波兰", nameEn: "Poland", flag: "🇵🇱", region: "欧洲" },
+        CZ: { name: "捷克", nameEn: "Czech Republic", flag: "🇨🇿", region: "欧洲" },
+        HU: { name: "匈牙利", nameEn: "Hungary", flag: "🇭🇺", region: "欧洲" },
+        IE: { name: "爱尔兰", nameEn: "Ireland", flag: "🇮🇪", region: "欧洲" },
+        RU: { name: "俄罗斯", nameEn: "Russia", flag: "🇷🇺", region: "欧洲" },
+        UA: { name: "乌克兰", nameEn: "Ukraine", flag: "🇺🇦", region: "欧洲" },
+        TR: { name: "土耳其", nameEn: "Turkey", flag: "🇹🇷", region: "欧洲" },
+        RS: { name: "塞尔维亚", nameEn: "Serbia", flag: "🇷🇸", region: "欧洲" },
+        HR: { name: "克罗地亚", nameEn: "Croatia", flag: "🇭🇷", region: "欧洲" },
+        BA: { name: "波黑", nameEn: "Bosnia", flag: "🇧🇦", region: "欧洲" },
+        ME: { name: "黑山", nameEn: "Montenegro", flag: "🇲🇪", region: "欧洲" },
+        AL: { name: "阿尔巴尼亚", nameEn: "Albania", flag: "🇦🇱", region: "欧洲" },
+        MK: { name: "北马其顿", nameEn: "North Macedonia", flag: "🇲🇰", region: "欧洲" },
+        BY: { name: "白俄罗斯", nameEn: "Belarus", flag: "🇧🇾", region: "欧洲" },
+        RO: { name: "罗马尼亚", nameEn: "Romania", flag: "🇷🇴", region: "欧洲" },
+        BG: { name: "保加利亚", nameEn: "Bulgaria", flag: "🇧🇬", region: "欧洲" },
+
+        // Americas
+        US: { name: "美国", nameEn: "United States", flag: "🇺🇸", region: "美洲" },
+        CA: { name: "加拿大", nameEn: "Canada", flag: "🇨🇦", region: "美洲" },
+        MX: { name: "墨西哥", nameEn: "Mexico", flag: "🇲🇽", region: "美洲" },
+        BR: { name: "巴西", nameEn: "Brazil", flag: "🇧🇷", region: "美洲" },
+        AR: { name: "阿根廷", nameEn: "Argentina", flag: "🇦🇷", region: "美洲" },
+        CL: { name: "智利", nameEn: "Chile", flag: "🇨🇱", region: "美洲" },
+        PE: { name: "秘鲁", nameEn: "Peru", flag: "🇵🇪", region: "美洲" },
+        CO: { name: "哥伦比亚", nameEn: "Colombia", flag: "🇨🇴", region: "美洲" },
+        EC: { name: "厄瓜多尔", nameEn: "Ecuador", flag: "🇪🇨", region: "美洲" },
+        CU: { name: "古巴", nameEn: "Cuba", flag: "🇨🇺", region: "美洲" },
+        PA: { name: "巴拿马", nameEn: "Panama", flag: "🇵🇦", region: "美洲" },
+        CR: { name: "哥斯达黎加", nameEn: "Costa Rica", flag: "🇨🇷", region: "美洲" },
+
+        // Oceania
+        AU: { name: "澳大利亚", nameEn: "Australia", flag: "🇦🇺", region: "大洋洲" },
+        NZ: { name: "新西兰", nameEn: "New Zealand", flag: "🇳🇿", region: "大洋洲" },
+        FJ: { name: "斐济", nameEn: "Fiji", flag: "🇫🇯", region: "大洋洲" },
+        WS: { name: "萨摩亚", nameEn: "Samoa", flag: "🇼🇸", region: "大洋洲" },
+        TO: { name: "汤加", nameEn: "Tonga", flag: "🇹🇴", region: "大洋洲" },
+        VU: { name: "瓦努阿图", nameEn: "Vanuatu", flag: "🇻🇺", region: "大洋洲" },
+        PG: { name: "巴布亚新几内亚", nameEn: "Papua New Guinea", flag: "🇵🇬", region: "大洋洲" },
+
+        // Africa
+        EG: { name: "埃及", nameEn: "Egypt", flag: "🇪🇬", region: "非洲" },
+        MA: { name: "摩洛哥", nameEn: "Morocco", flag: "🇲🇦", region: "非洲" },
+        TN: { name: "突尼斯", nameEn: "Tunisia", flag: "🇹🇳", region: "非洲" },
+        DZ: { name: "阿尔及利亚", nameEn: "Algeria", flag: "🇩🇿", region: "非洲" },
+        ZA: { name: "南非", nameEn: "South Africa", flag: "🇿🇦", region: "非洲" },
+        KE: { name: "肯尼亚", nameEn: "Kenya", flag: "🇰🇪", region: "非洲" },
+        TZ: { name: "坦桑尼亚", nameEn: "Tanzania", flag: "🇹🇿", region: "非洲" },
+        ET: { name: "埃塞俄比亚", nameEn: "Ethiopia", flag: "🇪🇹", region: "非洲" },
+        NG: { name: "尼日利亚", nameEn: "Nigeria", flag: "🇳🇬", region: "非洲" },
+        GH: { name: "加纳", nameEn: "Ghana", flag: "🇬🇭", region: "非洲" },
+        SN: { name: "塞内加尔", nameEn: "Senegal", flag: "🇸🇳", region: "非洲" },
+        CI: { name: "科特迪瓦", nameEn: "Ivory Coast", flag: "🇨🇮", region: "非洲" },
+        MU: { name: "毛里求斯", nameEn: "Mauritius", flag: "🇲🇺", region: "非洲" },
+        SC: { name: "塞舌尔", nameEn: "Seychelles", flag: "🇸🇨", region: "非洲" },
+        MG: { name: "马达加斯加", nameEn: "Madagascar", flag: "🇲🇬", region: "非洲" },
+        RW: { name: "卢旺达", nameEn: "Rwanda", flag: "🇷🇼", region: "非洲" },
+        UG: { name: "乌干达", nameEn: "Uganda", flag: "🇺🇬", region: "非洲" },
+        ZM: { name: "赞比亚", nameEn: "Zambia", flag: "🇿🇲", region: "非洲" },
+        ZW: { name: "津巴布韦", nameEn: "Zimbabwe", flag: "🇿🇼", region: "非洲" },
+        BW: { name: "博茨瓦纳", nameEn: "Botswana", flag: "🇧🇼", region: "非洲" },
+        NA: { name: "纳米比亚", nameEn: "Namibia", flag: "🇳🇦", region: "非洲" },
+        AO: { name: "安哥拉", nameEn: "Angola", flag: "🇦🇴", region: "非洲" }
+      };
+
+      // Popular destinations for quick selection
+      var POPULAR_DESTINATIONS = [
+        "JP",
+        "KR",
+        "TH",
+        "SG",
+        "MY",
+        "US",
+        "AU",
+        "GB",
+        "FR",
+        "DE",
+        "IT",
+        "MV",
+        "AE",
+        "NZ"
+      ];
+
+      // Passport country data
+      var PASSPORT_COUNTRIES = {
+        CN: { name: "中国", nameEn: "China", flag: "🇨🇳" },
+        HK: { name: "中国香港", nameEn: "Hong Kong SAR", flag: "🇭🇰" },
+        MO: { name: "中国澳门", nameEn: "Macau SAR", flag: "🇲🇴" },
+        TW: { name: "中国台湾", nameEn: "Taiwan", flag: "🇹🇼" }
+      };
+
+      var LS_KEY = "visa_checker_state_v1";
+
+      // Theme toggle
+      function toggleTheme() {
+        var body = document.body;
+        var isDark = body.getAttribute("data-theme") !== "light";
+        body.setAttribute("data-theme", isDark ? "light" : "dark");
+        localStorage.setItem("theme", isDark ? "light" : "dark");
+      }
+
+      // Load theme
+      (function () {
+        var saved = localStorage.getItem("theme");
+        if (saved === "light") {
+          document.body.setAttribute("data-theme", "light");
+        }
+      })();
+
+      // Toast notification
+      function showToast(msg, isError) {
+        var toast = document.getElementById("toast");
+        toast.textContent = msg;
+        toast.className = "toast" + (isError ? " error" : "");
+        toast.classList.add("show");
+        setTimeout(function () {
+          toast.classList.remove("show");
+        }, 2000);
+      }
+
+      // Initialize destination select
+      function initDestinationSelect() {
+        var select = document.getElementById("destinationCountry");
+
+        // Group countries by region
+        var regions = {};
+        Object.keys(COUNTRIES).forEach(function (code) {
+          var country = COUNTRIES[code];
+          if (!regions[country.region]) {
+            regions[country.region] = [];
           }
-        })();
+          regions[country.region].push({ code: code, country: country });
+        });
 
-        // Toast notification
-        function showToast(msg, isError) {
-          var toast = document.getElementById("toast");
-          toast.textContent = msg;
-          toast.className = "toast" + (isError ? " error" : "");
-          toast.classList.add("show");
-          setTimeout(function () {
-            toast.classList.remove("show");
-          }, 2000);
-        }
+        // Sort regions
+        var regionOrder = ["亚洲", "欧洲", "美洲", "大洋洲", "非洲"];
 
-        // Initialize destination select
-        function initDestinationSelect() {
-          var select = document.getElementById("destinationCountry");
+        regionOrder.forEach(function (regionName) {
+          if (regions[regionName]) {
+            var optgroup = document.createElement("optgroup");
+            optgroup.label = regionName;
 
-          // Group countries by region
-          var regions = {};
-          Object.keys(COUNTRIES).forEach(function (code) {
-            var country = COUNTRIES[code];
-            if (!regions[country.region]) {
-              regions[country.region] = [];
-            }
-            regions[country.region].push({ code: code, country: country });
-          });
+            // Sort countries within region by name
+            regions[regionName].sort(function (a, b) {
+              return a.country.name.localeCompare(b.country.name, "zh-CN");
+            });
 
-          // Sort regions
-          var regionOrder = ["亚洲", "欧洲", "美洲", "大洋洲", "非洲"];
+            regions[regionName].forEach(function (item) {
+              var option = document.createElement("option");
+              option.value = item.code;
+              option.textContent =
+                item.country.flag + " " + item.country.name + " (" + item.country.nameEn + ")";
+              optgroup.appendChild(option);
+            });
 
-          regionOrder.forEach(function (regionName) {
-            if (regions[regionName]) {
-              var optgroup = document.createElement("optgroup");
-              optgroup.label = regionName;
-
-              // Sort countries within region by name
-              regions[regionName].sort(function (a, b) {
-                return a.country.name.localeCompare(b.country.name, "zh-CN");
-              });
-
-              regions[regionName].forEach(function (item) {
-                var option = document.createElement("option");
-                option.value = item.code;
-                option.textContent =
-                  item.country.flag + " " + item.country.name + " (" + item.country.nameEn + ")";
-                optgroup.appendChild(option);
-              });
-
-              select.appendChild(optgroup);
-            }
-          });
-        }
-
-        // Initialize popular destinations buttons
-        function initPopularDestinations() {
-          var container = document.getElementById("popularDestinations");
-
-          POPULAR_DESTINATIONS.forEach(function (code) {
-            var country = COUNTRIES[code];
-            if (country) {
-              var btn = document.createElement("button");
-              btn.className = "dest-btn";
-
-              var flagSpan = document.createElement("span");
-              flagSpan.className = "flag";
-              flagSpan.textContent = country.flag;
-              btn.appendChild(flagSpan);
-
-              var nameText = document.createTextNode(country.name);
-              btn.appendChild(nameText);
-
-              btn.onclick = function () {
-                document.getElementById("destinationCountry").value = code;
-                checkVisa();
-              };
-              container.appendChild(btn);
-            }
-          });
-        }
-
-        // Get visa type label
-        function getVisaTypeLabel(type) {
-          switch (type) {
-            case VISA_TYPES.VISA_FREE:
-              return "免签";
-            case VISA_TYPES.VISA_ON_ARRIVAL:
-              return "落地签";
-            case VISA_TYPES.E_VISA:
-              return "电子签证";
-            case VISA_TYPES.VISA_REQUIRED:
-              return "需要签证";
-            default:
-              return "未知";
+            select.appendChild(optgroup);
           }
-        }
+        });
+      }
 
-        // Get visa type icon
-        function getVisaTypeIcon(type) {
-          switch (type) {
-            case VISA_TYPES.VISA_FREE:
-              return "✓";
-            case VISA_TYPES.VISA_ON_ARRIVAL:
-              return "🛬";
-            case VISA_TYPES.E_VISA:
-              return "💻";
-            case VISA_TYPES.VISA_REQUIRED:
-              return "📝";
-            default:
-              return "?";
-          }
-        }
+      // Initialize popular destinations buttons
+      function initPopularDestinations() {
+        var container = document.getElementById("popularDestinations");
 
-        // Create detail item element
-        function createDetailItem(label, value, isHighlight) {
-          var item = document.createElement("div");
-          item.className = "detail-item";
+        POPULAR_DESTINATIONS.forEach(function (code) {
+          var country = COUNTRIES[code];
+          if (country) {
+            var btn = document.createElement("button");
+            btn.className = "dest-btn";
 
-          var labelEl = document.createElement("span");
-          labelEl.className = "detail-label";
-          labelEl.textContent = label;
-          item.appendChild(labelEl);
+            var flagSpan = document.createElement("span");
+            flagSpan.className = "flag";
+            flagSpan.textContent = country.flag;
+            btn.appendChild(flagSpan);
 
-          var valueEl = document.createElement("span");
-          valueEl.className = "detail-value" + (isHighlight ? " highlight" : "");
-          valueEl.textContent = value;
-          item.appendChild(valueEl);
+            var nameText = document.createTextNode(country.name);
+            btn.appendChild(nameText);
 
-          return item;
-        }
-
-        // Check visa requirement
-        function checkVisa() {
-          var passportCode = document.getElementById("passportCountry").value;
-          var destCode = document.getElementById("destinationCountry").value;
-
-          if (!destCode) {
-            showToast("请选择目的地国家", true);
-            return;
-          }
-
-          var passport = PASSPORT_COUNTRIES[passportCode];
-          var destination = COUNTRIES[destCode];
-          var visaData = VISA_DATA[passportCode] && VISA_DATA[passportCode][destCode];
-
-          if (!visaData) {
-            // Default to visa required if no data
-            visaData = {
-              type: VISA_TYPES.VISA_REQUIRED,
-              days: 30,
-              notes: ["暂无详细数据", "请查阅官方渠道获取最新信息"]
+            btn.onclick = function () {
+              document.getElementById("destinationCountry").value = code;
+              checkVisa();
             };
+            container.appendChild(btn);
           }
+        });
+      }
 
-          // Update result card
-          document.getElementById("fromCountry").textContent = passport.flag + " " + passport.name;
-          document.getElementById("toCountry").textContent =
-            destination.flag + " " + destination.name;
+      // Get visa type label
+      function getVisaTypeLabel(type) {
+        switch (type) {
+          case VISA_TYPES.VISA_FREE:
+            return "免签";
+          case VISA_TYPES.VISA_ON_ARRIVAL:
+            return "落地签";
+          case VISA_TYPES.E_VISA:
+            return "电子签证";
+          case VISA_TYPES.VISA_REQUIRED:
+            return "需要签证";
+          default:
+            return "未知";
+        }
+      }
 
-          // Update badge
-          var badge = document.getElementById("visaBadge");
-          badge.className = "visa-badge " + visaData.type;
-          badge.textContent = getVisaTypeIcon(visaData.type) + " " + getVisaTypeLabel(visaData.type);
+      // Get visa type icon
+      function getVisaTypeIcon(type) {
+        switch (type) {
+          case VISA_TYPES.VISA_FREE:
+            return "✓";
+          case VISA_TYPES.VISA_ON_ARRIVAL:
+            return "🛬";
+          case VISA_TYPES.E_VISA:
+            return "💻";
+          case VISA_TYPES.VISA_REQUIRED:
+            return "📝";
+          default:
+            return "?";
+        }
+      }
 
-          // Build details using safe DOM methods
-          var detailsContainer = document.getElementById("resultDetails");
-          // Clear existing content
-          while (detailsContainer.firstChild) {
-            detailsContainer.removeChild(detailsContainer.firstChild);
-          }
+      // Create detail item element
+      function createDetailItem(label, value, isHighlight) {
+        var item = document.createElement("div");
+        item.className = "detail-item";
 
-          detailsContainer.appendChild(
-            createDetailItem("签证类型", getVisaTypeLabel(visaData.type), true)
-          );
+        var labelEl = document.createElement("span");
+        labelEl.className = "detail-label";
+        labelEl.textContent = label;
+        item.appendChild(labelEl);
 
-          if (visaData.days) {
-            detailsContainer.appendChild(createDetailItem("停留天数", visaData.days + " 天", false));
-          }
+        var valueEl = document.createElement("span");
+        valueEl.className = "detail-value" + (isHighlight ? " highlight" : "");
+        valueEl.textContent = value;
+        item.appendChild(valueEl);
 
-          if (visaData.fee !== undefined) {
-            detailsContainer.appendChild(
-              createDetailItem("签证费用", "约 " + visaData.fee + " 美元", false)
-            );
-          }
+        return item;
+      }
 
-          detailsContainer.appendChild(
-            createDetailItem("目的地", destination.name + " (" + destination.nameEn + ")", false)
-          );
-          detailsContainer.appendChild(createDetailItem("所属地区", destination.region, false));
+      // Check visa requirement
+      function checkVisa() {
+        var passportCode = document.getElementById("passportCountry").value;
+        var destCode = document.getElementById("destinationCountry").value;
 
-          // Update notes
-          var notesList = document.getElementById("notesList");
-          // Clear existing notes
-          while (notesList.firstChild) {
-            notesList.removeChild(notesList.firstChild);
-          }
-
-          if (visaData.notes && visaData.notes.length > 0) {
-            visaData.notes.forEach(function (note) {
-              var li = document.createElement("li");
-              li.textContent = note;
-              notesList.appendChild(li);
-            });
-            document.getElementById("notesSection").style.display = "block";
-          } else {
-            document.getElementById("notesSection").style.display = "none";
-          }
-
-          // Show result card
-          document.getElementById("resultCard").classList.add("show");
-
-          // Save state
-          saveToStorage();
-
-          showToast("查询完成");
+        if (!destCode) {
+          showToast("请选择目的地国家", true);
+          return;
         }
 
-        // Clear selection
-        function clearSelection() {
-          document.getElementById("passportCountry").value = "CN";
-          document.getElementById("destinationCountry").value = "";
-          document.getElementById("resultCard").classList.remove("show");
-          localStorage.removeItem(LS_KEY);
-          history.replaceState(null, "", location.pathname);
-          showToast("已清空");
-        }
+        var passport = PASSPORT_COUNTRIES[passportCode];
+        var destination = COUNTRIES[destCode];
+        var visaData = VISA_DATA[passportCode] && VISA_DATA[passportCode][destCode];
 
-        // Share result
-        function shareResult() {
-          var passportCode = document.getElementById("passportCountry").value;
-          var destCode = document.getElementById("destinationCountry").value;
-
-          if (!destCode) {
-            showToast("请先选择目的地", true);
-            return;
-          }
-
-          var data = { p: passportCode, d: destCode };
-          var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-          history.replaceState(null, "", "#" + encoded);
-
-          navigator.clipboard
-            .writeText(location.href)
-            .then(function () {
-              showToast("链接已复制到剪贴板");
-            })
-            .catch(function () {
-              showToast("请手动复制地址栏链接");
-            });
-        }
-
-        // Save to storage
-        function saveToStorage() {
-          var data = {
-            passport: document.getElementById("passportCountry").value,
-            destination: document.getElementById("destinationCountry").value
+        if (!visaData) {
+          // Default to visa required if no data
+          visaData = {
+            type: VISA_TYPES.VISA_REQUIRED,
+            days: 30,
+            notes: ["暂无详细数据", "请查阅官方渠道获取最新信息"]
           };
-          localStorage.setItem(LS_KEY, JSON.stringify(data));
         }
 
-        // Load from storage
-        function loadFromStorage() {
-          var saved = localStorage.getItem(LS_KEY);
-          if (!saved) return false;
+        // Update result card
+        document.getElementById("fromCountry").textContent = passport.flag + " " + passport.name;
+        document.getElementById("toCountry").textContent =
+          destination.flag + " " + destination.name;
 
-          try {
-            var data = JSON.parse(saved);
-            if (data.passport) {
-              document.getElementById("passportCountry").value = data.passport;
-            }
-            if (data.destination) {
-              document.getElementById("destinationCountry").value = data.destination;
-              checkVisa();
-            }
-            return true;
-          } catch (e) {
-            return false;
-          }
+        // Update badge
+        var badge = document.getElementById("visaBadge");
+        badge.className = "visa-badge " + visaData.type;
+        badge.textContent = getVisaTypeIcon(visaData.type) + " " + getVisaTypeLabel(visaData.type);
+
+        // Build details using safe DOM methods
+        var detailsContainer = document.getElementById("resultDetails");
+        // Clear existing content
+        while (detailsContainer.firstChild) {
+          detailsContainer.removeChild(detailsContainer.firstChild);
         }
 
-        // Load from URL
-        function loadFromUrl() {
-          var hash = location.hash.slice(1);
-          if (!hash) return false;
+        detailsContainer.appendChild(
+          createDetailItem("签证类型", getVisaTypeLabel(visaData.type), true)
+        );
 
-          try {
-            var data = JSON.parse(decodeURIComponent(atob(hash)));
-            if (data.p) {
-              document.getElementById("passportCountry").value = data.p;
-            }
-            if (data.d) {
-              document.getElementById("destinationCountry").value = data.d;
-              checkVisa();
-            }
-            return true;
-          } catch (e) {
-            return false;
-          }
+        if (visaData.days) {
+          detailsContainer.appendChild(createDetailItem("停留天数", visaData.days + " 天", false));
         }
 
-        // Calculate and display stats
-        function calculateStats() {
-          var passportCode = "CN";
-          var visaData = VISA_DATA[passportCode];
+        if (visaData.fee !== undefined) {
+          detailsContainer.appendChild(
+            createDetailItem("签证费用", "约 " + visaData.fee + " 美元", false)
+          );
+        }
 
-          if (!visaData) return;
+        detailsContainer.appendChild(
+          createDetailItem("目的地", destination.name + " (" + destination.nameEn + ")", false)
+        );
+        detailsContainer.appendChild(createDetailItem("所属地区", destination.region, false));
 
-          var stats = {
-            visaFree: 0,
-            visaOnArrival: 0,
-            eVisa: 0,
-            visaRequired: 0
-          };
+        // Update notes
+        var notesList = document.getElementById("notesList");
+        // Clear existing notes
+        while (notesList.firstChild) {
+          notesList.removeChild(notesList.firstChild);
+        }
 
-          Object.keys(visaData).forEach(function (destCode) {
-            var visa = visaData[destCode];
-            switch (visa.type) {
-              case VISA_TYPES.VISA_FREE:
-                stats.visaFree++;
-                break;
-              case VISA_TYPES.VISA_ON_ARRIVAL:
-                stats.visaOnArrival++;
-                break;
-              case VISA_TYPES.E_VISA:
-                stats.eVisa++;
-                break;
-              case VISA_TYPES.VISA_REQUIRED:
-                stats.visaRequired++;
-                break;
-            }
+        if (visaData.notes && visaData.notes.length > 0) {
+          visaData.notes.forEach(function (note) {
+            var li = document.createElement("li");
+            li.textContent = note;
+            notesList.appendChild(li);
           });
-
-          document.getElementById("statVisaFree").textContent = stats.visaFree;
-          document.getElementById("statVisaOnArrival").textContent = stats.visaOnArrival;
-          document.getElementById("statEVisa").textContent = stats.eVisa;
-          document.getElementById("statVisaRequired").textContent = stats.visaRequired;
+          document.getElementById("notesSection").style.display = "block";
+        } else {
+          document.getElementById("notesSection").style.display = "none";
         }
 
-        // Initialize
-        (function init() {
-          initDestinationSelect();
-          initPopularDestinations();
+        // Show result card
+        document.getElementById("resultCard").classList.add("show");
+
+        // Save state
+        saveToStorage();
+
+        showToast("查询完成");
+      }
+
+      // Clear selection
+      function clearSelection() {
+        document.getElementById("passportCountry").value = "CN";
+        document.getElementById("destinationCountry").value = "";
+        document.getElementById("resultCard").classList.remove("show");
+        localStorage.removeItem(LS_KEY);
+        history.replaceState(null, "", location.pathname);
+        showToast("已清空");
+      }
+
+      // Share result
+      function shareResult() {
+        var passportCode = document.getElementById("passportCountry").value;
+        var destCode = document.getElementById("destinationCountry").value;
+
+        if (!destCode) {
+          showToast("请先选择目的地", true);
+          return;
+        }
+
+        var data = { p: passportCode, d: destCode };
+        var encoded = btoa(encodeURIComponent(JSON.stringify(data)));
+        history.replaceState(null, "", "#" + encoded);
+
+        navigator.clipboard
+          .writeText(location.href)
+          .then(function () {
+            showToast("链接已复制到剪贴板");
+          })
+          .catch(function () {
+            showToast("请手动复制地址栏链接");
+          });
+      }
+
+      // Save to storage
+      function saveToStorage() {
+        var data = {
+          passport: document.getElementById("passportCountry").value,
+          destination: document.getElementById("destinationCountry").value
+        };
+        localStorage.setItem(LS_KEY, JSON.stringify(data));
+      }
+
+      // Load from storage
+      function loadFromStorage() {
+        var saved = localStorage.getItem(LS_KEY);
+        if (!saved) return false;
+
+        try {
+          var data = JSON.parse(saved);
+          if (data.passport) {
+            document.getElementById("passportCountry").value = data.passport;
+          }
+          if (data.destination) {
+            document.getElementById("destinationCountry").value = data.destination;
+            checkVisa();
+          }
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // Load from URL
+      function loadFromUrl() {
+        var hash = location.hash.slice(1);
+        if (!hash) return false;
+
+        try {
+          var data = JSON.parse(decodeURIComponent(atob(hash)));
+          if (data.p) {
+            document.getElementById("passportCountry").value = data.p;
+          }
+          if (data.d) {
+            document.getElementById("destinationCountry").value = data.d;
+            checkVisa();
+          }
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      // Calculate and display stats
+      function calculateStats() {
+        var passportCode = "CN";
+        var visaData = VISA_DATA[passportCode];
+
+        if (!visaData) return;
+
+        var stats = {
+          visaFree: 0,
+          visaOnArrival: 0,
+          eVisa: 0,
+          visaRequired: 0
+        };
+
+        Object.keys(visaData).forEach(function (destCode) {
+          var visa = visaData[destCode];
+          switch (visa.type) {
+            case VISA_TYPES.VISA_FREE:
+              stats.visaFree++;
+              break;
+            case VISA_TYPES.VISA_ON_ARRIVAL:
+              stats.visaOnArrival++;
+              break;
+            case VISA_TYPES.E_VISA:
+              stats.eVisa++;
+              break;
+            case VISA_TYPES.VISA_REQUIRED:
+              stats.visaRequired++;
+              break;
+          }
+        });
+
+        document.getElementById("statVisaFree").textContent = stats.visaFree;
+        document.getElementById("statVisaOnArrival").textContent = stats.visaOnArrival;
+        document.getElementById("statEVisa").textContent = stats.eVisa;
+        document.getElementById("statVisaRequired").textContent = stats.visaRequired;
+      }
+
+      // Initialize
+      (function init() {
+        initDestinationSelect();
+        initPopularDestinations();
+        calculateStats();
+
+        if (!loadFromUrl()) {
+          loadFromStorage();
+        }
+
+        // Auto-save on change
+        document.getElementById("passportCountry").addEventListener("change", function () {
           calculateStats();
-
-          if (!loadFromUrl()) {
-            loadFromStorage();
+          if (document.getElementById("destinationCountry").value) {
+            checkVisa();
           }
+        });
+      })();
+    </script>
 
-          // Auto-save on change
-          document.getElementById("passportCountry").addEventListener("change", function () {
-            calculateStats();
-            if (document.getElementById("destinationCountry").value) {
-              checkVisa();
-            }
-          });
-        })();
-</script>
-    
     <!-- 全局 UI 注入 -->
     <script src="../../assets/js/tool-chrome.js"></script>
   </body>


### PR DESCRIPTION
## Summary

- Run `prettier --write` on the 62 tool files touched by the functional QA + JSON-LD + runtime fix PR (#178)
- Pure cosmetic reformatting driven by `.prettierrc` `printWidth: 100` (HTML attribute line-wrapping, JSON-LD re-indentation)
- **No logic changes** — only whitespace/formatting diff
- Brings the changed files into `format:check` compliance without touching the other ~990 historical drift files

## Verification

- `npx prettier --check` on the 62 files: ✅ All matched files use Prettier code style
- `npm run lint` ✅ (HTMLHint + Stylelint + ESLint)
- `npm test` ✅ (59/59)

## Note

The remaining ~990 files in the repo still have historical Prettier drift. This PR intentionally scopes formatting to only the files we modified, per decision to avoid a repo-wide reformat diff. A separate repo-wide format PR can be opened later if desired.