### PR TITLE
fix: modernize Base64 encoding flows

### DIFF
--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { expect, test } from '@playwright/test';
 
 function collectPageErrors(page) {
@@ -114,6 +115,30 @@ test('URL codec exposes semantic controls and encodes input', async ({ page }) =
   await page.getByRole('button', { name: '解析 URL' }).click();
   await expect(page.getByRole('table', { name: 'URL 解析结果' })).toBeVisible();
   await expect(page.locator('#urlHost')).toHaveText('example.com');
+  expect(errors).toEqual([]);
+});
+
+test('Base64 tool encodes Unicode text and local files', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.goto('/tools/dev/base64.html');
+  const input = page.getByLabel('输入');
+  await input.fill('你好，WebUtils');
+  await page.getByRole('button', { name: '编码 (Text → Base64)' }).click();
+  await expect(page.getByLabel('输出')).toHaveValue('5L2g5aW977yMV2ViVXRpbHM=');
+
+  await input.fill('5L2g5aW977yMV2ViVXRpbHM=');
+  await page.getByRole('button', { name: '解码 (Base64 → Text)' }).click();
+  await expect(page.getByLabel('输出')).toHaveValue('你好，WebUtils');
+
+  await page.getByLabel('选择文件').setInputFiles({
+    name: 'hello.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('hello')
+  });
+  await expect(page.getByLabel('输出')).toHaveValue('aGVsbG8=');
+  await expect(page.locator('#fileName')).toContainText('hello.txt');
+  await expect(page.locator('#status')).toContainText('文件编码成功');
   expect(errors).toEqual([]);
 });
 

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -131,6 +131,14 @@ test('Base64 tool encodes Unicode text and local files', async ({ page }) => {
   await page.getByRole('button', { name: '解码 (Base64 → Text)' }).click();
   await expect(page.getByLabel('输出')).toHaveValue('你好，WebUtils');
 
+  const bomText = '\uFEFFhello';
+  await input.fill(bomText);
+  await page.getByRole('button', { name: '编码 (Text → Base64)' }).click();
+  await expect(page.getByLabel('输出')).toHaveValue('77u/aGVsbG8=');
+  await input.fill('77u/aGVsbG8=');
+  await page.getByRole('button', { name: '解码 (Base64 → Text)' }).click();
+  await expect(page.getByLabel('输出')).toHaveValue(bomText);
+
   await page.getByLabel('选择文件').setInputFiles({
     name: 'hello.txt',
     mimeType: 'text/plain',

--- a/tools/dev/base64.html
+++ b/tools/dev/base64.html
@@ -1124,7 +1124,7 @@
       function base64ToText(base64) {
         const binary = atob(base64);
         const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
-        return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
       }
 
       // 编码

--- a/tools/dev/base64.html
+++ b/tools/dev/base64.html
@@ -89,10 +89,6 @@
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
 
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
-      rel="stylesheet"
-    />
     <style>
       /* ============================================
          Design System - CSS Variables
@@ -411,7 +407,9 @@
         padding: var(--space-2) var(--space-1);
         margin-left: calc(var(--space-2) * -1);
         border-radius: var(--radius-sm);
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast);
         justify-self: start;
       }
 
@@ -460,7 +458,10 @@
         background: var(--color-bg-subtle);
         color: var(--color-text-secondary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          color var(--transition-fast),
+          transform var(--transition-fast);
       }
 
       .theme-toggle:hover {
@@ -538,12 +539,17 @@
         margin-bottom: var(--space-4);
       }
 
-      .input-group label {
+      .input-group label,
+      .input-group-label {
         display: block;
         font-weight: 500;
         margin-bottom: var(--space-2);
         font-size: 0.9375rem;
         color: var(--color-text-secondary);
+      }
+
+      .input-group-label {
+        margin-top: 0;
       }
 
       .input-row {
@@ -563,7 +569,11 @@
         background: var(--color-bg-input);
         color: var(--color-text-primary);
         font-family: var(--font-mono);
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          color var(--transition-fast),
+          box-shadow var(--transition-fast);
       }
 
       input:focus,
@@ -596,7 +606,12 @@
         background: var(--color-bg-subtle);
         color: var(--color-text-primary);
         cursor: pointer;
-        transition: all var(--transition-fast);
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast),
+          box-shadow var(--transition-fast),
+          color var(--transition-fast),
+          transform var(--transition-fast);
         font-family: var(--font-sans);
       }
 
@@ -680,19 +695,30 @@
         color: var(--color-text-primary);
       }
 
-      .file-input-wrapper {
-        position: relative;
-        display: inline-block;
+      input[type="file"] {
+        max-width: 100%;
+        color: var(--color-text-secondary);
+        font-family: var(--font-sans);
+        font-size: 0.875rem;
       }
 
-      .file-input-wrapper input[type="file"] {
-        position: absolute;
-        left: 0;
-        top: 0;
-        opacity: 0;
-        width: 100%;
-        height: 100%;
+      input[type="file"]::file-selector-button {
+        margin-right: var(--space-3);
+        padding: var(--space-3) var(--space-4);
+        border: 1px solid var(--color-border-default);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text-primary);
         cursor: pointer;
+        font: inherit;
+        transition:
+          background-color var(--transition-fast),
+          border-color var(--transition-fast);
+      }
+
+      input[type="file"]:hover::file-selector-button {
+        background: var(--color-bg-surface);
+        border-color: var(--color-accent-primary);
       }
 
       .file-name {
@@ -861,7 +887,7 @@
             <h2 class="card-title">编码 / 解码</h2>
 
             <div class="input-group">
-              <label>操作</label>
+              <h3 class="input-group-label">操作</h3>
               <div class="input-row">
                 <button id="btnPaste">粘贴</button>
                 <button id="btnEncode" class="primary">编码 (Text → Base64)</button>
@@ -872,18 +898,31 @@
             <div class="panels">
               <div class="panel">
                 <label for="input">输入</label>
-                <textarea id="input" placeholder="输入文本或 Base64 字符串..."></textarea>
+                <textarea
+                  id="input"
+                  name="base64-input"
+                  placeholder="输入文本或 Base64 字符串…"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
               </div>
               <div class="panel">
                 <label for="output">输出</label>
-                <textarea id="output" readonly="" placeholder="结果将显示在这里..."></textarea>
+                <textarea
+                  id="output"
+                  name="base64-output"
+                  readonly=""
+                  placeholder="结果将显示在这里…"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
               </div>
             </div>
 
-            <div id="status" class="status"></div>
+            <div id="status" class="status" role="status" aria-live="polite"></div>
 
             <div class="input-group" style="margin-top: var(--space-5)">
-              <label>工具</label>
+              <h3 class="input-group-label">工具</h3>
               <div class="input-row">
                 <button id="btnCopy">复制输出</button>
                 <button id="btnShare">分享链接</button>
@@ -897,12 +936,9 @@
             <h2 class="card-title">文件编码</h2>
 
             <div class="input-group">
-              <label>选择文件</label>
-              <div class="file-input-wrapper">
-                <button>选择文件</button>
-                <input type="file" id="fileInput" />
-              </div>
-              <span id="fileName" class="file-name"></span>
+              <label for="fileInput">选择文件</label>
+              <input type="file" id="fileInput" name="file-input" aria-describedby="fileName" />
+              <span id="fileName" class="file-name" aria-live="polite"></span>
             </div>
 
             <div class="info">选择文件后将自动编码为 Base64，输出在编码卡片的右侧文本框</div>
@@ -1076,6 +1112,21 @@
         localStorage.setItem(LS_KEY, inputEl.value);
       }
 
+      function bytesToBase64(bytes) {
+        const chunkSize = 0x8000;
+        let binary = "";
+        for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+          binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+        }
+        return btoa(binary);
+      }
+
+      function base64ToText(base64) {
+        const binary = atob(base64);
+        const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+        return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      }
+
       // 编码
       function encode() {
         const text = inputEl.value;
@@ -1085,8 +1136,7 @@
         }
 
         try {
-          // 支持 Unicode
-          const encoded = btoa(unescape(encodeURIComponent(text)));
+          const encoded = bytesToBase64(new TextEncoder().encode(text));
           outputEl.value = encoded;
           showStatus("编码成功，长度: " + encoded.length, "success");
         } catch (e) {
@@ -1103,8 +1153,7 @@
         }
 
         try {
-          // 支持 Unicode
-          const decoded = decodeURIComponent(escape(atob(text)));
+          const decoded = base64ToText(text);
           outputEl.value = decoded;
           showStatus("解码成功", "success");
         } catch (e) {


### PR DESCRIPTION
## Summary

- replace deprecated `escape`/`unescape` Unicode conversion with `TextEncoder` and `TextDecoder`
- replace the transparent overlay file picker with a visible, keyboard-focusable native control
- add semantic headings, form metadata, code-input settings, and polite status announcements
- remove a duplicate font request and replace broad CSS transitions with explicit properties
- add browser coverage for Unicode encode/decode and local file encoding

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test` (67 passed)
- `npm run test:e2e` (7 passed)
- `npm run build`
- `npm run check:version`
- `git diff --check`

## Scope

- no homepage/cover files changed