### PR TITLE
fix: improve timestamp converter accessibility

### DIFF
--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -85,6 +85,19 @@ test('JSON formatter exposes labeled controls and formats input', async ({ page 
   expect(errors).toEqual([]);
 });
 
+test('timestamp converter exposes labeled controls and converts Unix time', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.goto('/tools/time/timestamp.html');
+  await page.getByLabel('输入时间戳').fill('0');
+  await page.getByLabel('时间戳单位').selectOption('s');
+  await page.getByRole('button', { name: '转换', exact: true }).first().click();
+
+  await expect(page.locator('#resultIso')).toHaveText('1970-01-01T00:00:00.000Z');
+  await expect(page.locator('#tsStatus')).toHaveText('转换成功');
+  expect(errors).toEqual([]);
+});
+
 test('homepage has no horizontal overflow on a mobile viewport', async ({ page }) => {
   const errors = collectPageErrors(page);
 

--- a/tools/time/timestamp.html
+++ b/tools/time/timestamp.html
@@ -89,10 +89,6 @@
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
 
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
-      rel="stylesheet"
-    />
     <style>
       /* ============================================
          Design System - CSS Variables
@@ -411,7 +407,9 @@
         padding: var(--space-2) var(--space-1);
         margin-left: calc(var(--space-2) * -1);
         border-radius: var(--radius-sm);
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast);
         justify-self: start;
       }
 
@@ -460,7 +458,10 @@
         background: var(--color-bg-subtle);
         color: var(--color-text-secondary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast),
+          transform var(--transition-fast);
       }
 
       .theme-toggle:hover {
@@ -538,6 +539,7 @@
         font-family: var(--font-mono);
         color: var(--color-accent-primary);
         letter-spacing: -0.02em;
+        font-variant-numeric: tabular-nums;
       }
 
       .current-time .date {
@@ -600,7 +602,11 @@
         background: var(--color-bg-input);
         color: var(--color-text-primary);
         font-family: var(--font-mono);
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          color var(--transition-fast),
+          box-shadow var(--transition-fast);
       }
 
       input:focus,
@@ -629,7 +635,12 @@
         background: var(--color-bg-subtle);
         color: var(--color-text-primary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast),
+          color var(--transition-fast),
+          transform var(--transition-fast);
         font-family: var(--font-sans);
       }
 
@@ -880,15 +891,23 @@
           <div class="card">
             <h2 class="card-title">时间戳 → 日期</h2>
             <div class="input-group">
-              <label>输入时间戳</label>
+              <label for="tsInput">输入时间戳</label>
               <div class="input-row">
                 <input
                   type="text"
                   id="tsInput"
+                  name="timestamp"
                   class="timestamp-input"
-                  placeholder="输入时间戳..."
+                  placeholder="输入时间戳…"
+                  autocomplete="off"
                 />
-                <select id="tsUnit" class="unit-select">
+                <select
+                  id="tsUnit"
+                  name="timestamp-unit"
+                  class="unit-select"
+                  aria-label="时间戳单位"
+                  autocomplete="off"
+                >
                   <option value="s">秒 (s)</option>
                   <option value="ms" selected="">毫秒 (ms)</option>
                 </select>
@@ -896,7 +915,7 @@
                 <button id="btnConvertTs" class="primary">转换</button>
               </div>
             </div>
-            <div id="tsStatus" class="status"></div>
+            <div id="tsStatus" class="status" role="status" aria-live="polite"></div>
             <table id="tsResult" class="result-table" style="display: none">
               <tbody>
                 <tr>
@@ -923,14 +942,20 @@
           <div class="card">
             <h2 class="card-title">日期 → 时间戳</h2>
             <div class="input-group">
-              <label>选择日期时间</label>
+              <label for="dateInput">选择日期时间</label>
               <div class="input-row">
-                <input type="datetime-local" id="dateInput" step="1" />
+                <input
+                  type="datetime-local"
+                  id="dateInput"
+                  name="date-time"
+                  step="1"
+                  autocomplete="off"
+                />
                 <button id="btnNowDate">现在</button>
                 <button id="btnConvertDate" class="primary">转换</button>
               </div>
             </div>
-            <div id="dateStatus" class="status"></div>
+            <div id="dateStatus" class="status" role="status" aria-live="polite"></div>
             <table id="dateResult" class="result-table" style="display: none">
               <tbody>
                 <tr>


### PR DESCRIPTION
## Summary

- associate timestamp and date controls with accessible labels and stable form metadata
- announce conversion outcomes to assistive technology without changing the page layout
- remove a duplicate font request and replace broad CSS transitions with explicit properties
- stabilize the live timestamp numerals and add browser coverage for Unix epoch conversion

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test` (67 passed)
- `npm run test:e2e` (5 passed)
- `npm run build`
- `npm run check:version`
- targeted Prettier, Stylelint, and ESLint checks
- `git diff --check`

## Scope

- no homepage/cover files changed