### PR TITLE
docs: clarify hosted deployment status

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,6 +32,20 @@ The project is designed around four practical promises:
 
 Explore all 35 categories through [the live tool index](https://tools.realtime-ai.chat).
 
+## Hosted versions
+
+Use the custom domain for the latest recommended version. GitHub Pages, Cloudflare Pages, and Vercel are continuously deployed from the default branch. Historical mirrors remain available for compatibility, but they may lag behind and should not be used to verify the latest release.
+
+| Platform          | URL                                     | Maintenance status         |
+| ----------------- | --------------------------------------- | -------------------------- |
+| **Custom domain** | https://tools.realtime-ai.chat          | ✅ Recommended entry point |
+| GitHub Pages      | https://chicogong.github.io/html-tools/ | ✅ Continuous deployment   |
+| Cloudflare Pages  | https://htmltools-bkt.pages.dev         | ✅ Continuous deployment   |
+| Vercel            | https://html-tools-jade.vercel.app      | ✅ Continuous deployment   |
+| Render            | https://webutils-uj15.onrender.com      | ⚠️ Historical mirror       |
+| Surge             | https://webutils.surge.sh               | ⚠️ Historical mirror       |
+| Netlify           | https://localtools.netlify.app          | ⏸️ Updates paused          |
+
 ## Privacy and network boundaries
 
 “Browser-based” does not automatically mean “never connects to the network.” WebUtils documents the distinction:

--- a/README.md
+++ b/README.md
@@ -103,15 +103,17 @@ WebUtils 以静态 HTML 为主，不要求用户账户或统一后端。多数�
 
 ## 在线体验
 
-| 平台              | 链接                                    | 状态    |
-| ----------------- | --------------------------------------- | ------- |
-| **🌐 自定义域名** | https://tools.realtime-ai.chat          | ✅      |
-| GitHub Pages      | https://chicogong.github.io/html-tools/ | ✅      |
-| Cloudflare Pages  | https://htmltools-bkt.pages.dev         | ✅      |
-| Vercel            | https://html-tools-jade.vercel.app      | ✅      |
-| Render            | https://webutils-uj15.onrender.com      | ✅      |
-| Surge             | https://webutils.surge.sh               | ✅      |
-| Netlify           | https://localtools.netlify.app          | ⏸️ 暂停 |
+推荐使用自定义域名访问最新版本。GitHub Pages、Cloudflare Pages 和 Vercel 随主分支持续部署；历史镜像仅为兼容保留，内容可能滞后，不用于验收最新发布。
+
+| 平台              | 链接                                    | 维护状态      |
+| ----------------- | --------------------------------------- | ------------- |
+| **🌐 自定义域名** | https://tools.realtime-ai.chat          | ✅ 推荐入口   |
+| GitHub Pages      | https://chicogong.github.io/html-tools/ | ✅ 持续部署   |
+| Cloudflare Pages  | https://htmltools-bkt.pages.dev         | ✅ 持续部署   |
+| Vercel            | https://html-tools-jade.vercel.app      | ✅ 持续部署   |
+| Render            | https://webutils-uj15.onrender.com      | ⚠️ 历史镜像   |
+| Surge             | https://webutils.surge.sh               | ⚠️ 历史镜像   |
+| Netlify           | https://localtools.netlify.app          | ⏸️ 已暂停更新 |
 
 ## 工具列表 (1088 个)
 


### PR DESCRIPTION
## Summary

- identify the custom domain as the recommended WebUtils entry point
- distinguish continuously deployed targets from historical mirrors
- add the same hosting guidance to the English project overview

## Verification

- `npm test` (70 checks)
- `npm run format:check`
- `git diff --check`

## Scope

Documentation only. No cover, tool UI, deployment workflow, or hosting target was changed.