### PR TITLE
ci: move deployment actions to Node 24

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -35,8 +35,9 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '3.90.0'
           command: pages deploy dist --project-name=htmltools --commit-message="Deploy from GitHub Actions - ${{ github.sha }}" --branch="${{ github.ref_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,13 +39,13 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## 背景

主分支部署成功，但 GitHub 的检查注释显示 Pages 与 Cloudflare Actions 仍声明 Node 20；Runner 目前强制把它们放到 Node 24 执行。Node 20 已结束支持，这会持续产生告警，也让实际运行时与仓库配置不一致。

## 修改

- configure-pages v5 → v6.0.0（固定完整提交 SHA）
- upload-pages-artifact v4 → v5.0.0；其内部 upload-artifact 已使用 Node 24
- deploy-pages v4 → v5.0.0
- wrangler-action v3 → v4.0.0，并显式固定 wranglerVersion 3.90.0，避免同时引入 Wrangler CLI v4 行为变化

## 验证

- 四个固定提交的 action.yml 已核对：直接 Action 使用 Node 24；upload-pages-artifact 的内部 upload-artifact 也使用 Node 24
- actionlint 与 YAML 解析通过
- npm test：67/67
- HTML/CSS/JS lint 全绿（HTMLHint 1119 个文件）

## 风险与回滚

合并到 master 会触发 GitHub Pages、Cloudflare Pages 与 Vercel 生产部署。若任一部署异常，回滚本提交即可恢复旧 Action 固定版本；Wrangler CLI 版本保持 3.90.0 不变。

本 PR 只准备变更，不在未获生产审批时合并。