### PR TITLE
docs: add English project overview

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,96 @@
+# WebUtils
+
+[简体中文](README.md) | [English](README.en.md)
+
+> 1,088+ open-source browser tools. Static-first, privacy-conscious, offline-ready, and portable as standalone HTML.
+
+[Use WebUtils online](https://tools.realtime-ai.chat) · [Browse all tools](https://tools.realtime-ai.chat) · [Contribute](CONTRIBUTING.md)
+
+![WebUtils dark-mode homepage](screenshots/homepage-dark.png)
+
+## Why WebUtils?
+
+WebUtils is a large collection of focused utilities for developers, writers, designers, and everyday workflows. Most formatting, encoding, calculating, and generation tasks run inside the current browser page. No account is required, there are no ads, and the site does not include first-party analytics scripts.
+
+The project is designed around four practical promises:
+
+- **Local-first processing:** suitable tools keep their input in the browser.
+- **Transparent network boundaries:** tools that need an API or external resource identify that dependency instead of claiming universal offline behavior.
+- **Portable tools:** registered pages can be exported with repository-owned shared CSS and JavaScript inlined into a standalone HTML file.
+- **Auditable maintenance:** metadata, generated indexes, tests, lint rules, browser smoke checks, and release artifacts are validated in CI.
+
+## Featured tools
+
+| Tool                                                                                      | What it does                                             |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [JSON Formatter](https://tools.realtime-ai.chat/tools/dev/json-formatter.html)            | Format, minify, validate, sort, and inspect JSON locally |
+| [Timestamp Converter](https://tools.realtime-ai.chat/tools/time/timestamp.html)           | Convert Unix timestamps and local date-time values       |
+| [URL Codec](https://tools.realtime-ai.chat/tools/dev/url-codec.html)                      | Encode, decode, and inspect URL components               |
+| [Base64 Codec](https://tools.realtime-ai.chat/tools/dev/base64.html)                      | Encode and decode Unicode text or local files            |
+| [QR Code Generator](https://tools.realtime-ai.chat/tools/generator/qrcode-generator.html) | Generate customizable QR codes in the browser            |
+| [Image Compressor](https://tools.realtime-ai.chat/tools/media/image-compressor.html)      | Compress images locally with visual controls             |
+
+Explore all 35 categories through [the live tool index](https://tools.realtime-ai.chat).
+
+## Privacy and network boundaries
+
+“Browser-based” does not automatically mean “never connects to the network.” WebUtils documents the distinction:
+
+| Tool type                 | Typical behavior                                         | Offline expectation                                   |
+| ------------------------- | -------------------------------------------------------- | ----------------------------------------------------- |
+| Local computation         | Input is processed in the current page                   | Works offline when required assets are available      |
+| Browser capability        | Uses APIs such as Clipboard, File, Camera, or Web Crypto | Depends on browser support and permissions            |
+| Network client            | Sends a request to a user-selected or documented service | Requires network access                               |
+| External resource or data | Loads a CDN asset, image, font, or public API            | May expose ordinary request metadata to that provider |
+
+Check a tool's page, source, and browser network panel before processing sensitive content. A standalone export only inlines repository-owned shared assets; external APIs and CDN dependencies remain external.
+
+## Run locally
+
+Individual HTML tools can often be opened directly. Use the development server when testing shared assets, routing, or PWA behavior:
+
+```bash
+git clone https://github.com/chicogong/html-tools.git
+cd html-tools
+npm ci
+npm run dev
+```
+
+Build the deployable `dist/` directory with:
+
+```bash
+npm run build
+```
+
+Export a registered tool as standalone HTML with:
+
+```bash
+npm run export:standalone -- tools/dev/json-formatter.html
+```
+
+## Quality checks
+
+Run the same core checks used by CI:
+
+```bash
+npm run build
+npm test
+npm run lint
+npm run format:check
+npm run test:e2e
+```
+
+The current suite checks tool metadata, generated indexes, HTML structure, redirects, static assets, internationalization, standalone exports, shared styles, JavaScript, and representative browser workflows.
+
+## Contributing
+
+Bug fixes, accessibility improvements, documentation, translations, and carefully scoped new tools are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), use the shared design system, and keep network and privacy boundaries explicit.
+
+- [Report a bug](https://github.com/chicogong/html-tools/issues/new?template=bug_report.yml)
+- [Propose a tool](https://github.com/chicogong/html-tools/issues/new?template=new_tool.yml)
+- [Open a pull request](https://github.com/chicogong/html-tools/pulls)
+- [Join Discussions](https://github.com/chicogong/html-tools/discussions)
+
+## License
+
+WebUtils is available under the [MIT License](LICENSE). Third-party libraries, APIs, and external resources remain subject to their own licenses and terms.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WebUtils
 
+[简体中文](README.md) | [English](README.en.md)
+
 <div align="center">
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/scripts/check-release-artifact.mjs
+++ b/scripts/check-release-artifact.mjs
@@ -5,10 +5,17 @@ import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const artifactDir = path.resolve(root, process.argv[2] || 'dist');
-const requiredFiles = ['index.html', 'manifest.json', 'sitemap.xml', 'LICENSE', 'NOTICE'];
+const requiredFiles = [
+  'index.html',
+  'manifest.json',
+  'sitemap.xml',
+  'README.md',
+  'README.en.md',
+  'LICENSE',
+  'NOTICE'
+];
 
-const sha256 = (file) =>
-  crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+const sha256 = (file) => crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 
 for (const name of requiredFiles) {
   const source = path.join(root, name);

--- a/scripts/copy-to-dist.mjs
+++ b/scripts/copy-to-dist.mjs
@@ -24,6 +24,7 @@ const INCLUDE_FILES = [
   'social-preview.png',
   'offline.html',
   'README.md',
+  'README.en.md',
   'CHANGELOG.md',
   'LICENSE',
   'NOTICE',

--- a/scripts/create-release-artifacts.sh
+++ b/scripts/create-release-artifacts.sh
@@ -47,7 +47,7 @@ sha256sum --check SHA256SUMS
 
 zip_entries=$(unzip -Z1 "$zip_path" | sed 's#^\./##')
 tar_entries=$(tar -tzf "$tar_path" | sed 's#^\./##')
-for required_file in index.html manifest.json sitemap.xml LICENSE NOTICE; do
+for required_file in index.html manifest.json sitemap.xml README.md README.en.md LICENSE NOTICE; do
   if ! grep -Fqx "$required_file" <<<"$zip_entries"; then
     echo "$zip_path is missing $required_file" >&2
     exit 1

--- a/scripts/sync-all.js
+++ b/scripts/sync-all.js
@@ -4,7 +4,7 @@
  *
  * 从 tools.json 同步到所有相关文件：
  * - index.html: CATEGORIES 数组、TOOLS 数组、SEO meta、统计数字
- * - README.md: 徽章、标题、工具数量
+ * - README.md / README.en.md: 徽章、标题、工具数量
  * - sitemap.xml: 所有工具 URL
  * - manifest.json: 描述中的工具数量
  * - GitHub 仓库描述
@@ -25,6 +25,7 @@ const ROOT_DIR = path.join(__dirname, '..');
 const TOOLS_JSON = path.join(ROOT_DIR, 'tools.json');
 const INDEX_HTML = path.join(ROOT_DIR, 'index.html');
 const README_MD = path.join(ROOT_DIR, 'README.md');
+const README_EN_MD = path.join(ROOT_DIR, 'README.en.md');
 const SITEMAP_XML = path.join(ROOT_DIR, 'sitemap.xml');
 const MANIFEST_JSON = path.join(ROOT_DIR, 'manifest.json');
 const LLMS_TXT = path.join(ROOT_DIR, 'llms.txt');
@@ -491,6 +492,7 @@ function main() {
   const results = {
     indexHtml: updateIndexHtml(categoriesJs, toolsJs, toolCount, categoryCount),
     readme: updateReadme(toolCount, categoryCount),
+    readmeEn: updateEnglishReadme(toolCount),
     sitemap: updateSitemap(tools, toolCount, categoryPages),
     manifest: updateManifest(toolCount),
     i18n: updateI18n(toolCount),
@@ -515,6 +517,7 @@ function main() {
   console.log('📋 同步结果汇总:');
   console.log(`   index.html:    ${results.indexHtml ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   README.md:     ${results.readme ? '✅ 已更新' : '⏭️  无变化'}`);
+  console.log(`   README.en.md:  ${results.readmeEn ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   sitemap.xml:   ${results.sitemap ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   manifest.json: ${results.manifest ? '✅ 已更新' : '⏭️  无变化'}`);
   console.log(`   i18n:          ${results.i18n ? '✅ 已更新' : '⏭️  无变化'}`);
@@ -635,6 +638,44 @@ function updateReadme(toolCount, categoryCount) {
     return false;
   } catch (err) {
     console.log(`⚠️  README.md: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Update the tool count in README.en.md.
+ */
+function updateEnglishReadme(toolCount) {
+  try {
+    if (!fs.existsSync(README_EN_MD)) {
+      return false;
+    }
+
+    const original = fs.readFileSync(README_EN_MD, 'utf8');
+    const formattedCount = new Intl.NumberFormat('en-US').format(toolCount);
+    const readme = original.replace(
+      /[\d,]+\+ open-source browser tools/g,
+      `${formattedCount}+ open-source browser tools`
+    );
+
+    if (readme !== original) {
+      fs.writeFileSync(README_EN_MD, readme);
+      try {
+        execFileSync('npx', ['prettier', '--write', README_EN_MD], {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+      } catch {
+        // prettier 不可用时静默失败
+      }
+      console.log(`✅ README.en.md: ${formattedCount}+ tools`);
+      return true;
+    }
+
+    console.log('⏭️  README.en.md: no update needed');
+    return false;
+  } catch (err) {
+    console.log(`⚠️  README.en.md: ${err.message}`);
     return false;
   }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,16 +12,16 @@ npm test          # 运行全部测试（node tests/run.js）
 
 ## 结构
 
-| 文件                     | 职责                                                                                     |
-| ------------------------ | ---------------------------------------------------------------------------------------- |
-| `_harness.js`            | 零依赖测试框架（`test` / `assert` / `section` / `summary`）+ 仓库辅助函数                |
-| `run.js`                 | 入口：依次加载并运行所有 `*.test.js`，输出汇总与退出码                                   |
-| `tools-json.test.js`     | `tools.json` 结构：字段齐全、引用有效、ID 连续、文件存在                                 |
-| `data-quality.test.js`   | 数据质量：名称不重复、路径规范、字段取值范围、无游离文件                                 |
-| `sync.test.js`           | 同步一致性：`tools.json` 与 `index.html` / `sitemap.xml` / `manifest.json` / `README.md` |
-| `html-structure.test.js` | 每个工具 HTML 的 `<head>`：doctype、lang、SEO 元数据、canonical                          |
-| `redirects.test.js`      | `_redirects` 与 `vercel.json` 重定向目标有效、两份配置一致                               |
-| `assets.test.js`         | 静态资源与 i18n：sw 预缓存清单、manifest 图标/快捷方式、en/zh 翻译键一一对应             |
+| 文件                     | 职责                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `_harness.js`            | 零依赖测试框架（`test` / `assert` / `section` / `summary`）+ 仓库辅助函数                  |
+| `run.js`                 | 入口：依次加载并运行所有 `*.test.js`，输出汇总与退出码                                     |
+| `tools-json.test.js`     | `tools.json` 结构：字段齐全、引用有效、ID 连续、文件存在                                   |
+| `data-quality.test.js`   | 数据质量：名称不重复、路径规范、字段取值范围、无游离文件                                   |
+| `sync.test.js`           | 同步一致性：`tools.json` 与 `index.html` / `sitemap.xml` / `manifest.json` / 中英文 README |
+| `html-structure.test.js` | 每个工具 HTML 的 `<head>`：doctype、lang、SEO 元数据、canonical                            |
+| `redirects.test.js`      | `_redirects` 与 `vercel.json` 重定向目标有效、两份配置一致                                 |
+| `assets.test.js`         | 静态资源与 i18n：sw 预缓存清单、manifest 图标/快捷方式、en/zh 翻译键一一对应               |
 
 ## 新增测试
 

--- a/tests/sync.test.js
+++ b/tests/sync.test.js
@@ -104,6 +104,15 @@ test(`README.md 徽章为 Tools-${toolCount}+`, () => {
   );
 });
 
+test(`README.en.md tool count is "${toolCount.toLocaleString('en-US')}+"`, () => {
+  const readme = readText('README.en.md');
+  const formattedCount = toolCount.toLocaleString('en-US');
+  assert(
+    readme.includes(`${formattedCount}+ open-source browser tools`),
+    `README.en.md tool count is not ${formattedCount}+ —— 请运行 npm run sync:tools`
+  );
+});
+
 test(`i18n 副标题工具数为 "${toolCount}+"`, () => {
   for (const file of ['i18n/en.json', 'i18n/zh-CN.json']) {
     const json = readText(file);


### PR DESCRIPTION
## Summary

- add a concise English project overview and a language switch to the existing Chinese README
- explain the local-first model, network boundaries, standalone export, and contribution paths
- include both README files in deployment and release artifacts, with artifact validation
- leave the homepage cover and application UI unchanged

## Validation

- `npm run build`
- `npm run check:artifact-license`
- `npm test` (67 passed)
- `npm run lint`
- `npm run format:check`
- `bash -n scripts/create-release-artifacts.sh`
- verified all six featured live-tool links return HTTP 200
- `git diff --check`