### PR TITLE
ci: 对不可用部署渠道实行显式启用

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   deploy:
-    if: github.ref == 'refs/heads/master'
+    # Render is optional. Enable only after the deploy hook has been revalidated.
+    if: github.ref == 'refs/heads/master' && vars.RENDER_DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   deploy:
-    if: github.ref == 'refs/heads/master'
+    # Surge is optional. Enable only after login, token and domain are all configured.
+    if: github.ref == 'refs/heads/master' && vars.SURGE_DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production


### PR DESCRIPTION
## 结论

将目前不可用的 Render 与 Surge 生产渠道改成显式 opt-in，避免每次 `master` 更新留下已知红灯，同时保留恢复能力。

## 事实

- 合并 #205 后，Render Hook 连续返回 HTTP 404。
- Surge 缺少 `SURGE_LOGIN`，因此无法部署。
- Cloudflare Pages、GitHub Pages、Vercel 与主 Lint 已独立运行，不受本 PR 影响。

## 变化

- 仅当仓库变量 `RENDER_DEPLOY_ENABLED=true` 时运行 Render。
- 仅当仓库变量 `SURGE_DEPLOY_ENABLED=true` 时运行 Surge。
- 重新启用前仍必须核对对应身份、域名和回滚路径。

## 验证

- `actionlint` 通过。
- 仅修改两个工作流的 job 条件，不修改站点代码或现有生产内容。
