### PR TITLE
test: add browser smoke coverage

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -1,0 +1,34 @@
+name: Browser Smoke
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser smoke tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ npm-debug.log*
 firebase-debug.log
 test_*.log
 
+# Browser test artifacts
+test-results/
+playwright-report/
+blob-report/
+
 # Cache
 .eslintcache
 .stylelintcache

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,20 @@ export default [
   // Base config for all files
   js.configs.recommended,
 
+  // Playwright config and browser tests run as Node.js modules.
+  {
+    files: ['playwright.config.js', 'tests/e2e/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        process: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly'
+      }
+    }
+  },
+
   // HTML files + extracted assets/js (same project conventions)
   {
     files: ['**/*.html', 'assets/js/**/*.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ejs": "^6.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "eslint": "^9.39.5",
         "eslint-plugin-html": "^8.1.4",
         "htmlhint": "^1.9.2",
@@ -462,6 +463,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@types/estree": {
@@ -1408,6 +1425,21 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -2281,6 +2313,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run sync && node scripts/copy-to-dist.mjs",
     "build:release": "bash scripts/create-release-artifacts.sh",
     "test": "node tests/run.js",
+    "test:e2e": "playwright test",
     "check:version": "node scripts/check-version.mjs",
     "check:artifact-license": "node scripts/check-release-artifact.mjs dist",
     "audit:secrets": "gitleaks git . --log-opts=--all --redact=100 --no-banner",
@@ -18,7 +19,7 @@
     "lint:css": "npm run lint:css:tools && npm run lint:css:shared",
     "lint:css:tools": "stylelint \"tools/**/*.html\" --custom-syntax postcss-html",
     "lint:css:shared": "stylelint \"assets/css/tool-base.css\"",
-    "lint:js": "eslint \"tools/**/*.html\" \"assets/js/**/*.js\"",
+    "lint:js": "eslint \"tools/**/*.html\" \"assets/js/**/*.js\" \"tests/e2e/**/*.js\" playwright.config.js",
     "lint:fix": "npm run lint:css:tools -- --fix && npm run lint:css:shared -- --fix",
     "format": "prettier --write \"**/*.{html,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{html,js,json,md}\"",
@@ -27,6 +28,7 @@
     "sync:tools": "npm run sync"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "eslint": "^9.39.5",
     "eslint-plugin-html": "^8.1.4",
     "htmlhint": "^1.9.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'off'
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+function collectPageErrors(page) {
+  const errors = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  return errors;
+}
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => localStorage.clear());
+  await context.route(/^https:\/\//, (route) =>
+    route.fulfill({ status: 204, contentType: 'text/plain', body: '' })
+  );
+});
+
+test('homepage discovery, favorites, and recent tools work', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.goto('/');
+
+  const search = page.locator('#search');
+  await search.fill('JSON');
+  await expect(page.locator('.tool-card', { hasText: 'JSON 格式化' })).toBeVisible();
+  await expect(page.locator('.tool-card[href="tools/time/timestamp.html"]')).toBeHidden();
+  await search.fill('');
+
+  await page.locator('.category-btn[data-category="dev"]').click();
+  await expect(page).toHaveURL(/\?category=dev$/);
+
+  const jsonCard = page.locator('.tool-card[href="tools/dev/json-formatter.html"]');
+  const favoriteButton = jsonCard.locator('.favorite-btn');
+  await favoriteButton.focus();
+  await page.keyboard.press('Enter');
+  await expect(favoriteButton).toHaveClass(/active/);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('html_tools_favorites_v1'))))
+    .toContain('tools/dev/json-formatter.html');
+
+  await jsonCard.click({ position: { x: 32, y: 72 } });
+  await expect(page).toHaveURL(/tools\/dev\/json-formatter\.html$/);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('html_tools_recents_v1'))?.[0]))
+    .toBe('tools/dev/json-formatter.html');
+
+  expect(errors).toEqual([]);
+});
+
+test('representative calculator works without browser errors', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.goto('/tools/calculator/tip-calculator.html');
+  await page.getByLabel('账单金额').fill('100');
+  await page.getByRole('button', { name: '增加人数' }).click();
+
+  await expect(page.locator('#perPerson')).toHaveText('¥57.50');
+  await expect(page.getByRole('link', { name: '返回全部工具' })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test('homepage has no horizontal overflow on a mobile viewport', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const widths = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth
+  }));
+
+  expect(widths.scroll).toBe(widths.client);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- add a Playwright smoke suite for homepage discovery, category URL state, favorites, recent tools, a representative calculator, mobile overflow, and browser console errors
- run the suite in an isolated GitHub Actions workflow with Node 24 and Chromium
- lint the Playwright config and tests, and ignore generated test artifacts

## Scope boundary

- homepage and cover source files are unchanged
- external HTTPS resources are fulfilled with empty successful responses so the suite validates deterministic local functionality
- no visual, deployment, release, or publishing change

## Validation

- `npm run test:e2e` (3/3)
- `npx playwright test --repeat-each=5 --workers=1 --reporter=list` (15/15)
- `npm run build`
- `npm test` (67/67)
- `npm run lint` (1119 HTML files, shared CSS, JavaScript, Playwright config and tests)
- `npm run format:check`
- `npm run check:version`
- `git diff --check`

## Follow-up

The existing homepage favorite button is nested inside a navigation link. This MR uses its keyboard interaction path to avoid changing the cover; any DOM restructuring should be handled as a separately approved homepage change.
