### PR TITLE
fix: restore MCP clients presentation

### DIFF
--- a/assets/css/mcp-clients.css
+++ b/assets/css/mcp-clients.css
@@ -1,0 +1,627 @@
+/* MCP 客户端目录页样式。通用 token 与悬浮外壳来自 tool-base.css。 */
+
+html {
+  color-scheme: dark;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+}
+
+body {
+  min-height: 100vh;
+}
+
+.skip-link {
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  z-index: 2147483001;
+  padding: 10px 16px;
+  color: #071018;
+  background: var(--accent-cyan);
+  border-radius: var(--radius-md);
+  font-weight: 700;
+  text-decoration: none;
+  transform: translate(-50%, -160%);
+  transition: transform var(--transition-fast);
+}
+
+.skip-link:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 3px;
+  transform: translate(-50%, 0);
+}
+
+.tool-main {
+  min-height: 100vh;
+  padding: max(var(--space-6), env(safe-area-inset-top))
+    max(var(--space-6), env(safe-area-inset-right))
+    max(88px, calc(env(safe-area-inset-bottom) + 72px))
+    max(var(--space-6), env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at 12% 6%, var(--glow-cyan), transparent 30%),
+    radial-gradient(circle at 88% 4%, var(--glow-magenta), transparent 28%), var(--bg-deep);
+}
+
+.tool-main .container {
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 1100px);
+  min-height: calc(100vh - var(--space-6) - 88px);
+  margin: 0 auto;
+}
+
+#main-content:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 4px;
+}
+
+/* ---------- 页头 ---------- */
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
+}
+
+.back-link {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: 8px 14px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.back-link:hover {
+  color: var(--accent-magenta);
+  border-color: var(--accent-magenta);
+}
+
+.title-area {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.title-area h1 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: clamp(1.25rem, 4.4vw, 1.6rem);
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.title-area h1 .icon {
+  flex: 0 0 auto;
+  font-size: 1.25rem;
+}
+
+.title-area p {
+  margin: var(--space-1) 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+/* ---------- 页面说明 ---------- */
+
+.info-banner {
+  padding: var(--space-5);
+  margin-bottom: var(--space-6);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--accent-blue);
+  border-radius: var(--radius-lg);
+}
+
+.info-banner h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+}
+
+.info-banner p {
+  margin: 0 0 var(--space-3);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.info-banner p:last-child {
+  margin-bottom: 0;
+}
+
+.info-banner a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.info-banner a:hover {
+  text-decoration: underline;
+}
+
+/* ---------- 客户端分区与卡片 ---------- */
+
+.category {
+  margin-bottom: var(--space-6);
+}
+
+.category-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-bottom: var(--space-2);
+  margin: 0 0 var(--space-4);
+  color: var(--accent-purple);
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  line-height: 1.4;
+}
+
+.client-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+  gap: var(--space-4);
+}
+
+.client-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: var(--space-5);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.client-card:hover {
+  border-color: var(--accent-magenta);
+  box-shadow: 0 8px 24px rgb(247 37 133 / 10%);
+  transform: translateY(-2px);
+}
+
+.client-header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.client-icon {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  font-size: 1.5rem;
+}
+
+.client-info {
+  min-width: 0;
+}
+
+.client-info h3 {
+  margin: 0 0 2px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.client-info .subtitle {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.client-desc {
+  margin: 0 0 var(--space-3);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.client-features {
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.client-features ul {
+  padding: 0;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  list-style: none;
+}
+
+.client-features li {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: 3px 0;
+  overflow-wrap: anywhere;
+}
+
+.client-features li::before {
+  flex: 0 0 auto;
+  color: var(--accent-green);
+  content: '✓';
+  font-size: 0.75rem;
+}
+
+/* ---------- 安装命令 ---------- */
+
+.install-block {
+  min-width: 0;
+  margin-bottom: var(--space-3);
+  overflow: hidden;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.install-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 4px 6px 4px 10px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.install-header span {
+  min-width: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  overflow-wrap: anywhere;
+}
+
+.install-header button {
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 4px 10px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.install-header button:hover {
+  color: var(--accent-purple);
+  border-color: var(--border-subtle);
+}
+
+.install-cmd {
+  max-width: 100%;
+  padding: var(--space-2) 10px;
+  color: var(--accent-purple);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+/* ---------- 标签与链接 ---------- */
+
+.client-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: var(--space-3);
+}
+
+.tag {
+  padding: 3px 8px;
+  border: 1px solid;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  line-height: 1.4;
+}
+
+.tag-platform {
+  color: var(--accent-blue);
+  background: rgb(76 201 240 / 10%);
+  border-color: rgb(76 201 240 / 30%);
+}
+
+.tag-opensource {
+  color: var(--accent-green);
+  background: rgb(6 214 160 / 10%);
+  border-color: rgb(6 214 160 / 30%);
+}
+
+.tag-mcp {
+  color: var(--accent-magenta);
+  background: rgb(247 37 133 / 10%);
+  border-color: rgb(247 37 133 / 30%);
+}
+
+.tag-free {
+  color: var(--accent-yellow);
+  background: rgb(254 228 64 / 10%);
+  border-color: rgb(254 228 64 / 30%);
+}
+
+.tag-paid {
+  color: var(--accent-orange);
+  background: rgb(255 159 28 / 10%);
+  border-color: rgb(255 159 28 / 30%);
+}
+
+.client-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: auto;
+}
+
+.client-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 4px 12px;
+  color: var(--accent-blue);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.client-links a:hover {
+  background: rgb(76 201 240 / 10%);
+  border-color: var(--accent-blue);
+}
+
+.client-links a.primary {
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent-magenta), var(--accent-purple));
+  border-color: transparent;
+}
+
+.client-links a.primary:hover {
+  transform: translateY(-1px);
+}
+
+/* ---------- 推荐资源区 ---------- */
+
+.resources {
+  padding: var(--space-5);
+  margin-top: var(--space-2);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.resources h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr));
+  gap: var(--space-3);
+}
+
+.resource-item {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.resource-item:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--accent-cyan);
+  transform: translateY(-2px);
+}
+
+.resource-item h3 {
+  margin: 0 0 var(--space-1);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.resource-item p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+/* ---------- 页脚 ---------- */
+
+footer {
+  padding-top: var(--space-6);
+  margin-top: auto;
+  text-align: center;
+}
+
+footer p {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+footer a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+footer a:hover {
+  color: var(--accent-purple);
+}
+
+.footer-separator {
+  margin: 0 var(--space-2);
+  color: var(--text-muted);
+}
+
+/* ---------- 焦点可见性 ---------- */
+
+.back-link:focus-visible,
+.info-banner a:focus-visible,
+.install-header button:focus-visible,
+.client-links a:focus-visible,
+.resource-item:focus-visible,
+footer a:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
+
+.install-header button.is-copied {
+  color: var(--accent-green);
+  border-color: var(--accent-green);
+}
+
+.install-header button.copy-error {
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+/* ---------- 响应式 ---------- */
+
+@media (max-width: 720px) {
+  .tool-main {
+    padding: max(var(--space-4), env(safe-area-inset-top))
+      max(var(--space-4), env(safe-area-inset-right))
+      max(80px, calc(env(safe-area-inset-bottom) + 68px))
+      max(var(--space-4), env(safe-area-inset-left));
+  }
+
+  .tool-main .container {
+    min-height: calc(100vh - var(--space-4) - 80px);
+  }
+
+  .header {
+    gap: var(--space-3);
+  }
+
+  .info-banner,
+  .client-card,
+  .resources {
+    padding: var(--space-4);
+  }
+
+  .client-grid,
+  .resource-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .title-area {
+    flex: 0 1 auto;
+    width: 100%;
+  }
+
+  .title-area h1 {
+    font-size: 1.2rem;
+  }
+
+  .title-area p {
+    font-size: 0.82rem;
+  }
+
+  .info-banner,
+  .client-card,
+  .resources {
+    padding: var(--space-3);
+  }
+
+  .client-links a {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-link:focus-visible {
+    transform: translate(-50%, 0);
+  }
+
+  .client-card:hover,
+  .client-links a.primary:hover,
+  .resource-item:hover {
+    transform: none;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:html": "htmlhint \"tools/**/*.html\" --ignore \"**/ByteDanceVerify.html,**/baidu_verify_*.html,**/js-playground.html,**/code-screenshot.html,**/generator/wave-bg.html\"",
     "lint:css": "npm run lint:css:tools && npm run lint:css:shared",
     "lint:css:tools": "stylelint \"tools/**/*.html\" --custom-syntax postcss-html",
-    "lint:css:shared": "stylelint \"assets/css/{tool-base,claude-skills,mcp-guide}.css\"",
+    "lint:css:shared": "stylelint \"assets/css/{tool-base,claude-skills,mcp-guide,mcp-clients}.css\"",
     "lint:js": "eslint \"tools/**/*.html\" \"assets/js/**/*.js\" \"tests/e2e/**/*.js\" playwright.config.js",
     "lint:fix": "npm run lint:css:tools -- --fix && npm run lint:css:shared -- --fix",
     "format": "prettier --write \"**/*.{html,js,json,md}\"",

--- a/tests/e2e/mcp-clients-presentation.spec.js
+++ b/tests/e2e/mcp-clients-presentation.spec.js
@@ -1,0 +1,200 @@
+import { expect, test } from '@playwright/test';
+
+function collectPageErrors(page) {
+  const errors = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  return errors;
+}
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => localStorage.clear());
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+    origin: 'http://127.0.0.1:3000'
+  });
+  await context.route(/^https:\/\//, (route) =>
+    route.fulfill({ status: 204, contentType: 'text/plain', body: '' })
+  );
+});
+
+test('MCP 客户端目录保持卡片、分类和推荐资源布局', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 1440, height: 900 }
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/tools/ai/mcp-clients.html');
+
+    await expect(page.locator('main#main-content')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'MCP 客户端大全' })).toBeVisible();
+    await expect(page.locator('.category')).toHaveCount(4);
+    await expect(page.locator('.client-card').first()).toBeVisible();
+    await expect(page.locator('.resources')).toBeVisible();
+    await expect(page.locator('.resource-item').first()).toBeVisible();
+
+    const gridLayouts = await page.locator('.client-grid').evaluateAll((grids) => {
+      const documentElement = grids[0].ownerDocument.documentElement;
+      const body = grids[0].ownerDocument.body;
+      return grids.map((grid) => {
+        const cards = Array.from(grid.querySelectorAll('.client-card'), (card) => {
+          const rect = card.getBoundingClientRect();
+          return { top: rect.top, left: rect.left, right: rect.right };
+        });
+        const firstRowTop = cards[0]?.top;
+        return {
+          cards,
+          firstRowCount: cards.filter((card) => Math.abs(card.top - firstRowTop) < 1).length,
+          gridWidth: grid.getBoundingClientRect().width,
+          viewportWidth: documentElement.clientWidth,
+          documentWidth: Math.max(documentElement.scrollWidth, body.scrollWidth)
+        };
+      });
+    });
+
+    expect(gridLayouts).toHaveLength(4);
+    for (const layout of gridLayouts) {
+      expect(layout.documentWidth - layout.viewportWidth).toBeLessThanOrEqual(1);
+      expect(layout.gridWidth).toBeLessThanOrEqual(layout.viewportWidth);
+      expect(layout.firstRowCount).toBe(
+        viewport.width === 390 ? 1 : Math.min(layout.cards.length, 3)
+      );
+    }
+
+    const resourceLayout = await page.locator('.resource-grid').evaluate((grid) => {
+      const items = Array.from(grid.querySelectorAll('.resource-item'), (item) => {
+        const rect = item.getBoundingClientRect();
+        return { top: rect.top, left: rect.left, right: rect.right };
+      });
+      const firstRowTop = items[0]?.top;
+      const documentElement = grid.ownerDocument.documentElement;
+      const body = grid.ownerDocument.body;
+      return {
+        itemCount: items.length,
+        firstRowCount: items.filter((item) => Math.abs(item.top - firstRowTop) < 1).length,
+        gridWidth: grid.getBoundingClientRect().width,
+        viewportWidth: documentElement.clientWidth,
+        documentWidth: Math.max(documentElement.scrollWidth, body.scrollWidth)
+      };
+    });
+    expect(resourceLayout.itemCount).toBeGreaterThan(1);
+    if (viewport.width === 390) {
+      expect(resourceLayout.firstRowCount).toBe(1);
+    } else {
+      expect(resourceLayout.firstRowCount).toBeGreaterThan(1);
+    }
+    expect(resourceLayout.documentWidth - resourceLayout.viewportWidth).toBeLessThanOrEqual(1);
+    expect(resourceLayout.gridWidth).toBeLessThanOrEqual(resourceLayout.viewportWidth);
+
+    const commandWidths = await page.locator('.install-cmd').evaluateAll((commands) =>
+      commands.map((command) => ({
+        clientWidth: command.clientWidth,
+        scrollWidth: command.scrollWidth,
+        textLength: command.textContent.trim().length
+      }))
+    );
+    for (const command of commandWidths.filter((command) => command.textLength > 40)) {
+      expect(command.scrollWidth - command.clientWidth).toBeLessThanOrEqual(1);
+    }
+  }
+
+  const unsafeLinks = await page
+    .locator('a[target="_blank"]')
+    .evaluateAll((links) =>
+      links.filter((link) => !link.rel.split(/\s+/).includes('noopener')).map((link) => link.href)
+    );
+  expect(unsafeLinks).toEqual([]);
+  expect(errors).toEqual([]);
+});
+
+test('MCP 客户端复制控件写入剪贴板并支持失败重试与连续点击', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/tools/ai/mcp-clients.html');
+
+  const copyButton = page.locator('.install-header button').first();
+  const status = page.getByRole('status');
+  const expectedText = await copyButton.evaluate(
+    (button) => button.closest('.install-block').querySelector('.install-cmd').textContent
+  );
+
+  await copyButton.click();
+  await expect(copyButton).toHaveText('已复制');
+  await expect(status).toHaveText('配置文件路径已复制');
+  expect(await page.evaluate(() => globalThis.navigator.clipboard.readText())).toBe(
+    expectedText.trim()
+  );
+
+  await copyButton.dblclick();
+  await expect(copyButton).toHaveText('已复制');
+  await expect(copyButton).toHaveAttribute('data-original-label', '复制');
+  await expect(copyButton).toHaveText('复制', { timeout: 3000 });
+
+  await page.evaluate(() => {
+    globalThis.__originalClipboardWriteText = globalThis.navigator.clipboard.writeText.bind(
+      globalThis.navigator.clipboard
+    );
+    Object.defineProperty(globalThis.navigator.clipboard, 'writeText', {
+      configurable: true,
+      value: () => Promise.reject(new Error('clipboard denied'))
+    });
+  });
+  await copyButton.click();
+  await expect(copyButton).toHaveText('重试');
+  await expect(copyButton).toHaveClass(/copy-error/);
+  await expect(status).toContainText('复制失败');
+  await expect(copyButton).toBeVisible();
+
+  await page.evaluate(() => {
+    Object.defineProperty(globalThis.navigator.clipboard, 'writeText', {
+      configurable: true,
+      value: globalThis.__originalClipboardWriteText
+    });
+    delete globalThis.__originalClipboardWriteText;
+  });
+  await copyButton.click();
+  await expect(copyButton).toHaveText('已复制');
+  await expect(status).toHaveText('配置文件路径已复制');
+  expect(await page.evaluate(() => globalThis.navigator.clipboard.readText())).toBe(
+    expectedText.trim()
+  );
+
+  expect(errors).toEqual([]);
+});
+
+test('MCP 客户端目录支持 skip link、键盘焦点和 reduced motion', async ({ page }) => {
+  const errors = collectPageErrors(page);
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/tools/ai/mcp-clients.html');
+
+  const skipLink = page.getByRole('link', { name: '跳到主要内容' });
+  await skipLink.focus();
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toHaveCSS('outline-style', 'solid');
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#main-content')).toBeFocused();
+
+  const transitionDurationMs = await page
+    .locator('.client-card')
+    .first()
+    .evaluate((card) =>
+      card.ownerDocument.defaultView
+        .getComputedStyle(card)
+        .transitionDuration.split(',')
+        .reduce((total, duration) => {
+          const value = Number.parseFloat(duration);
+          if (!Number.isFinite(value)) return total;
+          return total + (duration.trim().endsWith('ms') ? value : value * 1000);
+        }, 0)
+    );
+  expect(transitionDurationMs).toBeLessThan(1);
+  expect(errors).toEqual([]);
+});

--- a/tools/ai/mcp-clients.html
+++ b/tools/ai/mcp-clients.html
@@ -92,29 +92,38 @@
     />
     <link rel="stylesheet" href="../../assets/css/tool-base.css" />
     <link rel="stylesheet" href="../../assets/css/article-base.css" />
-
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap"
-      rel="stylesheet"
-    />
+    <link rel="stylesheet" href="../../assets/css/mcp-clients.css" />
   </head>
   <body>
-    <div class="tool-main" role="main">
+    <a class="skip-link" href="#main-content">跳到主要内容</a>
+    <div id="copy-status" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+    <main class="tool-main" id="main-content" tabindex="-1">
       <div class="container">
         <header class="header">
           <a href="../../index.html" class="back-link">← 返回</a>
-          <button class="theme-toggle" onclick="toggleTheme()">☀️</button>
+          <button
+            class="theme-toggle"
+            type="button"
+            onclick="toggleTheme()"
+            title="切换明暗主题"
+            aria-label="切换明暗主题"
+          >
+            ☀️
+          </button>
           <div class="title-area">
             <h1>
-              <span class="icon">🖥️</span>
+              <span class="icon" aria-hidden="true">🖥️</span>
               MCP 客户端大全
             </h1>
             <p>支持 Model Context Protocol 的 AI 客户端和开发工具</p>
           </div>
         </header>
 
-        <div class="info-banner">
-          <h2>💡 什么是 MCP 客户端？</h2>
+        <section class="info-banner" aria-labelledby="mcp-client-overview-title">
+          <h2 id="mcp-client-overview-title">
+            <span aria-hidden="true">💡</span>
+            什么是 MCP 客户端？
+          </h2>
           <p>
             MCP 客户端是支持 Model Context Protocol 的应用程序，可以连接 MCP 服务器来扩展 AI
             的能力。通过 MCP，AI 可以访问文件系统、数据库、API 等外部资源。
@@ -123,19 +132,25 @@
             相关页面：
             <a href="mcp-guide.html">MCP 配置指南</a>
             · 官方文档：
-            <a href="https://modelcontextprotocol.io" target="_blank">modelcontextprotocol.io</a>
+            <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">
+              modelcontextprotocol.io
+            </a>
           </p>
-        </div>
+        </section>
 
         <!-- 官方客户端 -->
-        <div class="category">
-          <h2 class="category-title">🏠 官方客户端</h2>
+        <section class="category" aria-labelledby="category-official-title">
+          <h2 class="category-title" id="category-official-title">
+            <span aria-hidden="true">🏠</span>
+            官方客户端
+          </h2>
           <div class="client-grid">
             <!-- Claude Desktop -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #d97706, #f59e0b)"
                 >
                   🤖
@@ -159,7 +174,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>配置文件路径 (macOS)</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="配置文件路径"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">
                   ~/Library/Application Support/Claude/claude_desktop_config.json
@@ -171,16 +193,19 @@
                 <span class="tag tag-free">免费版可用</span>
               </div>
               <div class="client-links">
-                <a href="https://claude.ai/download" target="_blank" class="primary">下载</a>
-                <a href="mcp-guide.html" target="_blank">配置指南</a>
+                <a href="https://claude.ai/download" target="_blank" rel="noopener" class="primary">
+                  下载
+                </a>
+                <a href="mcp-guide.html" target="_blank" rel="noopener">配置指南</a>
               </div>
-            </div>
+            </article>
 
             <!-- Claude Code -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #8b5cf6, #a78bfa)"
                 >
                   ⌨️
@@ -202,7 +227,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>安装命令</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="安装命令"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">npm install -g @anthropic-ai/claude-code</div>
               </div>
@@ -215,24 +247,32 @@
                 <a
                   href="https://docs.anthropic.com/en/docs/claude-code"
                   target="_blank"
+                  rel="noopener"
                   class="primary"
                 >
                   文档
                 </a>
-                <a href="mcp-guide.html" target="_blank">配置指南</a>
+                <a href="mcp-guide.html" target="_blank" rel="noopener">配置指南</a>
               </div>
-            </div>
+            </article>
           </div>
-        </div>
+        </section>
 
         <!-- AI 编程 IDE -->
-        <div class="category">
-          <h2 class="category-title">💻 AI 编程 IDE</h2>
+        <section class="category" aria-labelledby="category-ide-title">
+          <h2 class="category-title" id="category-ide-title">
+            <span aria-hidden="true">💻</span>
+            AI 编程 IDE
+          </h2>
           <div class="client-grid">
             <!-- Cursor -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
-                <div class="client-icon" style="background: linear-gradient(135deg, #00d4aa, #09f)">
+                <div
+                  class="client-icon"
+                  aria-hidden="true"
+                  style="background: linear-gradient(135deg, #00d4aa, #09f)"
+                >
                   ⚡
                 </div>
                 <div class="client-info">
@@ -263,15 +303,16 @@
                 <span class="tag tag-free">免费版可用</span>
               </div>
               <div class="client-links">
-                <a href="https://cursor.com" target="_blank" class="primary">官网</a>
+                <a href="https://cursor.com" target="_blank" rel="noopener" class="primary">官网</a>
               </div>
-            </div>
+            </article>
 
             <!-- Windsurf -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #6366f1, #8b5cf6)"
                 >
                   🏄
@@ -304,15 +345,18 @@
                 <span class="tag tag-free">免费版可用</span>
               </div>
               <div class="client-links">
-                <a href="https://windsurf.com" target="_blank" class="primary">官网</a>
+                <a href="https://windsurf.com" target="_blank" rel="noopener" class="primary">
+                  官网
+                </a>
               </div>
-            </div>
+            </article>
 
             <!-- Cline -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #007acc, #5c2d91)"
                 >
                   🔌
@@ -336,7 +380,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>安装命令</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="安装命令"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">code --install-extension saoudrizwan.claude-dev</div>
               </div>
@@ -346,21 +397,30 @@
                 <span class="tag tag-mcp">MCP 支持</span>
               </div>
               <div class="client-links">
-                <a href="https://github.com/cline/cline" target="_blank" class="primary">GitHub</a>
+                <a
+                  href="https://github.com/cline/cline"
+                  target="_blank"
+                  rel="noopener"
+                  class="primary"
+                >
+                  GitHub
+                </a>
                 <a
                   href="https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev"
                   target="_blank"
+                  rel="noopener"
                 >
                   扩展市场
                 </a>
               </div>
-            </div>
+            </article>
 
             <!-- Zed -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #084c8d, #1a73e8)"
                 >
                   ⚡
@@ -384,7 +444,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>安装命令 (macOS)</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="安装命令"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">brew install --cask zed</div>
               </div>
@@ -394,22 +461,28 @@
                 <span class="tag tag-free">免费</span>
               </div>
               <div class="client-links">
-                <a href="https://zed.dev" target="_blank" class="primary">官网</a>
-                <a href="https://github.com/zed-industries/zed" target="_blank">GitHub</a>
+                <a href="https://zed.dev" target="_blank" rel="noopener" class="primary">官网</a>
+                <a href="https://github.com/zed-industries/zed" target="_blank" rel="noopener">
+                  GitHub
+                </a>
               </div>
-            </div>
+            </article>
           </div>
-        </div>
+        </section>
 
         <!-- AI 桌面客户端 -->
-        <div class="category">
-          <h2 class="category-title">🖥️ AI 桌面客户端</h2>
+        <section class="category" aria-labelledby="category-desktop-title">
+          <h2 class="category-title" id="category-desktop-title">
+            <span aria-hidden="true">🖥️</span>
+            AI 桌面客户端
+          </h2>
           <div class="client-grid">
             <!-- Cherry Studio -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #ff6b9d, #c084fc)"
                 >
                   🍒
@@ -442,18 +515,24 @@
                 <span class="tag tag-mcp">MCP 支持</span>
               </div>
               <div class="client-links">
-                <a href="https://github.com/CherryHQ/cherry-studio" target="_blank" class="primary">
+                <a
+                  href="https://github.com/CherryHQ/cherry-studio"
+                  target="_blank"
+                  rel="noopener"
+                  class="primary"
+                >
                   GitHub
                 </a>
-                <a href="https://cherry-ai.com" target="_blank">官网</a>
+                <a href="https://cherry-ai.com" target="_blank" rel="noopener">官网</a>
               </div>
-            </div>
+            </article>
 
             <!-- ChatBox -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #22c55e, #16a34a)"
                 >
                   💬
@@ -486,16 +565,21 @@
                 <span class="tag tag-free">免费</span>
               </div>
               <div class="client-links">
-                <a href="https://chatboxai.app" target="_blank" class="primary">官网</a>
-                <a href="https://github.com/Bin-Huang/chatbox" target="_blank">GitHub</a>
+                <a href="https://chatboxai.app" target="_blank" rel="noopener" class="primary">
+                  官网
+                </a>
+                <a href="https://github.com/Bin-Huang/chatbox" target="_blank" rel="noopener">
+                  GitHub
+                </a>
               </div>
-            </div>
+            </article>
 
             <!-- Witsy -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #ec4899, #a855f7)"
                 >
                   ✨
@@ -519,7 +603,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>安装命令 (macOS)</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="安装命令"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">brew install --cask witsy</div>
               </div>
@@ -529,17 +620,23 @@
                 <span class="tag tag-mcp">MCP 客户端</span>
               </div>
               <div class="client-links">
-                <a href="https://github.com/nbonamy/witsy" target="_blank" class="primary">
+                <a
+                  href="https://github.com/nbonamy/witsy"
+                  target="_blank"
+                  rel="noopener"
+                  class="primary"
+                >
                   GitHub
                 </a>
               </div>
-            </div>
+            </article>
 
             <!-- Raycast -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #ff6363, #ff9f43)"
                 >
                   🚀
@@ -563,7 +660,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>安装命令</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="安装命令"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">brew install --cask raycast</div>
               </div>
@@ -573,21 +677,27 @@
                 <span class="tag tag-free">免费版可用</span>
               </div>
               <div class="client-links">
-                <a href="https://raycast.com" target="_blank" class="primary">官网</a>
+                <a href="https://raycast.com" target="_blank" rel="noopener" class="primary">
+                  官网
+                </a>
               </div>
-            </div>
+            </article>
           </div>
-        </div>
+        </section>
 
         <!-- API 聚合和中转 -->
-        <div class="category">
-          <h2 class="category-title">🔀 API 聚合和中转</h2>
+        <section class="category" aria-labelledby="category-api-title">
+          <h2 class="category-title" id="category-api-title">
+            <span aria-hidden="true">🔀</span>
+            API 聚合和中转
+          </h2>
           <div class="client-grid">
             <!-- OpenRouter -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #f59e0b, #ef4444)"
                 >
                   🌐
@@ -611,7 +721,14 @@
               <div class="install-block">
                 <div class="install-header">
                   <span>API 地址</span>
-                  <button onclick="copyInstall(this)">复制</button>
+                  <button
+                    type="button"
+                    data-copy-label="API 地址"
+                    data-original-label="复制"
+                    onclick="copyInstall(this)"
+                  >
+                    复制
+                  </button>
                 </div>
                 <div class="install-cmd">https://openrouter.ai/api/v1</div>
               </div>
@@ -620,15 +737,18 @@
                 <span class="tag tag-free">有免费额度</span>
               </div>
               <div class="client-links">
-                <a href="https://openrouter.ai" target="_blank" class="primary">官网</a>
+                <a href="https://openrouter.ai" target="_blank" rel="noopener" class="primary">
+                  官网
+                </a>
               </div>
-            </div>
+            </article>
 
             <!-- API 中转说明 -->
-            <div class="client-card">
+            <article class="client-card">
               <div class="client-header">
                 <div
                   class="client-icon"
+                  aria-hidden="true"
                   style="background: linear-gradient(135deg, #3b82f6, #1d4ed8)"
                 >
                   🔄
@@ -660,64 +780,80 @@
                 <span class="tag tag-paid">付费服务</span>
               </div>
               <div class="client-links">
-                <a href="https://www.google.com/search?q=Claude+API+中转" target="_blank">
+                <a
+                  href="https://www.google.com/search?q=Claude+API+中转"
+                  target="_blank"
+                  rel="noopener"
+                >
                   搜索服务商
                 </a>
               </div>
-            </div>
+            </article>
           </div>
-        </div>
+        </section>
 
         <!-- 资源和平台 -->
-        <div class="resources">
-          <h3>🔗 MCP 资源平台</h3>
+        <section class="resources" aria-labelledby="resources-title">
+          <h2 id="resources-title">
+            <span aria-hidden="true">🔗</span>
+            MCP 资源平台
+          </h2>
           <div class="resource-grid">
-            <a href="https://mcp.so" target="_blank" class="resource-item">
-              <h4>mcp.so</h4>
+            <a href="https://mcp.so" target="_blank" rel="noopener" class="resource-item">
+              <h3>mcp.so</h3>
               <p>MCP 服务器搜索和发现平台</p>
             </a>
-            <a href="https://mcp.aibase.cn" target="_blank" class="resource-item">
-              <h4>AIbase MCP</h4>
+            <a href="https://mcp.aibase.cn" target="_blank" rel="noopener" class="resource-item">
+              <h3>AIbase MCP</h3>
               <p>收录 12 万+ MCP 服务器（中文）</p>
             </a>
             <a
               href="https://github.com/modelcontextprotocol/servers"
               target="_blank"
+              rel="noopener"
               class="resource-item"
             >
-              <h4>官方服务器仓库</h4>
+              <h3>官方服务器仓库</h3>
               <p>所有官方 MCP 服务器源码</p>
             </a>
             <a
               href="https://github.com/punkpeye/awesome-mcp-servers"
               target="_blank"
+              rel="noopener"
               class="resource-item"
             >
-              <h4>Awesome MCP</h4>
+              <h3>Awesome MCP</h3>
               <p>社区维护的 MCP 服务器列表</p>
             </a>
-            <a href="https://modelcontextprotocol.io/docs" target="_blank" class="resource-item">
-              <h4>MCP 官方文档</h4>
+            <a
+              href="https://modelcontextprotocol.io/docs"
+              target="_blank"
+              rel="noopener"
+              class="resource-item"
+            >
+              <h3>MCP 官方文档</h3>
               <p>协议规范和开发指南</p>
             </a>
             <a href="mcp-guide.html" class="resource-item">
-              <h4>MCP 配置指南</h4>
+              <h3>MCP 配置指南</h3>
               <p>本站 MCP 配置教程</p>
             </a>
           </div>
-        </div>
+        </section>
 
         <footer>
           <p>
-            <a href="https://modelcontextprotocol.io" target="_blank">MCP 官网</a>
-            <span style="margin: 0 8px">·</span>
-            <a href="https://github.com/chicogong/html-tools" target="_blank">GitHub</a>
-            <span style="margin: 0 8px">·</span>
+            <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP 官网</a>
+            <span class="footer-separator" aria-hidden="true">·</span>
+            <a href="https://github.com/chicogong/html-tools" target="_blank" rel="noopener">
+              GitHub
+            </a>
+            <span class="footer-separator" aria-hidden="true">·</span>
             <a href="../../index.html">WebUtils</a>
           </p>
         </footer>
       </div>
-    </div>
+    </main>
 
     <script>
       // 主题切换
@@ -726,11 +862,11 @@
         const btn = document.querySelector(".theme-toggle");
         if (html.getAttribute("data-theme") === "light") {
           html.removeAttribute("data-theme");
-          btn.textContent = "☀️";
+          if (btn) btn.textContent = "☀️";
           localStorage.setItem("theme", "dark");
         } else {
           html.setAttribute("data-theme", "light");
-          btn.textContent = "🌙";
+          if (btn) btn.textContent = "🌙";
           localStorage.setItem("theme", "light");
         }
       };
@@ -741,23 +877,62 @@
         const btn = document.querySelector(".theme-toggle");
         if (saved === "light") {
           document.documentElement.setAttribute("data-theme", "light");
-          btn.textContent = "🌙";
+          if (btn) btn.textContent = "🌙";
         }
       })();
 
       // 复制安装命令
-      window.copyInstall = function (btn) {
+      const copyTimers = new WeakMap();
+      const copyRequests = new WeakMap();
+
+      window.copyInstall = async function (btn) {
+        if (!btn) return;
         const installBlock = btn.closest(".install-block");
-        const cmd = installBlock.querySelector(".install-cmd").textContent;
-        navigator.clipboard.writeText(cmd).then(() => {
-          const originalText = btn.textContent;
+        const cmd = installBlock?.querySelector(".install-cmd")?.textContent.trim();
+        const status = document.getElementById("copy-status");
+        if (!installBlock || !cmd) return;
+
+        const originalText = btn.dataset.originalLabel || "复制";
+        const label = btn.dataset.copyLabel || "内容";
+        const requestId = (copyRequests.get(btn) || 0) + 1;
+        copyRequests.set(btn, requestId);
+
+        try {
+          await navigator.clipboard.writeText(cmd);
+          if (copyRequests.get(btn) !== requestId) return;
+
+          const previousTimer = copyTimers.get(btn);
+          if (previousTimer) window.clearTimeout(previousTimer);
           btn.textContent = "已复制";
-          btn.style.color = "var(--accent-green)";
-          setTimeout(() => {
-            btn.textContent = originalText;
-            btn.style.color = "";
-          }, 2000);
-        });
+          btn.classList.add("is-copied");
+          btn.classList.remove("copy-error");
+          if (status) status.textContent = `${label}已复制`;
+          copyTimers.set(
+            btn,
+            window.setTimeout(() => {
+              copyTimers.delete(btn);
+              btn.textContent = originalText;
+              btn.classList.remove("is-copied");
+            }, 2000)
+          );
+        } catch {
+          if (copyRequests.get(btn) !== requestId) return;
+
+          const previousTimer = copyTimers.get(btn);
+          if (previousTimer) window.clearTimeout(previousTimer);
+          btn.textContent = "重试";
+          btn.classList.remove("is-copied");
+          btn.classList.add("copy-error");
+          if (status) status.textContent = `${label}复制失败，请重试`;
+          copyTimers.set(
+            btn,
+            window.setTimeout(() => {
+              copyTimers.delete(btn);
+              btn.textContent = originalText;
+              btn.classList.remove("copy-error");
+            }, 4000)
+          );
+        }
       };
     </script>
 


### PR DESCRIPTION
## Summary

- restore the MCP clients directory cards, categories, resources, and responsive layout with shared design tokens
- improve semantic headings, decorative icon handling, copy feedback, keyboard focus, and external-link safety
- add resilient Playwright coverage for all client/resource grids, long commands, clipboard success/reject/retry, and mobile/desktop overflow

## Validation

- `npx playwright test tests/e2e/mcp-clients-presentation.spec.js` (3 passed)
- `npm run lint`
- `npm run format:check`
- `npm test` (70/70)
- `npm run build`
- `git diff --check`
- visual review at 390px and 1440px

## Scope

- no cover or category `index.html` changes
- no client-list fact updates
- no deployment or release actions