### PR TITLE
fix: restore Claude Skills presentation

### DIFF
--- a/assets/css/claude-skills.css
+++ b/assets/css/claude-skills.css
@@ -1,0 +1,460 @@
+/* Claude Skills page presentation. Keep page-specific layout out of article-base.css. */
+
+html {
+  color-scheme: dark;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+}
+
+body {
+  min-height: 100vh;
+}
+
+.skip-link {
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  z-index: 2147483001;
+  padding: 10px 16px;
+  color: #071018;
+  background: var(--accent-cyan);
+  border-radius: var(--radius-md);
+  font-weight: 700;
+  text-decoration: none;
+  transform: translate(-50%, -160%);
+  transition: transform var(--transition-fast);
+}
+
+.skip-link:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 3px;
+  transform: translate(-50%, 0);
+}
+
+.tool-main {
+  min-height: 100vh;
+  padding: max(var(--space-6), env(safe-area-inset-top))
+    max(var(--space-6), env(safe-area-inset-right))
+    max(88px, calc(env(safe-area-inset-bottom) + 72px))
+    max(var(--space-6), env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at 14% 8%, var(--glow-magenta), transparent 32%),
+    radial-gradient(circle at 86% 2%, var(--glow-cyan), transparent 28%), var(--bg-deep);
+}
+
+.tool-main .container {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
+}
+
+.back-link {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 14px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.back-link:hover {
+  color: var(--accent-magenta);
+  border-color: var(--accent-magenta);
+  transform: translateY(-1px);
+}
+
+.back-link:focus-visible,
+.info-banner a:focus-visible,
+.filter-btn:focus-visible,
+.install-cmd button:focus-visible,
+.skill-btn:focus-visible,
+footer a:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 3px;
+}
+
+.title-section {
+  min-width: 0;
+}
+
+.title-section h1 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+  line-height: 1.25;
+  text-wrap: balance;
+  scroll-margin-top: var(--space-6);
+}
+
+.title-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, var(--accent-magenta), var(--accent-purple));
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px var(--glow-magenta);
+  font-size: 20px;
+}
+
+.title-section .desc {
+  margin: var(--space-1) 0 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  text-wrap: pretty;
+}
+
+.info-banner {
+  padding: clamp(var(--space-4), 4vw, var(--space-6));
+  margin-bottom: var(--space-6);
+  background: linear-gradient(135deg, var(--glow-magenta), var(--glow-cyan));
+  border: 1px solid rgb(247 37 133 / 28%);
+  border-radius: var(--radius-lg);
+}
+
+.info-banner h2 {
+  margin: 0 0 var(--space-3);
+  color: var(--accent-magenta);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+}
+
+.info-banner p {
+  margin: 0 0 var(--space-3);
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.info-banner a,
+footer a {
+  color: var(--accent-cyan);
+}
+
+.install-cmd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: 12px 14px;
+  margin-top: var(--space-3);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.install-cmd code {
+  min-width: 0;
+  color: var(--accent-cyan);
+  overflow-wrap: anywhere;
+}
+
+.install-cmd button,
+.filter-btn {
+  flex: 0 0 auto;
+  min-height: 38px;
+  padding: 8px 13px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.install-cmd button:hover,
+.filter-btn:hover {
+  color: var(--accent-magenta);
+  border-color: var(--accent-magenta);
+  transform: translateY(-1px);
+}
+
+.stats-section {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  margin-bottom: var(--space-6);
+  overflow: hidden;
+  background: var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.stat-item {
+  padding: var(--space-4);
+  background: var(--bg-card);
+  text-align: center;
+}
+
+.stat-value {
+  color: var(--accent-magenta);
+  font-family: var(--font-mono);
+  font-size: clamp(1.45rem, 4vw, 2rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.stat-label {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+.filter-btn.active {
+  color: #fff;
+  background: var(--accent-magenta);
+  border-color: var(--accent-magenta);
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  gap: var(--space-5);
+  margin-bottom: var(--space-8);
+}
+
+.skill-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: var(--space-5);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition:
+    transform var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.skill-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+.skill-header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.skill-icon {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  font-size: 24px;
+}
+
+.skill-icon.doc {
+  background: linear-gradient(135deg, var(--accent-red), var(--accent-magenta));
+}
+
+.skill-icon.design {
+  background: linear-gradient(135deg, var(--accent-purple), var(--accent-blue));
+}
+
+.skill-icon.dev {
+  background: linear-gradient(135deg, var(--accent-green), var(--accent-cyan));
+}
+
+.skill-icon.comm {
+  background: linear-gradient(135deg, var(--accent-yellow), var(--accent-orange));
+}
+
+.skill-info {
+  min-width: 0;
+}
+
+.skill-name {
+  margin-bottom: var(--space-1);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.skill-category {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.skill-desc {
+  flex: 1;
+  margin-bottom: var(--space-4);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+.skill-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.feature-tag {
+  padding: 4px 8px;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.skill-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.skill-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 8px 13px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.skill-btn:hover {
+  transform: translateY(-1px);
+}
+
+.skill-btn.primary {
+  color: #fff;
+  background: var(--accent-magenta);
+  border: 1px solid var(--accent-magenta);
+}
+
+.skill-btn.secondary {
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+}
+
+.skill-btn.secondary:hover {
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan);
+}
+
+footer {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border-subtle);
+  text-align: center;
+}
+
+footer p {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+@media (max-width: 720px) {
+  .tool-main {
+    padding: max(var(--space-4), env(safe-area-inset-top))
+      max(var(--space-4), env(safe-area-inset-right))
+      max(80px, calc(env(safe-area-inset-bottom) + 68px))
+      max(var(--space-4), env(safe-area-inset-left));
+  }
+
+  .header {
+    align-items: flex-start;
+    gap: var(--space-3);
+  }
+
+  .stats-section {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stat-item:first-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 420px) {
+  .header {
+    flex-direction: column;
+  }
+
+  .install-cmd {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .install-cmd button {
+    align-self: flex-start;
+  }
+
+  .filter-btn {
+    flex: 1 1 calc(50% - var(--space-2));
+  }
+
+  .skill-card {
+    padding: var(--space-4);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:html": "htmlhint \"tools/**/*.html\" --ignore \"**/ByteDanceVerify.html,**/baidu_verify_*.html,**/js-playground.html,**/code-screenshot.html,**/generator/wave-bg.html\"",
     "lint:css": "npm run lint:css:tools && npm run lint:css:shared",
     "lint:css:tools": "stylelint \"tools/**/*.html\" --custom-syntax postcss-html",
-    "lint:css:shared": "stylelint \"assets/css/tool-base.css\"",
+    "lint:css:shared": "stylelint \"assets/css/{tool-base,claude-skills}.css\"",
     "lint:js": "eslint \"tools/**/*.html\" \"assets/js/**/*.js\" \"tests/e2e/**/*.js\" playwright.config.js",
     "lint:fix": "npm run lint:css:tools -- --fix && npm run lint:css:shared -- --fix",
     "format": "prettier --write \"**/*.{html,js,json,md}\"",

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -164,3 +164,35 @@ test('homepage has no horizontal overflow on a mobile viewport', async ({ page }
   expect(widths.scroll).toBe(widths.client);
   expect(errors).toEqual([]);
 });
+
+test('Claude Skills keeps its presentation and filters usable on mobile', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.setViewportSize({ width: 320, height: 568 });
+  await page.goto('/tools/ai/claude-skills.html');
+
+  await expect(page.getByRole('heading', { name: 'Claude Skills 精选' })).toBeVisible();
+  await expect(page.locator('.skills-grid')).toHaveCSS('display', 'grid');
+  await expect(page.locator('.skill-card').first()).not.toHaveCSS(
+    'background-color',
+    'rgba(0, 0, 0, 0)'
+  );
+
+  const widths = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth
+  }));
+  expect(widths.scroll).toBe(widths.client);
+
+  const skipLink = page.getByRole('link', { name: '跳到主要内容' });
+  await skipLink.focus();
+  await expect(skipLink).toBeFocused();
+
+  const designFilter = page.getByRole('button', { name: '🎨 设计创意' });
+  await designFilter.click();
+  await expect(designFilter).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: '全部' })).toHaveAttribute('aria-pressed', 'false');
+  await expect(page.locator('.skill-card:visible')).toHaveCount(5);
+
+  expect(errors).toEqual([]);
+});

--- a/tools/ai/claude-skills.html
+++ b/tools/ai/claude-skills.html
@@ -95,18 +95,22 @@
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
     <link rel="stylesheet" href="../../assets/css/article-base.css" />
-
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
-      rel="stylesheet"
-    />
+    <link rel="stylesheet" href="../../assets/css/claude-skills.css" />
   </head>
   <body>
-    <div class="tool-main" role="main">
+    <a class="skip-link" href="#main-content">跳到主要内容</a>
+    <main class="tool-main" id="main-content">
       <div class="container">
         <div class="header">
           <a href="../../index.html" class="back-link">← 返回</a>
-          <button class="theme-toggle" onclick="toggleTheme()" title="切换主题">🌙</button>
+          <button
+            class="theme-toggle"
+            onclick="toggleTheme()"
+            title="切换主题"
+            aria-label="切换明暗主题"
+          >
+            🌙
+          </button>
           <div class="title-section">
             <h1>
               <span class="title-icon">✨</span>
@@ -150,7 +154,7 @@
         <div class="stats-section">
           <div class="stat-item">
             <div class="stat-value">16</div>
-            <div class="stat-label">官方 Skills</div>
+            <div class="stat-label">精选 Skills</div>
           </div>
           <div class="stat-item">
             <div class="stat-value">4</div>
@@ -170,12 +174,12 @@
           </div>
         </div>
 
-        <div class="filter-bar">
-          <button class="filter-btn active" data-filter="all">全部</button>
-          <button class="filter-btn" data-filter="doc">📄 文档处理</button>
-          <button class="filter-btn" data-filter="design">🎨 设计创意</button>
-          <button class="filter-btn" data-filter="dev">💻 开发技术</button>
-          <button class="filter-btn" data-filter="comm">💬 企业沟通</button>
+        <div class="filter-bar" aria-label="Skills 分类筛选">
+          <button class="filter-btn active" data-filter="all" aria-pressed="true">全部</button>
+          <button class="filter-btn" data-filter="doc" aria-pressed="false">📄 文档处理</button>
+          <button class="filter-btn" data-filter="design" aria-pressed="false">🎨 设计创意</button>
+          <button class="filter-btn" data-filter="dev" aria-pressed="false">💻 开发技术</button>
+          <button class="filter-btn" data-filter="comm" aria-pressed="false">💬 企业沟通</button>
         </div>
 
         <div class="skills-grid" id="skillsGrid">
@@ -694,7 +698,7 @@
           </p>
         </footer>
       </div>
-    </div>
+    </main>
 
     <script>
       // Filter functionality
@@ -705,8 +709,12 @@
         btn.addEventListener("click", () => {
           const filter = btn.dataset.filter;
 
-          filterBtns.forEach((b) => b.classList.remove("active"));
+          filterBtns.forEach((b) => {
+            b.classList.remove("active");
+            b.setAttribute("aria-pressed", "false");
+          });
           btn.classList.add("active");
+          btn.setAttribute("aria-pressed", "true");
 
           skillCards.forEach((card) => {
             if (filter === "all" || card.dataset.category === filter) {
@@ -741,6 +749,8 @@
           await navigator.clipboard.writeText(name);
           // Show toast or feedback
           const toast = document.createElement("div");
+          toast.setAttribute("role", "status");
+          toast.setAttribute("aria-live", "polite");
           toast.textContent = `已复制: ${name}`;
           toast.style.cssText = `
           position: fixed;


### PR DESCRIPTION
## Summary

- restore the page-specific Claude Skills card, filter, stats, and install-command presentation lost during shared article CSS consolidation
- keep the restored styles in a dedicated linted stylesheet with responsive, focus, safe-area, and reduced-motion support
- improve main-content, skip-link, filter-state, theme-button, and copy-feedback semantics
- add a mobile browser regression that fails if the stylesheet or filter behavior disappears again

## Root cause

The page-specific inline stylesheet was removed when AI article styles were consolidated, but its unique selectors were not added to the shared article stylesheet. The HTML remained functional but rendered largely unstyled.

## Verification

- `npm test` (70 checks)
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e` (8 browser checks)
- `npm run build`
- Playwright visual checks at 320px, 390px, and 1440px

## Scope

No homepage cover, tool catalog, unrelated tool UI, hosting configuration, or release metadata was changed.