### PR TITLE
fix: improve JSON formatter accessibility

### DIFF
--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -62,6 +62,21 @@ test('representative calculator works without browser errors', async ({ page }) 
   expect(errors).toEqual([]);
 });
 
+test('JSON formatter exposes labeled controls and formats input', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.goto('/tools/dev/json-formatter.html');
+  await page.getByLabel('输入').fill('{"name":"WebUtils","active":true}');
+  await page.getByLabel('缩进:').selectOption('4');
+  await page.getByRole('button', { name: '格式化' }).click();
+
+  await expect(page.getByLabel('输出')).toHaveValue(
+    '{\n    "name": "WebUtils",\n    "active": true\n}'
+  );
+  await expect(page.getByRole('status')).toHaveText('格式化成功');
+  expect(errors).toEqual([]);
+});
+
 test('homepage has no horizontal overflow on a mobile viewport', async ({ page }) => {
   const errors = collectPageErrors(page);
 

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -74,6 +74,14 @@ test('JSON formatter exposes labeled controls and formats input', async ({ page 
     '{\n    "name": "WebUtils",\n    "active": true\n}'
   );
   await expect(page.getByRole('status')).toHaveText('格式化成功');
+
+  await page.getByLabel('输入').fill('{"name":}');
+  await page.getByRole('button', { name: '校验' }).click();
+  const errorDetail = page.locator('#errorDetail');
+  await expect(errorDetail).toBeVisible();
+  const errorText = await errorDetail.textContent();
+  expect(errorText).toBeTruthy();
+  await expect(page.locator('#errorAnnouncement')).toHaveText(errorText);
   expect(errors).toEqual([]);
 });
 

--- a/tools/dev/json-formatter.html
+++ b/tools/dev/json-formatter.html
@@ -92,10 +92,6 @@
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
 
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
-      rel="stylesheet"
-    />
     <style>
       /* CSS 变量兼容垫片 (修复 d03c9548 改名遗留) */
       :root {
@@ -393,7 +389,9 @@
         padding: var(--space-2) var(--space-1);
         margin-left: calc(var(--space-2) * -1);
         border-radius: var(--radius-sm);
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast);
         justify-self: start;
       }
       .nav-back:hover {
@@ -433,7 +431,10 @@
         background: var(--color-bg-subtle);
         color: var(--color-text-secondary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast),
+          transform var(--transition-fast);
       }
       .theme-toggle:hover {
         background: var(--color-border-strong);
@@ -481,7 +482,6 @@
         flex: 1;
         display: flex;
         flex-direction: column;
-        transition: all var(--transition-normal);
         animation: fade-in-up 0.4s ease-out;
       }
       @keyframes fade-in-up {
@@ -558,7 +558,10 @@
         border: none;
         border-radius: var(--radius-sm);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast),
+          box-shadow var(--transition-fast);
         white-space: nowrap;
       }
       .btn:hover {
@@ -596,7 +599,10 @@
         border-radius: var(--radius-sm);
         color: var(--color-text-primary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          color var(--transition-fast);
       }
       .option-item select:focus {
         outline: none;
@@ -651,7 +657,10 @@
         border-radius: var(--radius-md);
         resize: vertical;
         tab-size: 2;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast);
       }
       .panel-textarea::placeholder {
         color: var(--text-muted);
@@ -939,8 +948,8 @@
           </div>
           <div class="options-bar">
             <div class="option-item">
-              <span>缩进:</span>
-              <select id="indent">
+              <label for="indent">缩进:</label>
+              <select id="indent" name="indent" autocomplete="off">
                 <option value="2">2 空格</option>
                 <option value="4">4 空格</option>
                 <option value="tab">Tab</option>
@@ -953,28 +962,32 @@
           </div>
           <div class="panels">
             <div class="panel">
-              <div class="panel-header"><span class="panel-label">输入</span></div>
+              <div class="panel-header"><label class="panel-label" for="input">输入</label></div>
               <textarea
                 id="input"
+                name="json-input"
                 class="panel-textarea"
-                placeholder="在此粘贴 JSON 数据..."
+                placeholder="在此粘贴 JSON 数据…"
+                autocomplete="off"
                 spellcheck="false"
               ></textarea>
             </div>
             <div class="panel">
-              <div class="panel-header"><span class="panel-label">输出</span></div>
+              <div class="panel-header"><label class="panel-label" for="output">输出</label></div>
               <textarea
                 id="output"
+                name="json-output"
                 class="panel-textarea"
                 readonly=""
-                placeholder="处理结果..."
+                placeholder="处理结果…"
+                autocomplete="off"
                 spellcheck="false"
               ></textarea>
             </div>
           </div>
-          <div id="errorDetail" class="error-detail"></div>
+          <div id="errorDetail" class="error-detail" aria-live="polite"></div>
           <div class="status-bar">
-            <div id="status" class="status"></div>
+            <div id="status" class="status" role="status" aria-live="polite"></div>
             <div id="stats" class="stats">
               <div class="stat-item">
                 <span class="stat-value" id="statKeys">0</span>

--- a/tools/dev/json-formatter.html
+++ b/tools/dev/json-formatter.html
@@ -985,7 +985,8 @@
               ></textarea>
             </div>
           </div>
-          <div id="errorDetail" class="error-detail" aria-live="polite"></div>
+          <div id="errorDetail" class="error-detail"></div>
+          <div id="errorAnnouncement" class="sr-only" aria-live="polite"></div>
           <div class="status-bar">
             <div id="status" class="status" role="status" aria-live="polite"></div>
             <div id="stats" class="stats">
@@ -1138,6 +1139,7 @@
       const outputEl = document.getElementById("output");
       const statusEl = document.getElementById("status");
       const errorDetailEl = document.getElementById("errorDetail");
+      const errorAnnouncementEl = document.getElementById("errorAnnouncement");
       const statsEl = document.getElementById("stats");
       const indentEl = document.getElementById("indent");
       const removeEmptyEl = document.getElementById("removeEmpty");
@@ -1215,6 +1217,7 @@
         } else {
           errorDetailEl.textContent = msg;
         }
+        errorAnnouncementEl.textContent = errorDetailEl.textContent;
       }
 
       function removeEmptyValues(obj) {
@@ -1413,6 +1416,7 @@
         outputEl.value = "";
         inputEl.classList.remove("error");
         errorDetailEl.classList.remove("show");
+        errorAnnouncementEl.textContent = "";
         statsEl.classList.remove("show");
         statusEl.textContent = "";
         statusEl.className = "status";
@@ -1424,6 +1428,7 @@
         saveToUrl();
         inputEl.classList.remove("error");
         errorDetailEl.classList.remove("show");
+        errorAnnouncementEl.textContent = "";
       });
       document.addEventListener("keydown", function (e) {
         if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {


### PR DESCRIPTION
## Summary

- label the JSON input, output, and indentation controls for assistive technology
- announce formatter status and error updates without changing the page layout
- remove a duplicate font request and replace broad CSS transitions with explicit properties
- add browser coverage for the formatter workflow and semantic controls

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test` (67 passed)
- `npm run test:e2e` (4 passed)
- `npm run build`
- `npm run check:version`
- `git diff --check`

## Scope

- no homepage/cover files changed