### PR TITLE
fix: 为工具页补齐唯一主标题

### DIFF
--- a/assets/css/tool-base.css
+++ b/assets/css/tool-base.css
@@ -400,6 +400,18 @@ summary,
 }
 
 /* ---------- 7. 隐藏旧版页内导航（被悬浮外壳取代）---------- */
+.tool-page-heading {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .breadcrumb,
 nav.nav-bar,
 .theme-toggle {

--- a/scripts/sync-all.js
+++ b/scripts/sync-all.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import { load } from 'cheerio';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -120,7 +121,10 @@ function ensureToolPageHeadings(tools) {
     if (!fs.existsSync(abs)) continue;
 
     const html = fs.readFileSync(abs, 'utf8');
-    if (/<h1\b/i.test(html)) continue;
+    const $ = load(html);
+    $('script, style, template, noscript').remove();
+    const renderedHeadings = $('h1');
+    if (renderedHeadings.length > 0) continue;
 
     const body = /<body\b[^>]*>/i;
     if (!body.test(html)) {

--- a/scripts/sync-all.js
+++ b/scripts/sync-all.js
@@ -106,6 +106,39 @@ function escapeAttr(str) {
   return escapeHtml(str).replace(/"/g, '&quot;');
 }
 
+/**
+ * 为缺少主标题的工具页补充一个可访问但不改变现有布局的 H1。
+ *
+ * 页面名称以 tools.json 为唯一事实源；已有 H1 的页面保持原样。这里使用
+ * 小范围字符串插入而不是 HTML 序列化，避免无关的脚本、样式和格式变化。
+ */
+function ensureToolPageHeadings(tools) {
+  const updated = [];
+
+  for (const tool of tools) {
+    const abs = path.join(ROOT_DIR, tool.path);
+    if (!fs.existsSync(abs)) continue;
+
+    const html = fs.readFileSync(abs, 'utf8');
+    if (/<h1\b/i.test(html)) continue;
+
+    const body = /<body\b[^>]*>/i;
+    if (!body.test(html)) {
+      throw new Error(`无法为 ${tool.path} 补充 H1：缺少 <body>`);
+    }
+
+    const heading = `<h1 class="tool-page-heading">${escapeHtml(tool.name)}</h1>`;
+    const next = html.replace(body, (tag) => `${tag}\n    ${heading}`);
+    fs.writeFileSync(abs, next);
+    updated.push(tool.path);
+  }
+
+  console.log(
+    updated.length > 0 ? `✅ 工具页 H1: 已补充 ${updated.length} 个` : '⏭️  工具页 H1: 无需更新'
+  );
+  return updated;
+}
+
 /** 把对象序列化为可安全内嵌 <script> 的 JSON-LD 文本 */
 function toJsonLd(obj) {
   return JSON.stringify(obj, null, 2).replace(/</g, '\\u003c');
@@ -448,6 +481,7 @@ function main() {
   // 生成分类落地页（须在 sitemap 之前，sitemap 要纳入这些页面的 URL）
   const registeredPaths = new Set(tools.map((t) => t.path));
   const categoryPages = generateCategoryPages(categories, groupedTools, registeredPaths);
+  const toolPageHeadings = ensureToolPageHeadings(tools);
 
   // 执行所有同步
   const results = {
@@ -457,7 +491,8 @@ function main() {
     manifest: updateManifest(toolCount),
     i18n: updateI18n(toolCount),
     llmsTxt: updateLlmsTxt(toolCount, categories, groupedTools, sortedCategories),
-    github: updateGitHubDescription(toolCount)
+    github: updateGitHubDescription(toolCount),
+    toolPageHeadings
   };
 
   // 统计各分类数量
@@ -480,6 +515,9 @@ function main() {
   console.log(`   manifest.json: ${results.manifest ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   i18n:          ${results.i18n ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   llms.txt:      ${results.llmsTxt ? '✅ 已更新' : '⏭️  无变化'}`);
+  console.log(
+    `   工具页 H1:     ${results.toolPageHeadings.length > 0 ? `✅ ${results.toolPageHeadings.length} 个` : '⏭️  无变化'}`
+  );
   console.log(`   GitHub 描述:   ${results.github ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log('='.repeat(50));
 }

--- a/tests/html-structure.test.js
+++ b/tests/html-structure.test.js
@@ -6,6 +6,7 @@
  */
 
 import { section, test, assert, loadToolsData, readHead, readText, SITE } from './_harness.js';
+import { load } from 'cheerio';
 
 section('工具 HTML 结构');
 
@@ -56,13 +57,10 @@ test('每个工具页有且仅有一个非空 H1', () => {
   const bad = tools
     .map((t) => {
       const html = readText(t.path);
-      const headings = html.match(/<h1\b[^>]*>[\s\S]*?<\/h1>/gi) || [];
-      const nonEmpty = headings.filter((heading) =>
-        heading
-          .replace(/<[^>]+>/g, '')
-          .replace(/&nbsp;/gi, ' ')
-          .trim()
-      );
+      const $ = load(html);
+      $('script, style, template, noscript').remove();
+      const headings = $('h1');
+      const nonEmpty = headings.filter((_index, heading) => $(heading).text().trim().length > 0);
       return headings.length === 1 && nonEmpty.length === 1
         ? null
         : `#${t.id} ${t.path}: H1=${headings.length}, 非空=${nonEmpty.length}`;
@@ -70,4 +68,20 @@ test('每个工具页有且仅有一个非空 H1', () => {
     .filter(Boolean);
 
   assert(bad.length === 0, `${bad.length} 个文件未通过:\n${bad.slice(0, 20).join('\n')}`);
+});
+
+test('H1 门禁忽略脚本、注释与惰性模板中的标签文本', () => {
+  const $ = load(`
+    <body>
+      <script>const example = '<h1>脚本示例</h1>';</script>
+      <!-- <h1>注释示例</h1> -->
+      <template><h1>模板示例</h1></template>
+      <h1>真实标题</h1>
+    </body>
+  `);
+  $('script, style, template, noscript').remove();
+  const headings = $('h1');
+
+  assert(headings.length === 1, `期望 1 个真实 H1，实际 ${headings.length}`);
+  assert(headings.first().text() === '真实标题', '错误地把非渲染上下文计为 H1');
 });

--- a/tests/html-structure.test.js
+++ b/tests/html-structure.test.js
@@ -5,7 +5,7 @@
  * 每个检查项遍历全部工具，汇总失败文件后一次性断言，保持输出整洁。
  */
 
-import { section, test, assert, loadToolsData, readHead, SITE } from './_harness.js';
+import { section, test, assert, loadToolsData, readHead, readText, SITE } from './_harness.js';
 
 section('工具 HTML 结构');
 
@@ -51,3 +51,23 @@ checkAll('均含 <meta name="description">', (t) =>
 );
 checkAll('均含 <link rel="canonical">', (t) => canonicalHref(t.head) !== null);
 checkAll('canonical 链接与工具实际路径一致', (t) => canonicalHref(t.head) === `${SITE}/${t.path}`);
+
+test('每个工具页有且仅有一个非空 H1', () => {
+  const bad = tools
+    .map((t) => {
+      const html = readText(t.path);
+      const headings = html.match(/<h1\b[^>]*>[\s\S]*?<\/h1>/gi) || [];
+      const nonEmpty = headings.filter((heading) =>
+        heading
+          .replace(/<[^>]+>/g, '')
+          .replace(/&nbsp;/gi, ' ')
+          .trim()
+      );
+      return headings.length === 1 && nonEmpty.length === 1
+        ? null
+        : `#${t.id} ${t.path}: H1=${headings.length}, 非空=${nonEmpty.length}`;
+    })
+    .filter(Boolean);
+
+  assert(bad.length === 0, `${bad.length} 个文件未通过:\n${bad.slice(0, 20).join('\n')}`);
+});

--- a/tools/calculator/bmi-calculator.html
+++ b/tools/calculator/bmi-calculator.html
@@ -855,6 +855,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">BMI 计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/calculator/function-plotter.html
+++ b/tools/calculator/function-plotter.html
@@ -596,6 +596,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">函数图像绘制器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="sidebar">

--- a/tools/calculator/loan-calculator.html
+++ b/tools/calculator/loan-calculator.html
@@ -837,6 +837,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">贷款计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="card">

--- a/tools/calculator/matrix-calculator.html
+++ b/tools/calculator/matrix-calculator.html
@@ -606,6 +606,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">矩阵计算器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="matrices-row">

--- a/tools/calculator/mortgage-calculator.html
+++ b/tools/calculator/mortgage-calculator.html
@@ -641,6 +641,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">房贷计算器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="input-section">

--- a/tools/calculator/percentage-calculator.html
+++ b/tools/calculator/percentage-calculator.html
@@ -779,6 +779,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">百分比计算</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/calculator/unit-converter.html
+++ b/tools/calculator/unit-converter.html
@@ -867,6 +867,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">单位换算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/converter/area.html
+++ b/tools/converter/area.html
@@ -498,6 +498,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">面积单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/data-size-converter.html
+++ b/tools/converter/data-size-converter.html
@@ -497,6 +497,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">数据存储单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/data-size.html
+++ b/tools/converter/data-size.html
@@ -518,6 +518,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">数据大小转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/length.html
+++ b/tools/converter/length.html
@@ -512,6 +512,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">长度单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/speed.html
+++ b/tools/converter/speed.html
@@ -522,6 +522,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">速度单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/time.html
+++ b/tools/converter/time.html
@@ -507,6 +507,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">时间单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/volume.html
+++ b/tools/converter/volume.html
@@ -498,6 +498,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">体积容量转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/converter/weight.html
+++ b/tools/converter/weight.html
@@ -498,6 +498,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">重量单位转换器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/design/aurora-generator.html
+++ b/tools/design/aurora-generator.html
@@ -394,6 +394,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">极光背景生成器</h1>
     <!-- 页头/面包屑通常由外部嵌入或隐藏，零构建直接呈现核心内容 -->
 
     <main class="layout-container">

--- a/tools/dev/api-mock.html
+++ b/tools/dev/api-mock.html
@@ -578,6 +578,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">API 响应模拟器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/dev/base64.html
+++ b/tools/dev/base64.html
@@ -852,6 +852,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Base64 编解码</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/clipboard-viewer.html
+++ b/tools/dev/clipboard-viewer.html
@@ -759,6 +759,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">剪贴板查看器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/css-sprites.html
+++ b/tools/dev/css-sprites.html
@@ -637,6 +637,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">CSS雪碧图生成器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div

--- a/tools/dev/env-editor.html
+++ b/tools/dev/env-editor.html
@@ -645,6 +645,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">.env 文件编辑器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="editor-grid">

--- a/tools/dev/graphql-playground.html
+++ b/tools/dev/graphql-playground.html
@@ -627,6 +627,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">GraphQL Playground</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="endpoint-bar">

--- a/tools/dev/hash-generator.html
+++ b/tools/dev/hash-generator.html
@@ -904,6 +904,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Hash 生成器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/htaccess-nginx.html
+++ b/tools/dev/htaccess-nginx.html
@@ -512,6 +512,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">htaccess转Nginx</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/dev/js-ast-viewer.html
+++ b/tools/dev/js-ast-viewer.html
@@ -614,6 +614,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">JavaScript AST查看器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="panel">

--- a/tools/dev/js-obfuscator.html
+++ b/tools/dev/js-obfuscator.html
@@ -512,6 +512,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">JS代码混淆</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/dev/json-yaml.html
+++ b/tools/dev/json-yaml.html
@@ -812,6 +812,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">JSON-YAML 转换</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/jwt-decoder.html
+++ b/tools/dev/jwt-decoder.html
@@ -805,6 +805,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">JWT 解码器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/openapi-viewer.html
+++ b/tools/dev/openapi-viewer.html
@@ -691,6 +691,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">OpenAPI/Swagger查看器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="input-section">

--- a/tools/dev/package-json-editor.html
+++ b/tools/dev/package-json-editor.html
@@ -556,6 +556,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">package.json编辑器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="editor-grid">

--- a/tools/dev/sql-playground.html
+++ b/tools/dev/sql-playground.html
@@ -612,6 +612,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">SQL在线执行器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="sidebar">

--- a/tools/dev/svg-optimizer.html
+++ b/tools/dev/svg-optimizer.html
@@ -532,6 +532,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">SVG优化器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/dev/tsconfig-editor.html
+++ b/tools/dev/tsconfig-editor.html
@@ -636,6 +636,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">tsconfig编辑器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="sidebar">

--- a/tools/dev/url-codec.html
+++ b/tools/dev/url-codec.html
@@ -925,6 +925,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">URL 编解码</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/dev/webhook-tester.html
+++ b/tools/dev/webhook-tester.html
@@ -709,6 +709,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Webhook测试器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="section">

--- a/tools/dev/xpath-tester.html
+++ b/tools/dev/xpath-tester.html
@@ -548,6 +548,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">XPath 测试器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/fun/aim-trainer.html
+++ b/tools/fun/aim-trainer.html
@@ -651,6 +651,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">瞄准训练</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats-row">

--- a/tools/fun/coin-flip.html
+++ b/tools/fun/coin-flip.html
@@ -685,6 +685,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">抛硬币</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="coin-area">

--- a/tools/fun/dice-roller.html
+++ b/tools/fun/dice-roller.html
@@ -725,6 +725,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">骰子模拟器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="controls">

--- a/tools/fun/number-memory.html
+++ b/tools/fun/number-memory.html
@@ -626,6 +626,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">数字记忆测试</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats-row">

--- a/tools/fun/reaction-time.html
+++ b/tools/fun/reaction-time.html
@@ -594,6 +594,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">反应时间测试</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats-row">

--- a/tools/fun/sequence-memory.html
+++ b/tools/fun/sequence-memory.html
@@ -608,6 +608,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">序列记忆测试</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats-row">

--- a/tools/fun/what-to-eat.html
+++ b/tools/fun/what-to-eat.html
@@ -660,6 +660,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">今天吃什么</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="main-area">

--- a/tools/fun/wheel-spinner.html
+++ b/tools/fun/wheel-spinner.html
@@ -801,6 +801,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">转盘抽奖</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="wheel-section">

--- a/tools/fun/yes-or-no.html
+++ b/tools/fun/yes-or-no.html
@@ -717,6 +717,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">是或否决策器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="main-area">

--- a/tools/game/breakout-game.html
+++ b/tools/game/breakout-game.html
@@ -480,6 +480,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Breakout Game</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats">

--- a/tools/game/flappy-bird.html
+++ b/tools/game/flappy-bird.html
@@ -476,6 +476,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Flappy Bird</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="score-display">

--- a/tools/game/game-2048.html
+++ b/tools/game/game-2048.html
@@ -702,6 +702,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">2048 游戏</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="score-board">

--- a/tools/game/game-sudoku.html
+++ b/tools/game/game-sudoku.html
@@ -652,6 +652,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">数独</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="top-bar">

--- a/tools/game/guess-number.html
+++ b/tools/game/guess-number.html
@@ -554,6 +554,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Guess Number</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="game-info">

--- a/tools/game/pinball-game.html
+++ b/tools/game/pinball-game.html
@@ -469,6 +469,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Pinball Game</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats">

--- a/tools/game/shooter-game.html
+++ b/tools/game/shooter-game.html
@@ -471,6 +471,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Shooter Game</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats">

--- a/tools/game/tic-tac-toe.html
+++ b/tools/game/tic-tac-toe.html
@@ -526,6 +526,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Tic Tac Toe</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="score-board">

--- a/tools/game/word-chain.html
+++ b/tools/game/word-chain.html
@@ -529,6 +529,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Word Chain</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="stats">

--- a/tools/generator/password-generator.html
+++ b/tools/generator/password-generator.html
@@ -953,6 +953,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">密码生成器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/generator/qrcode-generator.html
+++ b/tools/generator/qrcode-generator.html
@@ -839,6 +839,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">二维码生成器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/generator/slug-generator.html
+++ b/tools/generator/slug-generator.html
@@ -520,6 +520,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">URL Slug 生成器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/health/alcohol-metabolism.html
+++ b/tools/health/alcohol-metabolism.html
@@ -984,6 +984,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">酒精代谢计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/health/bac-calculator.html
+++ b/tools/health/bac-calculator.html
@@ -972,6 +972,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">血液酒精浓度计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/health/blood-pressure.html
+++ b/tools/health/blood-pressure.html
@@ -1056,6 +1056,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">血压分析工具</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/health/calorie-burn-calculator.html
+++ b/tools/health/calorie-burn-calculator.html
@@ -850,6 +850,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">运动消耗卡路里计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/health/calorie-calculator.html
+++ b/tools/health/calorie-calculator.html
@@ -1002,6 +1002,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">卡路里需求计算器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/health/hearing-test.html
+++ b/tools/health/hearing-test.html
@@ -1080,6 +1080,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">听力测试工具</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/life/bank-card-validator.html
+++ b/tools/life/bank-card-validator.html
@@ -700,6 +700,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">银行卡号校验</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/id-card-validator.html
+++ b/tools/life/id-card-validator.html
@@ -663,6 +663,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">身份证号校验</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/income-tax-calculator.html
+++ b/tools/life/income-tax-calculator.html
@@ -691,6 +691,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">个税计算器 2025</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/license-plate-lookup.html
+++ b/tools/life/license-plate-lookup.html
@@ -582,6 +582,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">车牌归属地查询</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/money-uppercase.html
+++ b/tools/life/money-uppercase.html
@@ -606,6 +606,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">金额大写转换</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/mortgage-calculator.html
+++ b/tools/life/mortgage-calculator.html
@@ -690,6 +690,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">房贷计算器 2025</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/pomodoro-timer.html
+++ b/tools/life/pomodoro-timer.html
@@ -495,6 +495,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Pomodoro Timer</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/relative-calculator.html
+++ b/tools/life/relative-calculator.html
@@ -602,6 +602,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">亲戚称呼计算器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/life/retirement-calculator.html
+++ b/tools/life/retirement-calculator.html
@@ -692,6 +692,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">退休年龄计算器 2025</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/lifestyle/daily-affirmation.html
+++ b/tools/lifestyle/daily-affirmation.html
@@ -520,6 +520,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">每日正能量</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="affirmation-card" id="affirmationCard">

--- a/tools/media/gif-maker.html
+++ b/tools/media/gif-maker.html
@@ -569,6 +569,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">GIF制作</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/gif-splitter.html
+++ b/tools/media/gif-splitter.html
@@ -516,6 +516,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">GIF分割</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/id-photo.html
+++ b/tools/media/id-photo.html
@@ -576,6 +576,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">证件照裁剪</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-blur.html
+++ b/tools/media/image-blur.html
@@ -513,6 +513,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片模糊</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-border.html
+++ b/tools/media/image-border.html
@@ -530,6 +530,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片加边框</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-collage.html
+++ b/tools/media/image-collage.html
@@ -545,6 +545,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片拼接</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-compressor.html
+++ b/tools/media/image-compressor.html
@@ -989,6 +989,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片压缩器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/media/image-filter.html
+++ b/tools/media/image-filter.html
@@ -514,6 +514,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片滤镜</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-flip.html
+++ b/tools/media/image-flip.html
@@ -509,6 +509,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片翻转</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-mosaic.html
+++ b/tools/media/image-mosaic.html
@@ -501,6 +501,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片马赛克</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-resize.html
+++ b/tools/media/image-resize.html
@@ -998,6 +998,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片压缩对比</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/media/image-rotate.html
+++ b/tools/media/image-rotate.html
@@ -536,6 +536,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片旋转</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-round-corner.html
+++ b/tools/media/image-round-corner.html
@@ -542,6 +542,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片圆角</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-sketch.html
+++ b/tools/media/image-sketch.html
@@ -533,6 +533,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片转素描</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-split.html
+++ b/tools/media/image-split.html
@@ -526,6 +526,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片分割</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-text.html
+++ b/tools/media/image-text.html
@@ -536,6 +536,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片加文字</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/media/image-to-base64.html
+++ b/tools/media/image-to-base64.html
@@ -539,6 +539,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">图片 Base64 转换</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="tabs">

--- a/tools/media/svg-render.html
+++ b/tools/media/svg-render.html
@@ -917,6 +917,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">SVG 渲染器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/office/barcode-label.html
+++ b/tools/office/barcode-label.html
@@ -703,6 +703,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Barcode Label</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/office/leave-calculator.html
+++ b/tools/office/leave-calculator.html
@@ -738,6 +738,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Leave Calculator</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/office/stamp-generator.html
+++ b/tools/office/stamp-generator.html
@@ -668,6 +668,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Stamp Generator</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/office/timesheet.html
+++ b/tools/office/timesheet.html
@@ -705,6 +705,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Timesheet</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/privacy/file-hash.html
+++ b/tools/privacy/file-hash.html
@@ -911,6 +911,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">文件哈希校验</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/privacy/log-masker.html
+++ b/tools/privacy/log-masker.html
@@ -800,6 +800,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">日志脱敏</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/security/bcrypt-generator.html
+++ b/tools/security/bcrypt-generator.html
@@ -525,6 +525,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Bcrypt 工具</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/security/hash-generator.html
+++ b/tools/security/hash-generator.html
@@ -577,6 +577,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">哈希生成器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="card">

--- a/tools/text/case-converter.html
+++ b/tools/text/case-converter.html
@@ -805,6 +805,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">文本大小写转换</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/text/column-processor.html
+++ b/tools/text/column-processor.html
@@ -714,6 +714,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">文本列处理器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/text/diff-checker.html
+++ b/tools/text/diff-checker.html
@@ -597,6 +597,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">文本对比工具</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="input-grid">

--- a/tools/text/line-sorter.html
+++ b/tools/text/line-sorter.html
@@ -737,6 +737,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">行排序工具</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/text/markdown-editor.html
+++ b/tools/text/markdown-editor.html
@@ -645,6 +645,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Markdown 编辑器</h1>
     <div class="tool-main" role="main">
       <div class="container">
         <div class="editor">

--- a/tools/text/markdown-preview.html
+++ b/tools/text/markdown-preview.html
@@ -971,6 +971,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Markdown 预览</h1>
     <div class="tool-main" role="main">
       <main class="main-container">
         <!-- Toolbar with View Toggle -->

--- a/tools/time/new-year-countdown.html
+++ b/tools/time/new-year-countdown.html
@@ -1317,6 +1317,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">新年倒计时</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/time/timestamp.html
+++ b/tools/time/timestamp.html
@@ -865,6 +865,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">时间戳转换</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/time/timezone-converter.html
+++ b/tools/time/timezone-converter.html
@@ -862,6 +862,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">时区转换器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/currency-exchange.html
+++ b/tools/travel/currency-exchange.html
@@ -491,6 +491,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Currency Exchange</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/distance-calculator.html
+++ b/tools/travel/distance-calculator.html
@@ -500,6 +500,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Distance Calculator</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/flight-time.html
+++ b/tools/travel/flight-time.html
@@ -531,6 +531,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Flight Time</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/fuel-cost.html
+++ b/tools/travel/fuel-cost.html
@@ -604,6 +604,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Fuel Cost</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/hotel-cost.html
+++ b/tools/travel/hotel-cost.html
@@ -485,6 +485,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Hotel Cost</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/size-converter.html
+++ b/tools/travel/size-converter.html
@@ -712,6 +712,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">尺码转换器</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/time-difference.html
+++ b/tools/travel/time-difference.html
@@ -494,6 +494,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Time Difference</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/tip-guide.html
+++ b/tools/travel/tip-guide.html
@@ -532,6 +532,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Tip Guide</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/travel-checklist.html
+++ b/tools/travel/travel-checklist.html
@@ -576,6 +576,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">旅行准备清单</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/travel-insurance.html
+++ b/tools/travel/travel-insurance.html
@@ -684,6 +684,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Travel Insurance</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/vaccine-checker.html
+++ b/tools/travel/vaccine-checker.html
@@ -692,6 +692,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Vaccine Checker</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/weather-planner.html
+++ b/tools/travel/weather-planner.html
@@ -720,6 +720,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">Weather Planner</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">

--- a/tools/travel/world-clock.html
+++ b/tools/travel/world-clock.html
@@ -581,6 +581,7 @@
     </style>
   </head>
   <body>
+    <h1 class="tool-page-heading">旅行世界时钟</h1>
     <div class="tool-main" role="main">
       <main class="main-content">
         <div class="container">


### PR DESCRIPTION
## 结果

为当前 1088 个登记工具补齐可验证的主标题结构：原先 121 个没有 `H1` 的页面现在都有且仅有一个非空 `H1`。

## 修改内容

- 由 `tools.json` 提供页面名称，只为缺少主标题的页面补充语义标题
- 使用共享的 `.tool-page-heading` 无障碍隐藏样式，不改变现有工具界面布局
- `npm run sync` 保证后续新增或遗留页面自动补齐，已有 `H1` 的页面保持原样
- 新增全仓门禁：每个登记工具页必须恰好有一个非空 `H1`

## 根因

部分历史工具页依赖视觉卡片或运行时外壳表达页面名称，静态 HTML 中没有主标题；原有测试只检查 `<head>` 元数据，未覆盖正文标题层级。

## 验证

- `npm test`: 66/66
- `npm run lint`: HTMLHint 1119 files、Stylelint、ESLint 全部通过
- `npm run build`: 通过；第二次同步不再产生 H1 变化
- 本次涉及的脚本、测试、共享 CSS 通过 Prettier
- `git diff --check`: 通过
- Chromium：4 个代表页面 × 1440×1000 / 390×844；H1 名称、1px 隐藏布局、无横向溢出、无控制台错误

说明：仓库全量 `npm run format:check` 仍报告一批既有历史文件，本 PR 未批量格式化无关页面。

## 边界

- 本 PR 只处理结构性 H1 缺口，不批量生成 SEO 文案
- Title/description 继续等待最新 Bing/Search Console 数据后按真实曝光分批优化
- Draft 阶段不触发正式版本发布；合并会触发生产部署，需单独确认

Closes #163
