### PR TITLE
fix: tighten mobile tool accessibility

### DIFF
--- a/tests/e2e/image-compressor-accessibility.spec.js
+++ b/tests/e2e/image-compressor-accessibility.spec.js
@@ -1,0 +1,41 @@
+import { Buffer } from 'node:buffer';
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => localStorage.clear());
+  await context.route(/^https:\/\//, (route) =>
+    route.fulfill({ status: 204, contentType: 'text/plain', body: '' })
+  );
+});
+
+test('image compressor upload control is keyboard accessible', async ({ page }) => {
+  await page.goto('/tools/media/image-compressor.html');
+
+  const uploadButton = page.getByRole('button', { name: /点击或拖拽图片到这里/ });
+  await expect(uploadButton).toBeVisible();
+  await expect(uploadButton).toHaveAttribute('type', 'button');
+
+  const fileInput = page.getByLabel('选择图片文件');
+  await expect(fileInput).toHaveAttribute('name', 'image-file');
+  await expect(fileInput).toHaveAttribute('accept', 'image/*');
+
+  await uploadButton.focus();
+  await expect(uploadButton).toBeFocused();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    uploadButton.press('Enter')
+  ]);
+  await fileChooser.setFiles({
+    name: 'keyboard-upload.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64'
+    )
+  });
+
+  await expect(page.locator('#previewArea')).toBeVisible();
+  await expect(page.locator('#originalFormat')).toHaveText('PNG');
+  await expect(page.locator('#uploadArea')).toBeHidden();
+});

--- a/tests/e2e/qrcode-accessibility.spec.js
+++ b/tests/e2e/qrcode-accessibility.spec.js
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.route(/^https:\/\//, (route) =>
+    route.fulfill({ status: 204, contentType: 'text/plain', body: '' })
+  );
+});
+
+test('QR generator exposes labelled controls and a semantic generate button', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/tools/generator/qrcode-generator.html');
+
+  const textInput = page.getByLabel('文本或 URL', { exact: true });
+  await expect(textInput).toBeVisible();
+  await expect(textInput).toHaveAttribute('name', 'qr-text');
+  await expect(textInput).toHaveAttribute('autocomplete', 'off');
+  await expect(textInput).toHaveAttribute('placeholder', '输入要编码的文本或 URL…');
+
+  const sizeInput = page.getByLabel('二维码大小 (px)', { exact: true });
+  await expect(sizeInput).toHaveValue('256');
+  await expect(sizeInput).toHaveAttribute('name', 'qr-size');
+  await expect(sizeInput).toHaveAttribute('autocomplete', 'off');
+  await expect(sizeInput).toHaveAttribute('placeholder', '例如 256');
+
+  const foregroundColor = page.getByLabel('前景色', { exact: true });
+  await expect(foregroundColor).toHaveValue('#000000');
+  await expect(foregroundColor).toHaveAttribute('name', 'foreground-color');
+  await expect(foregroundColor).toHaveAttribute('autocomplete', 'off');
+
+  const backgroundColor = page.getByLabel('背景色', { exact: true });
+  await expect(backgroundColor).toHaveValue('#ffffff');
+  await expect(backgroundColor).toHaveAttribute('name', 'background-color');
+  await expect(backgroundColor).toHaveAttribute('autocomplete', 'off');
+
+  const generateButton = page.getByRole('button', { name: '生成二维码', exact: true });
+  await expect(generateButton).toBeVisible();
+  await expect(generateButton).toHaveAttribute('type', 'button');
+});

--- a/tests/e2e/timestamp-mobile.spec.js
+++ b/tests/e2e/timestamp-mobile.spec.js
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('timestamp converter fits a narrow mobile viewport and converts Unix time', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await page.goto('/tools/time/timestamp.html');
+
+  const widths = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth
+  }));
+
+  expect(widths.scroll).toBe(widths.client);
+
+  await page.getByLabel('输入时间戳').fill('0');
+  await page.getByLabel('时间戳单位').selectOption('s');
+  await page.getByRole('button', { name: '转换', exact: true }).first().click();
+
+  await expect(page.locator('#resultIso')).toHaveText('1970-01-01T00:00:00.000Z');
+  await expect(page.locator('#tsStatus')).toHaveText('转换成功');
+});

--- a/tools/generator/qrcode-generator.html
+++ b/tools/generator/qrcode-generator.html
@@ -552,6 +552,14 @@
         color: var(--color-text-secondary);
       }
 
+      .input-group .input-label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: var(--space-2);
+        font-size: 0.9375rem;
+        color: var(--color-text-secondary);
+      }
+
       textarea,
       input[type="text"],
       input[type="number"],
@@ -600,6 +608,11 @@
         display: flex;
         align-items: center;
         gap: var(--space-3);
+      }
+
+      .color-group label {
+        display: inline;
+        margin-bottom: 0;
       }
 
       /* Buttons */
@@ -850,43 +863,66 @@
               <h2 class="card-title">输入内容</h2>
 
               <div class="input-group">
-                <label>文本或 URL</label>
-                <textarea id="textInput" placeholder="输入要编码的文本或 URL..."></textarea>
+                <label for="textInput">文本或 URL</label>
+                <textarea
+                  id="textInput"
+                  name="qr-text"
+                  placeholder="输入要编码的文本或 URL…"
+                  autocomplete="off"
+                ></textarea>
               </div>
 
               <div class="input-group">
-                <label for="input--------px-">二维码大小 (px)</label>
+                <label for="qrSize">二维码大小 (px)</label>
                 <input
                   type="number"
                   id="qrSize"
+                  name="qr-size"
                   value="256"
                   min="64"
                   max="1024"
                   step="32"
-                  aria-label="数字输入框"
-                  placeholder="请输入数字输入框"
+                  placeholder="例如 256"
+                  autocomplete="off"
                 />
               </div>
 
               <div class="input-group">
-                <label>颜色</label>
+                <span class="input-label">颜色</span>
                 <div class="color-row">
                   <div class="color-group">
-                    <span>前景色</span>
-                    <input type="color" id="fgColor" value="#000000" aria-label="颜色选择器" />
+                    <label for="fgColor">前景色</label>
+                    <input
+                      type="color"
+                      id="fgColor"
+                      name="foreground-color"
+                      value="#000000"
+                      autocomplete="off"
+                    />
                   </div>
                   <div class="color-group">
-                    <span>背景色</span>
-                    <input type="color" id="bgColor" value="#ffffff" aria-label="颜色选择器" />
+                    <label for="bgColor">背景色</label>
+                    <input
+                      type="color"
+                      id="bgColor"
+                      name="background-color"
+                      value="#ffffff"
+                      autocomplete="off"
+                    />
                   </div>
                 </div>
               </div>
 
               <div class="btn-row">
-                <button class="primary" onclick="generateQR()" aria-label="生成二维码">
+                <button
+                  class="primary"
+                  type="button"
+                  onclick="generateQR()"
+                  aria-label="生成二维码"
+                >
                   生成二维码
                 </button>
-                <button onclick="clearInput()" aria-label="清空">清空</button>
+                <button type="button" onclick="clearInput()" aria-label="清空">清空</button>
               </div>
             </div>
 

--- a/tools/media/image-compressor.html
+++ b/tools/media/image-compressor.html
@@ -546,7 +546,15 @@
         padding: var(--space-8) var(--space-6);
         text-align: center;
         cursor: pointer;
-        transition: all var(--transition-normal);
+        display: block;
+        width: 100%;
+        font: inherit;
+        color: inherit;
+        transition:
+          background-color var(--transition-normal),
+          border-color var(--transition-normal),
+          box-shadow var(--transition-normal),
+          transform var(--transition-normal);
         margin-bottom: var(--space-5);
         box-shadow: var(--shadow-md);
       }
@@ -565,11 +573,13 @@
       }
 
       .upload-icon {
+        display: block;
         font-size: 48px;
         margin-bottom: var(--space-4);
       }
 
       .upload-text {
+        display: block;
         color: var(--color-text-primary);
         font-size: 1.0625rem;
         font-weight: 500;
@@ -577,6 +587,7 @@
       }
 
       .upload-hint {
+        display: block;
         color: var(--text-muted);
         font-size: 0.875rem;
       }
@@ -994,16 +1005,13 @@
       <main class="main-content">
         <div class="container">
           <!-- Upload Area -->
-          <div
-            class="upload-area"
-            id="uploadArea"
-            onclick="document.getElementById('fileInput').click()"
-          >
-            <div class="upload-icon">📷</div>
-            <div class="upload-text">点击或拖拽图片到这里</div>
-            <div class="upload-hint">支持 JPG、PNG、WebP 格式 • 最大 50 MB</div>
-          </div>
-          <input type="file" id="fileInput" accept="image/*" onchange="handleFile(this.files[0])" />
+          <button type="button" class="upload-area" id="uploadArea">
+            <span class="upload-icon" aria-hidden="true">📷</span>
+            <span class="upload-text">点击或拖拽图片到这里</span>
+            <span class="upload-hint">支持 JPG、PNG、WebP 格式 • 最大 50 MB</span>
+          </button>
+          <label class="sr-only" for="fileInput">选择图片文件</label>
+          <input type="file" id="fileInput" name="image-file" accept="image/*" />
 
           <!-- Controls Card -->
           <div class="card" id="controlsCard" style="display: none">
@@ -1230,6 +1238,9 @@
       // Drag and Drop
       // ============================================
       const uploadArea = document.getElementById("uploadArea");
+      const fileInput = document.getElementById("fileInput");
+      uploadArea.addEventListener("click", () => fileInput.click());
+      fileInput.addEventListener("change", () => handleFile(fileInput.files[0]));
       uploadArea.addEventListener("dragover", (e) => {
         e.preventDefault();
         uploadArea.classList.add("dragover");

--- a/tools/time/timestamp.html
+++ b/tools/time/timestamp.html
@@ -784,6 +784,10 @@
           width: 100%;
         }
 
+        input[type="datetime-local"] {
+          max-width: 100%;
+        }
+
         .result-table th {
           width: 100px;
           font-size: 0.8125rem;


### PR DESCRIPTION
## Summary

- prevent the timestamp converter datetime control from overflowing a 320px viewport
- connect QR text, size, and color controls to specific labels and stable form metadata
- replace the image compressor upload div with a keyboard-accessible native button while preserving click and drag-and-drop uploads
- add focused Playwright coverage for all three regressions

## Verification

- `npm run lint`
- `npm run format:check`
- `npm test` (70 checks)
- `npm run test:e2e` (11 browser checks)
- `npm run build`
- visual review at 320x568 for all three tools

## Scope

No homepage cover, unrelated tool UI, deployment configuration, or release metadata was changed.

## Implementation

The three fixes were implemented independently by delegated luna-max agents and consolidated after maintainer review.